### PR TITLE
return different return codes for different errors

### DIFF
--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -78,7 +78,7 @@ def run(prg, argv=None):
         return 1
     except KeyboardInterrupt:
         print('interrupted!', file=sys.stderr)
-        return 1
+        return 130
     except oscerr.UserAbort:
         print('aborted.', file=sys.stderr)
         return 1


### PR DESCRIPTION
babysitter eats all interesting reasons why osc exited and returns just 3 values:
0 for success, 1 for error and 2 for wrong parameters/options

This patch is attempt to address the problem, I tried to select some sane values, organize it a bit but you may have better ideas.