### PR TITLE
Fixed traceback in get_prj_results

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5171,7 +5171,7 @@ def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=Non
         row = ['_'] + ['/'.join(tg) for tg in targets]
         r.append(';'.join(row))
         for pac in pacs:
-            row = [pac] + [status[pac][tg] for tg in targets]
+            row = [pac] + [status[pac][tg] for tg in targets if tg in status[pac]]
             r.append(';'.join(row))
         return r
 


### PR DESCRIPTION
The reason of the crash is that not all targets are always defined for
all packages. In our environment it happens when linked project is
created and sources have just been uploaded to one package.

Here is the crash:
Traceback (most recent call last):
  File "../tools-testing/build-package", line 313, in <module>
    sys.exit(main(sys.argv))
  File "../tools-testing/build-package", line 309, in main
    return build(apiurl, tproject, package, timeout)
  File "../tools-testing/build-package", line 226, in build
    hide_legend=True, csv=True)
  File "/usr/lib/python2.7/site-packages/osc/core.py", line 5135, in get_prj_results
    row = [pac] + [status[pac][tg] for tg in targets]
status[pac]]
KeyError: ('Fedora_18', 'i586', 'outdated')

Please note that this fix fixes only csv mode. For other modes osc still
can crash, but it's hard to reproduce here as we're not using them.

Signed-off-by: Ed Bartosh bartosh@gmail.com
