### PR TITLE
correctly refer to exception

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -710,7 +710,7 @@ def add_section(filename, url, user, passwd):
     cp = get_configParser(filename)
     try:
         cp.add_section(url)
-    except OscConfigParser.ConfigParser.DuplicateSectionError:
+    except OscConfigParser.configparser.DuplicateSectionError:
         # Section might have existed, but was empty
         pass
     if config['use_keyring'] and GENERIC_KEYRING:


### PR DESCRIPTION
this is left-over from 87d354e1a013806ef37f11e22f015e5cc43e533d

Addressing:

```
Traceback (most recent call last):
  File "/usr/bin/osc", line 26, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python2.7/site-packages/osc/babysitter.py", line 60, in run
    return prg.main()
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 335, in main
    self.postoptparse()
  File "/usr/lib/python2.7/site-packages/osc/commandline.py", line 136, in postoptparse
    override_verbose = self.options.verbose)
  File "/usr/lib/python2.7/site-packages/osc/conf.py", line 873, in get_config
    add_section(conffile, url, user, passwordx)
  File "/usr/lib/python2.7/site-packages/osc/conf.py", line 712, in add_section
    except OscConfigParser.ConfigParser.DuplicateSectionError:
AttributeError: class OscConfigParser has no attribute 'ConfigParser'
```
