### PR TITLE
add basic completion support for fish shell

### DIFF
--- a/osc.fish
+++ b/osc.fish
@@ -3,7 +3,7 @@
 
 function __fish_osc_needs_command
   set cmd (commandline -opc)
-  if [ (count $cmd) -eq 1 -a $cmd[1] = 'osc' ]
+  if contains "$cmd" 'osc' 'osc help'
     return 0
   end
   return 1


### PR DESCRIPTION
I didn't use `osc.complete` helper due the incompatibilities between bash and fish.

I didn't find a place where scripts get copied, but just put `osc.fish` file into the `/usr/share/fish/completions/` directory. http://fishshell.com/docs/current/index.html#completion
