### PR TITLE
Support for building Debian Live Systems

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -116,6 +116,8 @@ class Buildinfo:
             self.pacsuffix = 'deb'
         if self.buildtype == 'arch':
             self.pacsuffix = 'arch'
+        if self.buildtype == 'livebuild':
+            self.pacsuffix = 'deb'
 
         self.buildarch = root.find('arch').text
         if root.find('hostarch') != None:
@@ -278,6 +280,11 @@ def get_built_files(pacdir, buildtype):
                                     '-name', '*.pkg.tar*'],
                                    stdout=subprocess.PIPE).stdout.read().strip()
         s_built = ''
+    elif buildtype == 'livebuild':
+        b_built = subprocess.Popen(['find', os.path.join(pacdir, 'OTHER'),
+                                    '-name', '*.iso*'],
+                                   stdout=subprocess.PIPE).stdout.read().strip()
+        s_built = ''
     else:
         print('WARNING: Unknown package type \'%s\'.' % buildtype, file=sys.stderr)
         b_built = ''
@@ -406,9 +413,9 @@ def main(apiurl, opts, argv):
     build_type = os.path.splitext(build_descr)[1][1:]
     if os.path.basename(build_descr) == 'PKGBUILD':
         build_type = 'arch'
-    if build_type not in ['spec', 'dsc', 'kiwi', 'arch']:
+    if build_type not in ['spec', 'dsc', 'kiwi', 'arch', 'livebuild']:
         raise oscerr.WrongArgs(
-                'Unknown build type: \'%s\'. Build description should end in .spec, .dsc or .kiwi.' \
+                'Unknown build type: \'%s\'. Build description should end in .spec, .dsc, .kiwi or .livebuild.' \
                         % build_type)
     if not os.path.isfile(build_descr):
         raise oscerr.WrongArgs('Error: build description file named \'%s\' does not exist.' % build_descr)

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5377,7 +5377,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 for subarch in osc.build.can_also_build.get(mainarch):
                     all_archs.append(subarch)
             for arg in args:
-                if arg.endswith('.spec') or arg.endswith('.dsc') or arg.endswith('.kiwi') or arg == 'PKGBUILD':
+                if arg.endswith('.spec') or arg.endswith('.dsc') or arg.endswith('.kiwi') or arg.endswith('.livebuild') or arg == 'PKGBUILD':
                     arg_descr = arg
                 else:
                     if (arg == osc.build.hostarch or arg in all_archs) and arg_arch is None:
@@ -5434,7 +5434,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         # can be implemented using
         # reduce(lambda x, y: x + y, (glob.glob(x) for x in ('*.spec', '*.dsc', '*.kiwi')))
         # but be a bit more readable :)
-        descr = glob.glob('*.spec') + glob.glob('*.dsc') + glob.glob('*.kiwi') + glob.glob('PKGBUILD')
+        descr = glob.glob('*.spec') + glob.glob('*.dsc') + glob.glob('*.kiwi') + glob.glob('*.livebuild') + glob.glob('PKGBUILD')
         
         # FIXME:
         # * request repos from server and select by build type.
@@ -5449,7 +5449,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 pac = os.path.basename(os.getcwd())
                 if is_package_dir(os.getcwd()):
                     pac = store_read_package(os.getcwd())
-                extensions = ['spec', 'dsc', 'kiwi']
+                extensions = ['spec', 'dsc', 'kiwi', 'livebuild']
                 cands = [i for i in descr for ext in extensions if i == '%s-%s.%s' % (pac, arg_repository, ext)]
                 if len(cands) == 1:
                     arg_descr = cands[0]
@@ -5460,7 +5460,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 if not arg_descr:
                     msg = 'Multiple build description files found: %s' % ', '.join(descr)
             elif not ignore_descr:
-                msg = 'Missing argument: build description (spec, dsc or kiwi file)'
+                msg = 'Missing argument: build description (spec, dsc, kiwi or livebuild file)'
                 try:
                     p = Package('.')
                     if p.islink() and not p.isexpanded():


### PR DESCRIPTION
This series of commits adds support for building Debian Live Systems with the help of live-build (see live.debian.net). This change requires infrastructure changes in open-build-service (pull req #728) and in obs-build (already merged pull req #115).
