### PR TITLE
Implemented osc mkrpac

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -3641,6 +3641,18 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 addFiles([arg])
 
+    def do_mkrpac(self, subcmd, opts, *args):
+        """${cmd_name}: Create a new package on the server
+
+        usage:
+            osc mkrpac project new_package
+        ${cmd_option_list}
+        """
+        if len(args) != 2:
+            raise oscerr.WrongArgs('Wrong number of arguments.')
+
+        createRemotePackage(self.get_api_url(), args[0], args[1])
+        
 
     def do_mkpac(self, subcmd, opts, *args):
         """${cmd_name}: Create a new package under version control

--- a/osc/core.py
+++ b/osc/core.py
@@ -5671,6 +5671,19 @@ def createPackageDir(pathname, prj_obj=None):
             msg += '\ntry svn instead of osc.'
         raise oscerr.NoWorkingCopy(msg)
 
+def createRemotePackage(apiurl, project, package):
+    """create package on the server"""
+
+    data = """
+<package project="%s" name="%s">
+  <title/>
+  <description/>
+</package>
+""" % (project, package)
+
+    url = make_meta_url("pkg", (quote_plus(project), quote_plus(package)),
+                        apiurl, False)
+    http_PUT(url, data=data)
 
 def stripETxml(node):
     node.tail = None


### PR DESCRIPTION
Hi,

osc mkrpac allows users to create packages remotely, without using web UI.

A bit of explanations why this is useful:

Usually I start my packaging work this way:
1. git clone git_url_of_package
2. cd package/
3. mkdir rpm
4. git archive --prefix package-version/ HEAD | gzip > rpm/package-version.tar.gz
5. cd rpm
6. Create package using WebUI
7. osc co --output-dir=./ project package
8. vi package.spec
9. osc add package.spec
10. osc add package-version.tar.gz
11. osc commit -m 'Init'
12. git add package.spec
13. git commit -m 'Added rpm spec file'

"osc mkrpac project package" would make it possible to do step 6 (and the whole process) without using Web UI.

Please, apply if you don't mind.

Thank you,
Ed Bartosh
