### PR TITLE
ppc64le can be built on ppc64

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -64,7 +64,7 @@ can_also_build = {
              'armv8l' :[                                         'armv4l', 'armv5el', 'armv6el', 'armv7el', 'armv8el' ], # not existing arch, just for compatibility
              'armv5tel':[                                        'armv4l', 'armv5el',                                 'armv5tel' ], 
              's390x':  ['s390' ],
-             'ppc64':  [                        'ppc', 'ppc64', 'ppc64p7' ],
+             'ppc64':  [                        'ppc', 'ppc64', 'ppc64p7', 'ppc64le' ],
              'ppc64le':[ 'ppc64le' ],
              'i586':   [                'i386' ],
              'i686':   [        'i586', 'i386' ],


### PR DESCRIPTION
In case vm-type is KVM, we can build Little Endian packages on Big
Endian host.

Signed-off-by: Dinar Valeev dvaleev@suse.com
