### PR TITLE
Fix %(apihost)s in "build-root" option for osc chroot

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -9,6 +9,7 @@ import conf
 import oscerr
 import sys
 import time
+import urlparse
 
 from optparse import SUPPRESS_HELP
 
@@ -5177,8 +5178,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             package = os.path.splitext(descr)[0]
         else:
             package = store_read_package('.')
+        apihost = urlparse.urlsplit(self.get_api_url())[1]
         buildroot = os.environ.get('OSC_BUILD_ROOT', conf.config['build-root']) \
-            % {'repo': repository, 'arch': arch, 'project': project, 'package': package}
+            % {'repo': repository, 'arch': arch, 'project': project, 'package': package, 'apihost': apihost}
         if not os.path.isdir(buildroot):
             raise oscerr.OscIOError(None, '\'%s\' is not a directory' % buildroot)
 


### PR DESCRIPTION
Prevents a crash in osc chroot when %(apihost)s is defined in the
"build-root" config option.

Signed-off-by: Markus Lehtonen markus.lehtonen@linux.intel.com
