### PR TITLE
Ignore build descr directory in build-root substitution for local packages

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -606,7 +606,7 @@ def main(apiurl, opts, argv):
             except oscerr.NoWorkingCopy:
                 opts.local_package = True
         if opts.local_package:
-            pacname = os.path.splitext(build_descr)[0]
+            pacname = os.path.splitext(os.path.basename(build_descr))[0]
     apihost = urlsplit(apiurl)[1]
     if not build_root:
         build_root = config['build-root']

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6139,7 +6139,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             repository, arch, descr = self.parse_repoarchdescr(args, opts.noinit or opts.offline, opts.alternative_project)
             project = opts.alternative_project or store_read_project('.')
             if opts.local_package:
-                package = os.path.splitext(descr)[0]
+                package = os.path.splitext(os.path.basename(descr))[0]
             else:
                 package = store_read_package('.')
             apihost = urlsplit(self.get_api_url())[1]


### PR DESCRIPTION
If build-root contains %(package) substitution, --local-package builds
would substitute absolute path there. This is different than the rule used
in osc chroot (uses relative path), causing the chroot to fail by default.

This commit removes the directory part from both build-root substitutions.