### PR TITLE
Fix ServiceRuntimeError to print out actually.

### DIFF
--- a/osc/oscerr.py
+++ b/osc/oscerr.py
@@ -50,9 +50,6 @@ class ExtRuntimeError(OscBaseError):
 
 class ServiceRuntimeError(OscBaseError):
     """Exception raised when there is source service error runtime error"""
-    def __init__(self, msg):
-        OscBaseError.__init__(self)
-        self.msg = msg
 
 class WrongArgs(OscBaseError):
     """Exception raised by the cli for wrong arguments usage"""


### PR DESCRIPTION
As per summary the init of the parent is not required here and just cause the raise oscerr.ServiceRuntimeError to not print anything.

This solves it.
