### PR TITLE
build.py: bugfix: incorrect determination of hostarch available for build

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -647,7 +647,7 @@ def main(apiurl, opts, argv):
     # vs.
     # arch we are supposed to build for
     if bi.hostarch != None:
-        if hostarch != bi.hostarch and not hostarch in can_also_build.get(hostarch, []):
+        if hostarch != bi.hostarch and not bi.hostarch in can_also_build.get(hostarch, []):
             print >>sys.stderr, 'Error: hostarch \'%s\' is required.' % (bi.hostarch)
             return 1
     elif hostarch != bi.buildarch:


### PR DESCRIPTION
- x86-64 should be able to build for i586 hostarch but it doesn't.

Similar to https://github.com/openSUSE/osc/pull/11 but seems to be better solution.
