### PR TITLE
Support running osc non-interactively (in e.g. scripts).

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -35,6 +35,7 @@ except NameError:
 # remains fully buffered (see PyFile_SetBufSize (Objects/fileobject.c))).
 if not os.isatty(sys.stdout.fileno()):
     sys.stdout = os.fdopen(sys.stdout.fileno(), sys.stdout.mode, 1)
+    sys.argv.insert(1, "--non-interactive")
 
 osccli = commandline.Osc()
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -114,6 +114,8 @@ class Osc(cmdln.Cmdln):
                       help='disable usage of desktop keyring system')
         optparser.add_option('--no-gnome-keyring', action='store_true',
                       help='disable usage of GNOME Keyring')
+        optparser.add_option('--non-interactive', action='store_true',
+                      help='try to avoid asking questions from the user')
         optparser.add_option('-v', '--verbose', dest='verbose', action='count', default=0,
                       help='increase verbosity')
         optparser.add_option('-q', '--quiet',   dest='verbose', action='store_const', const=-1,
@@ -133,8 +135,13 @@ class Osc(cmdln.Cmdln):
                             override_post_mortem = self.options.post_mortem,
                             override_no_keyring = self.options.no_keyring,
                             override_no_gnome_keyring = self.options.no_gnome_keyring,
+                            override_non_interactive = self.options.non_interactive,
                             override_verbose = self.options.verbose)
         except oscerr.NoConfigfile as e:
+            if self.options.non_interactive:
+                print("OSC has not been configured.\nCannot prompt the user "
+                        "for the missing information in non-interactive mode.")
+                exit(1)
             print(e.msg, file=sys.stderr)
             print('Creating osc configuration file %s ...' % e.file, file=sys.stderr)
             import getpass
@@ -153,6 +160,11 @@ class Osc(cmdln.Cmdln):
             if try_again:
                 self.postoptparse(try_again = False)
         except oscerr.ConfigMissingApiurl as e:
+            if self.options.non_interactive:
+                print("OSC configuration is missing API URL information.\n"
+                        "Cannot prompt the user for the missing"
+                        " information in non-interactive mode.")
+                exit(1)
             print(e.msg, file=sys.stderr)
             import getpass
             user = raw_input('Username: ')

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -123,6 +123,7 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
 
             'buildlog_strip_time': '0',  # strips the build time from the build log
 
+            'non_interactive': '0',
             'debug': '0',
             'http_debug': '0',
             'http_full_debug': '0',
@@ -189,7 +190,7 @@ config = DEFAULTS.copy()
 boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'traceback', 'check_filelist', 'plaintext_passwd',
     'checkout_no_colon', 'checkout_rooted', 'check_for_request_on_action', 'linkcontrol', 'show_download_progress', 'request_show_interactive',
     'request_show_source_buildstatus', 'review_inherit_group', 'use_keyring', 'gnome_keyring', 'no_verify', 'builtin_signature_check',
-    'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage']
+    'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage', 'non_interactive']
 
 api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']
 
@@ -404,7 +405,6 @@ def is_known_apiurl(url):
     """returns true if url is a known apiurl"""
     apiurl = urljoin(*parse_apisrv_url(None, url))
     return apiurl in config['api_host_options']
-
 
 def extract_known_apiurl(url):
     """
@@ -805,6 +805,7 @@ def get_config(override_conffile=None,
                override_post_mortem=None,
                override_no_keyring=None,
                override_no_gnome_keyring=None,
+               override_non_interactive=None,
                override_verbose=None):
     """do the actual work (see module documentation)"""
     global config
@@ -998,6 +999,8 @@ def get_config(override_conffile=None,
     # override values which we were called with
     if override_verbose:
         config['verbose'] = override_verbose + 1
+    if override_non_interactive:
+        config['non_interactive'] = override_non_interactive
 
     if override_debug:
         config['debug'] = override_debug


### PR DESCRIPTION
Provide a global option for setting non-interactive mode and disable
prompts when creating a new config file if the new option was given by the
user.

Co-Authored-By: Juha Kallioinen <juha.kallioinen@ericsson.com>