### PR TITLE
fix an "400 Bad Request" when running against old API

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -3688,6 +3688,9 @@ def get_project_sourceinfo(apiurl, project, nofilename, *packages):
     try:
         si = show_project_sourceinfo(apiurl, project, nofilename, *packages)
     except HTTPError, e:
+        # old API servers do not know the 'nofilename' parameter, so retry without
+        if e.code == 400 and nofilename:
+            return get_project_sourceinfo(apiurl, project, False, *packages)
         if e.code != 414:
             raise
         if len(packages) == 1:


### PR DESCRIPTION
Updating a whole project against an old API server (experienced with
2.3.5) leads to:
	Server returned an error: HTTP Error 400: Bad Request
	unknown parameter 'nofilename'
So just retry without nofilename if an 400 is thrown.