### PR TITLE
Don't check hostarch with hostarch setting in OBS project config

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -646,11 +646,7 @@ def main(apiurl, opts, argv):
     # real arch of this machine
     # vs.
     # arch we are supposed to build for
-    if bi.hostarch != None:
-        if hostarch != bi.hostarch and not hostarch in can_also_build.get(hostarch, []):
-            print >>sys.stderr, 'Error: hostarch \'%s\' is required.' % (bi.hostarch)
-            return 1
-    elif hostarch != bi.buildarch:
+    if hostarch != bi.buildarch:
         if not bi.buildarch in can_also_build.get(hostarch, []):
             # OBSOLETE: qemu_can_build should not be needed anymore since OBS 2.3
             if not bi.buildarch in qemu_can_build:


### PR DESCRIPTION
If Hostarch is set in OBS project config, it's hard to check in osc.

For example:
If Hostarch is set to i586 in OBS project config, osc build fails
on x86_64 system;
If Hostarch is set to x86_64 in OBS project config, osc build fails
on i586 system.
