### PR TITLE
Fix: allow using osc mv ../foo/bar.txt .

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 0.140
+  - allow specifying directories as mv targets
   -
 
 0.139

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7638,6 +7638,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if not tgt_pkg:
             raise oscerr.NoWorkingCopy("Error: \"%s\" does not point to an osc working copy." % os.path.abspath(dest))
 
+        if os.path.isfile(source) and os.path.isdir(dest):
+            dest = os.path.join(dest, os.path.basename(source))
         os.rename(source, dest)
         try:
             tgt_pkg[0].addfile(os.path.basename(dest))


### PR DESCRIPTION
Otherwise osc would crash because the target directory would be in use (in
case of ".".)
