### PR TITLE
Fix handling of meta command within local working directory

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -731,22 +731,30 @@ class Osc(cmdln.Cmdln):
             raise oscerr.WrongArgs('Too many arguments.')
 
         apiurl = self.get_api_url()
-        if len(args) < 2:
-            apiurl = store_read_apiurl(os.curdir)
 
-        # specific arguments
+        # Specific arguments
+        #
+        # If project or package arguments missing, assume to work
+        # with project and/or package in current local directory.
         attributepath = []
-        if cmd in ['pkg', 'prj', 'prjconf' ]:
-            if len(args) == 0:
+        if cmd in ['prj', 'prjconf']:
+            if len(args) < 1:
+                apiurl = store_read_apiurl(os.curdir)
                 project = store_read_project(os.curdir)
             else:
                 project = args[0]
 
-            if cmd == 'pkg':
-                if len(args) < 2:
+        elif cmd == 'pkg':
+            if len(args) < 2:
+                apiurl = store_read_apiurl(os.curdir)
+                project = store_read_project(os.curdir)
+                if len(args) < 1:
                     package = store_read_package(os.curdir)
                 else:
-                    package = args[1]
+                    package = args[0]
+            else:
+                project = args[0]
+                package = args[1]
 
         elif cmd == 'attribute':
             project = args[0]


### PR DESCRIPTION
I recently had the issue of osc ignoring the -A command option when editing a project's meta data. After some confusion and debugging I realized it was because I happened to be in a local working copy of a different project from a different build service and in that case, osc ignores the passed api url and tries the URL of the local working project. This patch fixes that scenario as well as improves on the general handling of the `osc meta` command within a local working copy (at least the way I expect it to work ;)
- Fix osc ignoring -A apiurl command option when arguments are
  less than 2 and executed within local working copy
- Enhance handling of meta command within local working copy.
  - `osc meta prj`: Try to use project and apiurl of local working copy
    if no arguments are passed
  - `osc meta pkg`: Try to use project and apiurl of local working copy
    if one argument is passed (single argument assumed to be package
    name), and try to use project, package and apiurl if no
    arguments are passed
