### PR TITLE
osc: stop saying "not found at x, trying openSUSE Build Service"

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -96,8 +96,8 @@ class Fetcher:
         """failure output for failovers from urlgrabber"""
         if errobj.url.startswith('file://'):
             return {}
-        print('Trying openSUSE Build Service server for %s (%s), not found at %s.'
-              % (self.curpac, self.curpac.project, errobj.url.split('/')[2]))
+        print('%s:%s: attempting download via BSRPC, since not available through HTTP %s'
+              % (self.curpac.project, self.curpac, self.curpac.project, errobj.url.split('/')[2]))
         return {}
 
     def __add_cpio(self, pac):


### PR DESCRIPTION
1. The message is nonsensical in a private instance scenario.

"Trying openSUSE Build Service server for trade-secret (product:1.0),
not found at thehttpwedidnotsetup.company.com."

2. The message is self-referential, redundant for openSUSE.

"Trying openSUSE Build Service server for foo (bar),
not found at download.opensuse.org"

For many people, download.opensuse.org is (part of) the build service,
one way or another. If it was not found there in the first place, why
try there again.

3. The message suggests something bad happened, but this is not
the case.

It is normal for packages not to available on HTTP, which can happen
if no such server was set up, is down for maintenance, or has not
synchronized yet with the newest state for various reasons, such as
bs_publish not having run for the project yet, which in turn can
happen if the project is still building.

All in all, it is a normal situation, and so the message warrants
being reworded.