### PR TITLE
fix test failures

### DIFF
--- a/tests/test_difffiles.py
+++ b/tests/test_difffiles.py
@@ -1,6 +1,7 @@
 import osc.core
 import osc.oscerr
 import os
+import re
 from common import GET, OscTestCase
 
 FIXTURES_DIR = os.path.join(os.getcwd(), 'difffile_fixtures')
@@ -294,18 +295,42 @@ Binary file 'binary' has changed.
         p = osc.core.Package('.')
         self.__check_diff(p, '', 3)
 
-    def __check_diff(self, p, expected, revision=None):
+    def __check_diff(self, p, exp, revision=None):
         got = ''
         for i in p.get_diff(revision):
             got += ''.join(i)
-        if (got + expected).find('\n') == -1:
-            self.assertEqual(got, expected)
+
+        # When a hunk header refers to a single line in the "from"
+        # file and/or the "to" file, e.g.
+        #
+        #   @@ -37,37 +41,43 @@
+        #   @@ -37,39 +41,41 @@
+        #   @@ -37,37 +41,41 @@
+        #
+        # some systems will avoid repeating the line number:
+        #
+        #   @@ -37 +41,43 @@
+        #   @@ -37,39 +41 @@
+        #   @@ -37 +41 @@
+        #
+        # so we need to canonise the output to avoid false negative
+        # test failures.
+        def __canonise_diff(diff):
+            diff = re.sub('^@@ -(\d+) ', '@@ -\\1,\\1 ', diff, 0, re.MULTILINE)
+            diff = re.sub('^(@@ -\d+,\d+) \+(\d+) ', '\\1 +\\2,\\2 ', diff, 0, re.MULTILINE)
+            return diff
+
+        got = __canonise_diff(got)
+        exp = __canonise_diff(exp)
+
+        if (got + exp).find('\n') == -1:
+            self.assertEqual(got, exp)
         else:
             start_delim = "\n" + (" 8< ".join(["-----"] * 8)) + "\n"
             end_delim   = "\n" + (" >8 ".join(["-----"] * 8)) + "\n\n"
-            self.assertEqual(got, expected,
+            self.assertEqual(got, exp,
                              "got:"      + start_delim + got + end_delim +
-                             "expected:" + start_delim + expected + end_delim)
+                             "expected:" + start_delim + exp + end_delim)
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
On my system, some of the tests were failing.  I tweaked the failure output to be more readable, and this made it obvious that the failures were due to subtle differences in the diff hunk header.
