### PR TITLE
switch to new obsinfo service

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 0.154
+  - switch to new obs_scm service when adding git URL's
   - set OSC_VERSION environment for source services
 
 0.153

--- a/osc/core.py
+++ b/osc/core.py
@@ -343,21 +343,27 @@ class Serviceinfo:
 
     def addSetVersion(self, serviceinfo_node):
         r = serviceinfo_node
-        s = ET.Element( "service", name="set_version" )
+        s = ET.Element( "service", name="set_version", mode="buildtime" )
         r.append( s )
         return r
 
     def addGitUrl(self, serviceinfo_node, url_string):
         r = serviceinfo_node
-        s = ET.Element( "service", name="tar_scm" )
+        s = ET.Element( "service", name="obs_scm" )
         ET.SubElement(s, "param", name="url").text = url_string
         ET.SubElement(s, "param", name="scm").text = "git"
         r.append( s )
         return r
 
+    def addTarUp(self, serviceinfo_node):
+        r = serviceinfo_node
+        s = ET.Element( "service", name="tar", mode="buildtime" )
+        r.append( s )
+        return r
+
     def addRecompressTar(self, serviceinfo_node):
         r = serviceinfo_node
-        s = ET.Element( "service", name="recompress" )
+        s = ET.Element( "service", name="recompress", mode="buildtime" )
         ET.SubElement(s, "param", name="file").text = "*.tar"
         ET.SubElement(s, "param", name="compression").text = "xz"
         r.append( s )
@@ -6644,6 +6650,7 @@ def addGitSource(url):
     stripETxml( services )
     si = Serviceinfo()
     s = si.addGitUrl(services, url)
+    s = si.addTarUp(services)
     s = si.addRecompressTar(services)
     s = si.addSetVersion(services)
     si.read(s)


### PR DESCRIPTION
Hi Marcus,

this is an incompatible change I want to have on purpose (but want to hear a second opinion therefore).

It changes the used service when adding a new git repo via "osc add git:...".

I think this incompatible change is okay, because it affects only users who add a new git repo and I think the command is not widely used that so far.

This will help us a lot with disk storage on the server in future and it will help developers to work inside their git check outs (detailed docu will follow).

So I think we can risk this change and could add a config option to revert later if really needed. (But I do not believe we do).