### PR TITLE
Initialize variable 's_built' during image build.

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -268,6 +268,7 @@ def get_built_files(pacdir, buildtype):
         b_built = subprocess.Popen(['find', os.path.join(pacdir, 'KIWI'),
                                     '-type', 'f'],
                                    stdout=subprocess.PIPE).stdout.read().strip()
+        s_built = ''
     elif buildtype == 'dsc':
         b_built = subprocess.Popen(['find', os.path.join(pacdir, 'DEBS'),
                                     '-name', '*.deb'],


### PR DESCRIPTION
Fixed images local build failure because of
uninitialized variable 's_built'.
