### PR TITLE
get_prefer_pkgs: don't ignore debuginfo packages

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -427,8 +427,6 @@ def get_prefer_pkgs(dirs, wanted_arch, type, cpio):
             continue
         if path.endswith('.patch.rpm') or path.endswith('.delta.rpm'):
             continue
-        if path.find('-debuginfo-') > 0:
-            continue
         packageQuery = packagequery.PackageQuery.query(path)
         packageQueries.add(packageQuery)
 


### PR DESCRIPTION
This has been part of the original implementation, but it doesn't make
sense.  It should be possible to build with debuginfo packages belonging
to the preferred packages, if you want to debug something in the build
root.