### PR TITLE
The BEAST is gonna get ya... 

### DIFF
--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -155,7 +155,7 @@ class mySSLContext(SSL.Context):
     def __init__(self):
         SSL.Context.__init__(self, 'sslv23')
         self.set_options(m2.SSL_OP_NO_SSLv2 | m2.SSL_OP_NO_SSLv3)
-        self.set_cipher_list("ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH")
+        self.set_cipher_list("ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH")
         self.set_session_cache_mode(m2.SSL_SESS_CACHE_CLIENT)
         self.verrs = None
         #self.set_info_callback() # debug


### PR DESCRIPTION
This patch workarounds the BEAST attack in the client side
making OSC to prefer TLS v1.1 or v1.2 ciphers/key exchanges
when available.
Now, as long as openSUSE API webservers do not support
these protocols it will prefer the RC4-SHA1 combination to
be in the safe side.
