### PR TITLE
Fix exception handling in osc my

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6894,6 +6894,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     # skip it ... try again with old style below
                     pass
 
+                # other errors are handled elsewhere
+                raise e
+
         res = get_user_projpkgs(apiurl, user, role_filter, exclude_projects,
                                 'project' in what, 'package' in what,
                                 opts.maintained, opts.verbose)


### PR DESCRIPTION
The exception handler did nothing and one side effect was that
using osc my --user unknownuser would dump out a huge list
of open requests.