### PR TITLE
fix osc service exit code

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6063,7 +6063,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             elif command == "disabledrun" or command == "dr":
                 mode = "disabled"
 
-        p.run_source_services(mode, singleservice)
+        return p.run_source_services(mode, singleservice)
 
     @cmdln.option('-a', '--arch', metavar='ARCH',
                         help='trigger rebuilds for a specific architecture')


### PR DESCRIPTION
Commands like `osc service disabledrun` would always return exitcode 0 even when the source service failed.  This broke any scripts which wrapped around osc service.
