### PR TITLE
Add __repr__ for Repo class

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5176,6 +5176,9 @@ class Repo:
     def __str__(self):
         return self.repo_line_templ % (self.name, self.arch)
 
+    def __repr__(self):
+        return 'Repo(%s %s)' % (self.name, self.arch)
+
     @staticmethod
     def fromfile(filename):
         if not os.path.exists(filename):


### PR DESCRIPTION
Add _repr__ function to Repo class, which makes it easier to view which object you are working on in an interactive shell.
Out[10]: <osc.core.Repo instance at 0x7fb29fbd3e18>
VS.
Out[19]: Repo(openSUSE_13.2 i586)
