### PR TITLE
Add support for non-root paths in API URLs.

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -3135,8 +3135,8 @@ def makeurl(baseurl, l, query=[]):
     elif isinstance(query, type(dict())):
         query = urlencode(query)
 
-    scheme, netloc = urlsplit(baseurl)[0:2]
-    return urlunsplit((scheme, netloc, '/'.join(l), query, ''))
+    scheme, netloc, path = urlsplit(baseurl)[0:3]
+    return urlunsplit((scheme, netloc, '/'.join([path] + l), query, ''))
 
 
 def http_request(method, url, headers={}, data=None, file=None):
@@ -3161,10 +3161,11 @@ def http_request(method, url, headers={}, data=None, file=None):
 
     req = URLRequest(url)
     api_host_options = {}
-    if conf.is_known_apiurl(url):
+    apiurl = conf.extract_known_apiurl(url)
+    if apiurl is not None:
         # ok no external request
-        install_opener(conf._build_opener(url))
-        api_host_options = conf.get_apiurl_api_host_options(url)
+        install_opener(conf._build_opener(apiurl))
+        api_host_options = conf.get_apiurl_api_host_options(apiurl)
         for header, value in api_host_options['http_headers']:
             req.add_header(header, value)
 


### PR DESCRIPTION
Currently osc supports API URLs without path only,
like https://api.example.com (if there is pathname, it's just ignored).
With this change API URLS with path, like https://example.com/api
are supported correctly.

This is useful for those who can't have OBS api, webui and main site
on different domains and buy separate X.509 certificates for them,
or just can't afford to have separate IP addresses for them
(please note that currently osc doesn't support TLS SNI).

Signed-off-by: Oleg Girko <ol@infoserver.lv>