### PR TITLE
Support build-type='none' for non-Linux systems

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5833,6 +5833,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         import osc.build
 
+        if conf.config['build-type'] and conf.config['build-type'] == "none":
+            print('Error: build command has been disabled for this platform, cannot run local builds')
+            return 1
+
         if which(conf.config['build-cmd']) is None:
             print('Error: build (\'%s\') command not found' % conf.config['build-cmd'], file=sys.stderr)
             print('Install the build package from http://download.opensuse.org/repositories/openSUSE:/Tools/', file=sys.stderr)

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -104,7 +104,7 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
 
             # build type settings
             'build-cmd': '/usr/bin/build',
-            'build-type': '',                   # may be empty for chroot, kvm or xen
+            'build-type': '',                   # may be empty for chroot, kvm or xen, none to disable local builds
             'build-root': '/var/tmp/build-root/%(repo)s-%(arch)s',
             'build-uid': '',                    # use the default provided by build
             'build-device': '',                 # required for VM builds


### PR DESCRIPTION
osc can be used for interaction with a remote build service on platforms
other than Linux, for example OS X. However, local builds are not
supported, so we want to fail gracefully if the package maintainer
patched the default configuration to build-type = 'none'.