### PR TITLE
Add support for TLS SNI if M2Crypto supports it.

### DIFF
--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -250,7 +250,12 @@ class myHTTPSConnection(M2Crypto.httpslib.HTTPSConnection):
         M2Crypto.httpslib.HTTPSConnection.__init__(self, *args, **kwargs)
 
     def connect(self, *args):
-        M2Crypto.httpslib.HTTPSConnection.connect(self, *args)
+        self.sock = SSL.Connection(self.ssl_ctx)
+        if self.session:
+            self.sock.set_session(self.session)
+        if hasattr(self.sock, 'set_tlsext_host_name'):
+            self.sock.set_tlsext_host_name(self.host)
+        self.sock.connect((self.host, self.port))
         verify_certificate(self)
 
     def getHost(self):


### PR DESCRIPTION
Currently osc can't access API URLs which share the same IP address with other SSL-enabled sites, complaining about certificate not matching hostname.

This change solves this problem by instructing `M2Crypto.SSL.Connection` to send the desired hostname to https server using TLS SNI extension, thus allowing the server to present the right certificate and choose the right virtual site.

This is useful for those who can't afford to have a separate IP address for OBS API.

For TLS SNI to work correctly, M2Crypto should be patched:
https://bugzilla.osafoundation.org/show_bug.cgi?id=13073
Some distributions (like Fedora) already include this patch.

For unpatched M2Crypto osc degrades to operation without TLS SNI.