### PR TITLE
When lxml fails to parse the _service file show error message instead of backtrace

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -2296,7 +2296,12 @@ rev: %s
         si = Serviceinfo()
         if os.path.exists('_service'):
             if self.filenamelist.count('_service') or self.filenamelist_unvers.count('_service'):
-                service = ET.parse(os.path.join(self.absdir, '_service')).getroot()
+                try:
+                    service = ET.parse(os.path.join(self.absdir, '_service')).getroot()
+                except ET.ParseError as v:
+                    line, column = v.position
+                    print('XML error in _service file on line %s, column %s' % (line, column))
+                    sys.exit(1)
                 si.read(service)
         si.getProjectGlobalServices(self.apiurl, self.prjname, self.name)
         r = si.execute(self.absdir, mode, singleservice, verbose)


### PR DESCRIPTION
Print a user friendly error when there is an XML syntax error in the _service file when committing.