### PR TITLE
ReviewState will now also store it's history nodes and not discard them.

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -2400,6 +2400,9 @@ class ReviewState(AbstractState):
         if not review_node.find('comment') is None and \
             review_node.find('comment').text:
             self.comment = review_node.find('comment').text.strip()
+        self.statehistory = []
+        for history_element in review_node.findall('history'):
+            self.statehistory.append(RequestHistory(history_element))
 
     def get_node_attrs(self):
         return ('state', 'by_user', 'by_group', 'by_project', 'by_package', 'who', 'when')

--- a/tests/request_fixtures/test_read_request3.xml
+++ b/tests/request_fixtures/test_read_request3.xml
@@ -1,0 +1,25 @@
+<request id="123">
+  <action type="submit">
+    <source package="abc" project="xyz" />
+    <options>
+      <sourceupdate>cleanup</sourceupdate>
+      <updatelink>1</updatelink>
+    </options>
+  </action>
+  <action type="add_role">
+    <target project="home:foo" />
+    <person name="bar" role="maintainer" />
+    <group name="groupxyz" role="reader" />
+  </action>
+  <state name="review" when="2010-12-27T01:36:29" who="abc" />
+  <review by_group="group1" state="new" when="2010-12-28T00:11:22" who="abc">
+    <comment>review accepted</comment>
+    <history who="abc" when="2010-12-28T00:11:22">
+      <description>Review got accepted</description>
+      <comment>review start</comment>
+    </history>
+  </review>
+  <history when="2010-12-11T00:00:00" who="creator">
+    <description>Created request</description>
+  </history>
+</request>

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -426,6 +426,23 @@ class TestRequest(OscTestCase):
 
         self.assertEqual(exp, r.to_str())
 
+    def test_read_request_review_history(self):
+        """test history of reviews is parsed."""
+        from xml.etree import cElementTree as ET
+        xml = open(os.path.join(self._get_fixtures_dir(),
+                                'test_read_request3.xml'),
+                   'r').read().strip()
+        r = osc.core.Request()
+        r.read(ET.fromstring(xml))
+        self.assertEqual(r.reqid, '123')
+        self.assertEqual(len(r.reviews[0].statehistory), 1)
+        self.assertEqual(r.reviews[0].statehistory[0].who, 'abc')
+        self.assertEqual(r.reviews[0].statehistory[0].when,
+                         '2010-12-28T00:11:22')
+        self.assertEqual(r.reviews[0].statehistory[0].description,
+                         'Review got accepted')
+        self.assertEqual(r.reviews[0].statehistory[0].comment, 'review start')
+
     def test_request_list_view1(self):
         """test the list_view method"""
         from xml.etree import cElementTree as ET


### PR DESCRIPTION
I added code to not discard the `history`-nodes of a `review` element in a request.

The history-nodes are handled exactly like the history-nodes of a `request` and added to a `statehistory`-list.
