### PR TITLE
[UNTESTED] pass apiurl to source services (#234)

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -297,6 +297,7 @@ class Serviceinfo:
             self.services.append(data)
 
     def getProjectGlobalServices(self, apiurl, project, package):
+        self.apiurl = apiurl
         # get all project wide services in one file, we don't store it yet
         u = makeurl(apiurl, ['source', project, package], query='cmd=getprojectservices')
         try:
@@ -392,6 +393,7 @@ class Serviceinfo:
 
         # set environment when using OBS 2.3 or later
         if self.project != None:
+            os.putenv("OBS_SERVICE_APIURL",  self.apiurl)
             os.putenv("OBS_SERVICE_PROJECT", self.project)
             os.putenv("OBS_SERVICE_PACKAGE", self.package)
 


### PR DESCRIPTION
[**NOTE**: I haven't tested this yet, or at least I don't *think* I've tested it, but then [I can't even remember coding it](https://github.com/openSUSE/osc/issues/234#issuecomment-250940279) so who knows ... ;-)  It looks reasonable to me though.]

Some source services need to know the apiurl, e.g. to lookup values in the `~/.oscrc` config file.

Closes #234.