### PR TITLE
Command line handling: accept rq accept --submit-devel

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1109,9 +1109,13 @@ class Osc(cmdln.Cmdln):
             value = root.findtext('attribute/value')
             if value and not opts.yes:
                 repl = ''
-                print('\n\nThere are already following submit request: %s.' % \
-                      ', '.join([str(i) for i in myreqs ]))
-                repl = raw_input('\nSupersede the old requests? (y/n) ')
+                if opts.submit_devel:
+                    # In case the user passed --submit-devel, we don't ask anymore
+                    repl = 'y'
+                else:
+                    print('\n\nThere are already following submit request: %s.' % \
+                          ', '.join([str(i) for i in myreqs ]))
+                    repl = raw_input('\nSupersede the old requests? (y/n) ')
                 if repl.lower() == 'y':
                     myreqs += [ value ]
 
@@ -1865,6 +1869,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='output the diff in the unified diff format')
     @cmdln.option('--no-devel', action='store_true',
                   help='Do not attempt to forward to devel project')
+    @cmdln.option('--submit-devel', action='store_true',
+                  help='Attempt to forward to devel project if defined, superseding any existing request')
     @cmdln.option('-m', '--message', metavar='TEXT',
                   help='specify message TEXT')
     @cmdln.option('-t', '--type', metavar='TYPE',
@@ -2364,10 +2370,13 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                 print(project, end=' ')
                                 if package != action.tgt_package:
                                     print("/", package, end=' ')
-                                repl = raw_input('\nForward this submit to it? ([y]/n)')
+                                if not opts.submit_devel:
+                                    repl = raw_input('\nForward this submit to it? ([y]/n)')
+                                else:
+                                    repl = 'y'
                                 if repl.lower() == 'y' or repl == '':
                                     (supersede, reqs) = check_existing_requests(apiurl, action.tgt_project, action.tgt_package,
-                                                                                project, package)
+                                                                                project, package, opts.submit_devel)
                                     msg = "%s (forwarded request %s from %s)" % (rq.description, reqid, rq.get_creator())
                                     rid = create_submit_request(apiurl, action.tgt_project, action.tgt_package,
                                                                 project, package, cgi.escape(msg))

--- a/osc/core.py
+++ b/osc/core.py
@@ -4254,16 +4254,19 @@ def get_request_log(apiurl, reqid):
     return data
 
 def check_existing_requests(apiurl, src_project, src_package, dst_project,
-                            dst_package):
+                            dst_package, opt_supersede=False):
     reqs = get_exact_request_list(apiurl, src_project, dst_project,
                                   src_package, dst_package,
                                   req_type='submit',
                                   req_state=['new', 'review', 'declined'])
     repl = ''
     if reqs:
-        print('There are already the following submit request: %s.' % \
-              ', '.join([i.reqid for i in reqs]))
-        repl = raw_input('Supersede the old requests? (y/n/c) ')
+        if opt_supersede:
+            repl = 'y'
+        else:
+            print('There are already the following submit request: %s.' % \
+                  ', '.join([i.reqid for i in reqs]))
+            repl = raw_input('Supersede the old requests? (y/n/c) ')
         if repl.lower() == 'c':
             print('Aborting', file=sys.stderr)
             raise oscerr.UserAbort()


### PR DESCRIPTION
This will do the opposite of --no-devel and forward to a devel project
without furher asking, automatically superseding existing requests.

Comes in handy in our workflow, where we develop unstable GNOME in GNOME:Next, then submit it to GNOME:Factory and in some cases need to directly submit it to openSUSE:Factory.

Doing a large batch of submit requests, not being asked to forward every single one is mandatory