### PR TITLE
Include filelimit=0 when querying full serverside diff

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4201,6 +4201,7 @@ def server_diff(apiurl,
         query['meta'] = 1
     if full:
         query['filelimit'] = 0
+        query['tarlimit'] = 0
 
     u = makeurl(apiurl, ['source', new_project, new_package], query=query)
 


### PR DESCRIPTION
Without this change, "osc rdiff -p" simply returns "(XXX lines skipped)"
