### PR TITLE
Enable container-based Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
   - "2.7"
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq diffstat
+addons:
+  apt:
+    packages:
+    - diffstat
+sudo: false
 script: cd tests; python suite.py


### PR DESCRIPTION
Hello,

Travis is moving away from VM-based builds to container-based builds. Advantages for users are more resources available and less waiting time before a build starts.

Documentation: http://docs.travis-ci.com/user/migrating-from-legacy/
Example run: https://travis-ci.org/bluca/osc/builds/75360677