### PR TITLE
Add --unset parameter to setdevelproject

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -553,6 +553,8 @@ class Osc(cmdln.Cmdln):
             print(devprj)
 
     @cmdln.alias('sdp')
+    @cmdln.option('-u', '--unset', action='store_true',
+                  help='remove devel project')
     def do_setdevelproject(self, subcmd, opts, *args):
         """${cmd_name}: Set the devel project / package of a package
 
@@ -575,7 +577,10 @@ class Osc(cmdln.Cmdln):
             if len(args) == 2:
                 devpkg = args[1]
         else:
-            raise oscerr.WrongArgs('need at least DEVPRJ (and possibly DEVPKG)')
+            if opts.unset:
+                project, package = store_read_project(os.curdir), store_read_package(os.curdir)
+            else:
+                raise oscerr.WrongArgs('need at least DEVPRJ (and possibly DEVPKG)')
 
         set_devel_project(apiurl, project, package, devprj, devpkg)
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -3155,18 +3155,24 @@ def show_devel_project(apiurl, prj, pac):
         return node.get('project'), node.get('package', None)
 
 
-def set_devel_project(apiurl, prj, pac, devprj, devpac=None):
+def set_devel_project(apiurl, prj, pac, devprj=None, devpac=None):
     meta = show_package_meta(apiurl, prj, pac)
     root = ET.fromstring(''.join(meta))
     node = root.find('devel')
     if node is None:
+        if devprj is None:
+            return
         node = ET.Element('devel')
         root.append(node)
     else:
-        node.clear()
-    node.set('project', devprj)
-    if devpac:
-        node.set('package', devpac)
+        if devprj is None:
+            root.remove(node)
+        else:
+            node.clear()
+    if devprj:
+        node.set('project', devprj)
+        if devpac:
+            node.set('package', devpac)
     url = makeurl(apiurl, ['source', prj, pac, '_meta'])
     mf = metafile(url, ET.tostring(root, encoding=ET_ENCODING))
     mf.sync()


### PR DESCRIPTION
Allows to unset the devel project (much like setlinkrev -u).
