### PR TITLE
avoid buffering stdout output on pipes (bnc#930137)

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -5,6 +5,7 @@
 
 import locale
 import sys
+import os
 
 from osc import commandline, babysitter
 
@@ -20,6 +21,10 @@ try:
 except NameError:
     #reload, neither setdefaultencoding are in python3
     pass
+
+# avoid buffering output on pipes (bnc#930137)
+if sys.stdout.name == '<stdout>':
+    sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
 
 osccli = commandline.Osc()
 


### PR DESCRIPTION
This change is slightly tested and seems to fix the case of | tee 

https://bugzilla.opensuse.org/show_bug.cgi?id=930137