### PR TITLE
added a simple way to verify osc code base with the python security scanner bandit

### DIFF
--- a/run_bandit.sh
+++ b/run_bandit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# you can pass as argument "csv","json" or "txt" (default)
+if [ "$1" != "" ];then
+    OUTPUT=$1
+else
+    OUTPUT="txt"
+fi
+
+# check if bandit is installed
+command -v bandit >/dev/null 2>&1 || { echo "bandit should be installed. get the package from https://build.opensuse.org/package/show/home:vpereirabr/python-bandit.  Aborting." >&2; exit 1; }
+
+bandit -c /usr/etc/bandit/bandit.yaml -r osc -f $OUTPUT
+
+if [ "$OUTPUT" == "csv" ];then
+    cat bandit_results.csv
+    rm -f bandit_results.csv
+fi


### PR DESCRIPTION
openstack released a tool named bandit, a security scanner. I tested osc and the results looks relevant. 

more information about the tool can be found here https://wiki.openstack.org/wiki/Security/Projects/Bandit

I packaged it and you can find it here: https://build.opensuse.org/package/show/home:vpereirabr/python-bandit

the output from the osc scan, can be found here https://gist.github.com/vpereira/f54afa4ea11bb41c1a72

I integrated it in a obs project - using brp - and at build time i scan the python code.. it works.