### PR TITLE
add "osc service runall"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 0.155
-  -
+  - osc service runall: runs all service local, independend of the mode
+                        This allows to create local files even when disabled or
+                        just created at buildtime
 
 0.154
   - switch to new obs_scm service when adding git URL's

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6272,8 +6272,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             run         r  run defined services locally, it takes an optional parameter to run only a
                            specified source service. In case parameters exist for this one in _service file
                            they are used.
-            localrun    lr run services locally and store files as local created
-            disabledrun dr run disabled or server side only services locally and store files as local created
+            runall      ra run all services independend of the used mode
             remoterun   rr trigger a re-run on the server side
             merge          commits all server side generated files and drops the _service definition
             wait           waits until the service finishes and returns with an error if it failed
@@ -6303,7 +6302,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         command = args[0]
 
-        if not (command in ( 'run', 'localrun', 'disabledrun', 'remoterun', 'lr', 'dr', 'r', 'rr', 'merge', 'wait' )):
+        if not (command in ( 'runall', 'ra', 'run', 'localrun', 'disabledrun', 'remoterun', 'lr', 'dr', 'r', 'rr', 'merge', 'wait' )):
             raise oscerr.WrongArgs('Wrong command given.')
 
         if command == "remoterun" or command == "rr":
@@ -6318,7 +6317,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print(mergeservice(apiurl, project, package))
             return
 
-        if command in ('run', 'localrun', 'disabledrun', 'lr', 'dr', 'r'):
+        if command in ('runall', 'ra', 'run', 'localrun', 'disabledrun', 'lr', 'dr', 'r'):
             if not is_package_dir(os.curdir):
                 raise oscerr.WrongArgs('Local directory is no package')
             p = Package(".")
@@ -6326,6 +6325,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 mode = "local"
             elif command == "disabledrun" or command == "dr":
                 mode = "disabled"
+            elif command == "runall" or command == "ra":
+                mode = "all"
 
         return p.run_source_services(mode, singleservice)
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -398,18 +398,19 @@ class Serviceinfo:
         # recreate files
         ret = 0
         for service in allservices:
-            if singleservice and service['name'] != singleservice:
-                continue
-            if service['mode'] == "buildtime":
-                continue
-            if service['mode'] == "serveronly" and callmode != "disabled":
-                continue
-            if service['mode'] == "disabled" and callmode != "disabled":
-                continue
-            if service['mode'] != "disabled" and callmode == "disabled":
-                continue
-            if service['mode'] != "trylocal" and service['mode'] != "localonly" and callmode == "trylocal":
-                continue
+            if callmode != "all":
+                if singleservice and service['name'] != singleservice:
+                    continue
+                if service['mode'] == "buildtime":
+                    continue
+                if service['mode'] == "serveronly" and callmode != "disabled":
+                    continue
+                if service['mode'] == "disabled" and callmode != "disabled":
+                    continue
+                if service['mode'] != "disabled" and callmode == "disabled":
+                    continue
+                if service['mode'] != "trylocal" and service['mode'] != "localonly" and callmode == "trylocal":
+                    continue
             temp_dir = None
             try:
                 temp_dir = tempfile.mkdtemp(dir=dir, suffix='.%s.service' % service['name'])
@@ -428,7 +429,7 @@ class Serviceinfo:
                     #        updating _services.
                     return r
 
-                if service['mode'] == "disabled" or service['mode'] == "trylocal" or service['mode'] == "localonly" or callmode == "local" or callmode == "trylocal":
+                if service['mode'] == "disabled" or service['mode'] == "trylocal" or service['mode'] == "localonly" or callmode == "local" or callmode == "trylocal" or callmode == "all":
                     for filename in os.listdir(temp_dir):
                         os.rename(os.path.join(temp_dir, filename), os.path.join(dir, filename))
                 else:


### PR DESCRIPTION
This is up for discussion, but I try to simplify the interface here:
- obsolete "localrun" and "disabledrun". Still implemented, but not anymore
  recommended and documented. can hopefully removed later.
- "runall" is running all services local, also buildtime services
  - files get replaced by the service
  - can be used to get final tar balls to be used with tools like quilt

I am not 100% sure about this, please give a second thought as well...