### PR TITLE
Add Travis CI build for Python 3.3, 3.4, 3.5-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5-dev"
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hello,

In case it can be useful, this commit adds CI builds with Python 3. Thanks in part to the container-based infrastructure, tests across all versions are started and ran in parallel, so there is no additional time to wait for results. Travis supports 3.2, 3.3, 3.4 and release candidate builds of 3.5 (scheduled to be release in a month, so it's probably a good idea to start testing on it).

Tests on 3.2 are failing (is it supported?), so 3.2 is not included, see https://travis-ci.org/bluca/osc/jobs/75774509 for the log if you are interested.