### PR TITLE
Support --download-api-only in bash-completion

### DIFF
--- a/dist/osc.complete
+++ b/dist/osc.complete
@@ -350,7 +350,7 @@ add|addremove|ar)
     fi
     ;;
 build)
-    opts=(--help --oldpackages --disable-cpio-bulk-download --release --baselibs 
+    opts=(--help --oldpackages --disable-cpio-bulk-download --download-api-only --release --baselibs 
 	  --disable-debuginfo --debuginfo --alternative-project --vm-type --linksources 
 	  --local-package --build-uid --userootforbuild --define --without --with 
 	  --ccache --icecream --jobs --root --extra-pkgs --keep-pkgs --prefer-pkgs 


### PR DESCRIPTION
Simple pull request - adds --download-api-only to bash-completion.

I was tempted to add a help message for it in commandline, but I can't actually find any suitable documentation to aptly describe what it does.. --disable-cpio-bulk-download could do with one too.

If someone has some suitable text I'm happy to push a commit to add those in (they're suppressed right now)
