### PR TITLE
Better detection of user charset

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -11,9 +11,9 @@ from osc import commandline, babysitter
 # this is a hack to make osc work as expected with utf-8 characters,
 # no matter how site.py is set...
 reload(sys)
-loc = locale.getdefaultlocale()[1]
+loc = locale.getpreferredencoding()
 if not loc:
-    loc = sys.getdefaultencoding()
+    loc = sys.getpreferredencoding()
 sys.setdefaultencoding(loc)
 del sys.setdefaultencoding
 


### PR DESCRIPTION
Using locale.getdefaultlocale() for encoding detection breaks with
locales that use modifiers, such as de_DE@euro, or ca_ES@valencia.
Use locale.getpreferredencoding() instead, which should do the right
thing.

Originally reported at http://bugs.debian.org/682261
