### PR TITLE
FIX results watch returns in blocked state

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5536,7 +5536,12 @@ def get_package_results(apiurl, project, package, wait=False, *args, **kwargs):
             elif result.get('code') in waiting_states:
                 waiting = True
                 break
-
+            else:
+                pkg = result.find('status')
+                if pkg.get('code') in waiting_states:
+                    waiting = True
+                    break
+                
         if not wait or not waiting:
             break
         else:


### PR DESCRIPTION
At the moment only the project status is taken into account when determining when to stop watching a build.
This leads to wrong behavior when a package is in 'blocked' for a longer time.
In this state the project status and code is 'published' but the package remains at 'blocked'.
With this additional check this problem is fixed.