### PR TITLE
Support .kiwi files for bash-completion

### DIFF
--- a/dist/osc.complete
+++ b/dist/osc.complete
@@ -437,8 +437,9 @@ build)
 	done
     fi 
     if ((count == 2)) ; then
-	specs=($(command ls *.spec))
-	builtin compgen -W "${opts[*]} ${specs[*]}" -- "${cmdline[count]}"
+	specs=($(command ls *.spec 2>/dev/null))
+	images=($(command ls *.kiwi 2>/dev/null))
+	builtin compgen -W "${opts[*]} ${specs[*]} ${images[*]}" -- "${cmdline[count]}"
     fi
     ;;
 branch|getpac|bco|branchco)


### PR DESCRIPTION
This commit enables osc to provide completion for both .spec and .kiwi
files, and ensures no ugly "not found" messages are displayed in the
terminal due to globbing.

I sometimes create my own images for various appliances, and being able to tab-complete .kiwi
files is somewhat helpful :)
