### PR TITLE
passx encode/decode functions

### DIFF
--- a/tests/conf_fixtures/oscrc
+++ b/tests/conf_fixtures/oscrc
@@ -1,0 +1,103 @@
+[general]
+# URL to access API server, e.g. https://api.opensuse.org
+# you also need a section [https://api.opensuse.org] with the credentials
+apiurl = http://localhost
+# Downloaded packages are cached here. Must be writable by you.
+#packagecachedir = /var/tmp/osbuild-packagecache
+# Wrapper to call build as root (sudo, su -, ...)
+#su-wrapper = su -c
+# rootdir to setup the chroot environment
+# can contain %(repo)s, %(arch)s, %(project)s and %(package)s for replacement, e.g.
+# /srv/oscbuild/%(repo)s-%(arch)s or
+# /srv/oscbuild/%(repo)s-%(arch)s-%(project)s-%(package)s
+#build-root = /var/tmp/build-root
+# compile with N jobs (default: "getconf _NPROCESSORS_ONLN")
+#build-jobs = N
+# build-type to use - values can be (depending on the capabilities of the 'build' script)
+# empty    -  chroot build
+# kvm      -  kvm VM build  (needs build-device, build-swap, build-memory)
+# xen      -  xen VM build  (needs build-device, build-swap, build-memory)
+#   experimental:
+#     qemu -  qemu VM build
+#     lxc  -  lxc build
+#build-type =
+# build-device is the disk-image file to use as root for VM builds
+# e.g. /var/tmp/FILE.root
+#build-device = /var/tmp/FILE.root
+# build-swap is the disk-image to use as swap for VM builds
+# e.g. /var/tmp/FILE.swap
+#build-swap = /var/tmp/FILE.swap
+# build-memory is the amount of memory used in the VM
+# value in MB - e.g. 512
+#build-memory = 512
+# build-vmdisk-rootsize is the size of the disk-image used as root in a VM build
+# values in MB - e.g. 4096
+#build-vmdisk-rootsize = 4096
+# build-vmdisk-swapsize is the size of the disk-image used as swap in a VM build
+# values in MB - e.g. 1024
+#build-vmdisk-swapsize = 1024
+# Numeric uid:gid to assign to the "abuild" user in the build-root
+# or "caller" to use the current users uid:gid
+# This is convenient when sharing the buildroot with ordinary userids
+# on the host.
+# This should not be 0
+# build-uid =
+# extra packages to install when building packages locally (osc build)
+# this corresponds to osc build's -x option and can be overridden with that
+# -x '' can also be given on the command line to override this setting, or
+# you can have an empty setting here.
+#extra-pkgs = vim gdb strace
+# build platform is used if the platform argument is omitted to osc build
+#build_repository = openSUSE_Factory
+# default project for getpac or bco
+#getpac_default_project = openSUSE:Factory
+# alternate filesystem layout: have multiple subdirs, where colons were.
+#checkout_no_colon = 0
+# local files to ignore with status, addremove, ....
+#exclude_glob = .osc CVS .svn .* _linkerror *~ #*# *.orig *.bak *.changes.*
+# keep passwords in plaintext. If you see this comment, your osc
+# already uses the encrypted password, and only keeps them in plain text
+# for backwards compatibility. Default will change to 0 in future releases.
+# You can remove the plaintext password without harm, if you do not need
+# backwards compatibility.
+#plaintext_passwd = 1
+# limit the age of requests shown with 'osc req list'.
+# this is a default only, can be overridden by 'osc req list -D NNN'
+# Use 0 for unlimted.
+#request_list_days = 0
+# show info useful for debugging
+#debug = 1
+# show HTTP traffic useful for debugging
+#http_debug = 1
+# Skip signature verification of packages used for build.
+#no_verify = 1
+# jump into the debugger in case of errors
+#post_mortem = 1
+# print call traces in case of errors
+#traceback = 1
+# use KDE/Gnome/MacOS/Windows keyring for credentials if available
+#use_keyring = 1
+# check for unversioned/removed files before commit
+#check_filelist = 1
+# check for pending requests after executing an action (e.g. checkout, update, commit)
+#check_for_request_on_action = 0
+# what to do with the source package if the submitrequest has been accepted. If
+# nothing is specified the API default is used
+#submitrequest_on_accept_action = cleanup|update|noupdate
+#review requests interactively (default: off)
+#request_show_review = 1
+# Directory with executables to validate sources, esp before committing
+#source_validator_directory = /usr/lib/osc/source_validators
+
+[http://localhost]
+user=Admin
+pass=opensuse
+# set aliases for this apiurl
+# aliases = foo, bar
+# email used in .changes, unless the one from osc meta prj <user> will be used
+# email =
+# additional headers to pass to a request, e.g. for special authentication
+#http_headers = Host: foofoobar,
+#       User: mumblegack
+# Force using of keyring for this API
+#keyring = 1

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,32 @@
+from osc.conf import passx_encode, passx_decode
+from common import OscTestCase
+
+import os
+
+FIXTURES_DIR = os.path.join(os.getcwd(), 'conf_fixtures')
+
+def suite():
+    import unittest
+    return unittest.makeSuite(TestAddFiles)
+
+class TestConf(OscTestCase):
+    def _get_fixtures_dir(self):
+        return FIXTURES_DIR
+
+    def setUp(self):
+        return super(TestConf, self).setUp(copytree=False)
+    
+    def testPassxEncodeDecode(self):
+        
+        passwd = "J0e'sPassword!@#"
+        passx = passx_encode(passwd)
+        #base64.b64encode(passwd.encode('bz2'))
+        passx27 = "QlpoOTFBWSZTWaDg4dQAAAKfgCiAQABAEEAAJgCYgCAAMQAACEyYmTyei67AsYSDSaLuSKcKEhQcHDqA"
+        
+        self.assertEqual(passwd, passx_decode(passx))
+        self.assertEqual(passwd, passx_decode(passx27))
+        self.assertEqual(passx, passx27)
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
The string.encode('bz2') does not work in python3. Implement
passx_encode/passx_decode functions compatible with python 2.6, 2.7 and
3.3.

Add a simple unit test.
