### PR TITLE
Pass threads option to obs-build

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -444,6 +444,8 @@ def main(apiurl, opts, argv):
         build_root = opts.root
     if opts.target:
         buildargs.append('--target=%s' % opts.target)
+    if opts.threads:
+        buildargs.append('--threads=%s' % opts.threads)
     if opts.jobs:
         buildargs.append('--jobs=%s' % opts.jobs)
     elif config['build-jobs'] > 1:

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5527,6 +5527,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='Build in specified directory')
     @cmdln.option('-j', '--jobs', metavar='N',
                   help='Compile with N jobs')
+    @cmdln.option('-t', '--threads', metavar='N',
+                  help='Compile with N threads')
     @cmdln.option('--icecream', metavar='N',
                   help='use N parallel build jobs with icecream')
     @cmdln.option('--ccache', action='store_true',


### PR DESCRIPTION
Currently --jobs sets only -smp flag for VM, in some cases we want
to pass threads as well. So the command line would like -smp 4,threads=4

Signed-off-by: Dinar Valeev <dvaleev@suse.com>