### PR TITLE
Alter osc update operation's default behaviour.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4720,7 +4720,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     # (a) update all packages
                     args += prj.pacs_have
                     # (b) fetch new packages
-                    prj.checkout_missing_pacs(expand_link = not opts.unexpand_link)
+                    prj.checkout_missing_pacs(opts.expand_link, opts.unexpand_link)
                     args.remove(arg)
                 print_request_list(prj.apiurl, prj.name)
 


### PR DESCRIPTION
Make update operation behave as checkout does and do not checkout linked
packages from the same project (by default) during a project wide update.

Default behaviour can be altered with the link expansion options.