### PR TITLE
Add kernel initrd

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -991,6 +991,11 @@ def main(apiurl, opts, argv):
                 if os.access(build_root, os.W_OK) and os.access('/dev/kvm', os.W_OK):
                     # so let's hope there's also an fstab entry
                     need_root = False
+                if config['build-kernel']:
+                    vm_options += [ '--vm-kernel=' + config['build-kernel'] ]
+                if config['build-initrd']:
+                    vm_options += [ '--vm-initrd=' + config['build-initrd'] ]
+
             build_root += '/.mount'
 
         if config['build-memory']:

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -112,6 +112,8 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'build-vmdisk-rootsize': '',        # optional for VM builds
             'build-vmdisk-swapsize': '',        # optional for VM builds
             'build-vmdisk-filesystem': '',        # optional for VM builds
+            'build-kernel': '',                 # optional for VM builds
+            'build-initrd': '',                 # optional for VM builds
 
             'build-jobs': _get_processors(),
             'builtin_signature_check': '1',     # by default use builtin check for verify pkgs
@@ -226,6 +228,12 @@ apiurl = %(apiurl)s
 # build-swap is the disk-image to use as swap for VM builds
 # e.g. /var/tmp/FILE.swap
 #build-swap = /var/tmp/FILE.swap
+
+# build-kernel is the boot kernel used for VM builds
+#build-kernel = /boot/vmlinuz
+
+# build-initrd is the boot initrd used for VM builds
+#build-initrd = /boot/initrd
 
 # build-memory is the amount of memory used in the VM
 # value in MB - e.g. 512


### PR DESCRIPTION
Some distributions have no initrd images compatible with KVM builds and sometimes we need to use non system kernel version.

New options proposed for $HOME/.oscrc configuration file to point to different versions :
- build-kernel -- kernel used for VM builds
- build-initrd -- initrd image used for VM builds
