### PR TITLE
support for multibuild / locallink feature of OBS

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4977,6 +4977,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='Show results only for specified architecture(s)')
     @cmdln.option('-v', '--verbose', action='store_true', default=False,
                         help='more verbose output')
+    @cmdln.option('-m', '--multibuild', action='store_true', default=False,
+                        help='Show results for all packages in multibuild')
+    @cmdln.option('-M', '--multibuild-package', action='append', default=[],
+                        help='Only show results for the specified multibuild package')
     @cmdln.option('-w', '--watch', action='store_true', default=False,
                         help='watch the results until all finished building')
     @cmdln.option('', '--xml', action='store_true', default=False,
@@ -5035,6 +5039,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         kwargs = {'apiurl': apiurl, 'project': project, 'package': package,
                   'lastbuild': opts.last_build, 'repository': opts.repo,
                   'arch': opts.arch, 'wait': opts.watch}
+        if opts.multibuild_package:
+            opts.multibuild = True
+            kwargs['multibuild_packages'] = opts.multibuild_package
+        kwargs['multibuild'] = kwargs['locallink'] = opts.multibuild
         if opts.xml or opts.csv:
             for xml in get_package_results(**kwargs):
                 if opts.xml:


### PR DESCRIPTION
Adds multibuild output to the osc results output. This feature is needed to give the user the possibility to show all results. 

The normal output looks like this: 

```
# osc r 
openSUSE_Tumbleweed  i586       excluded
openSUSE_Tumbleweed  x86_64     excluded
images               x86_64     excluded
images               m68k       excluded
images               ppc64le    excluded
OSU_SLE_12           m68k       excluded
OSU_SLE_12           x86_64     excluded
```

You can now add a -m (--multi-package) or a -s (--subpackage) switch to get the results of the multibuild packages too.

1. osc r -m 
get the result from main package and all sub packages
2. osc r -s SUBPACK
get only the result from SUBPACK


**Example osc r -m:**
```
# osc r -m 
openSUSE_Tumbleweed  i586       kernel                                   excluded
openSUSE_Tumbleweed  i586       kernel:kernel-obs-build                  failed
openSUSE_Tumbleweed  i586       kernel:kernel-source                     succeeded
openSUSE_Tumbleweed  x86_64     kernel                                   excluded
openSUSE_Tumbleweed  x86_64     kernel:kernel-obs-build                  failed
openSUSE_Tumbleweed  x86_64     kernel:kernel-source                     succeeded
images               x86_64     kernel                                   excluded
images               x86_64     kernel:kernel-obs-build                  excluded
images               x86_64     kernel:kernel-source                     excluded
images               m68k       kernel                                   excluded
images               m68k       kernel:kernel-obs-build                  excluded
images               m68k       kernel:kernel-source                     excluded
images               ppc64le    kernel                                   excluded
images               ppc64le    kernel:kernel-obs-build                  excluded
images               ppc64le    kernel:kernel-source                     excluded
OSU_SLE_12           m68k       kernel                                   excluded
OSU_SLE_12           m68k       kernel:kernel-obs-build                  excluded
OSU_SLE_12           m68k       kernel:kernel-source                     unresolvable
OSU_SLE_12           x86_64     kernel                                   excluded
OSU_SLE_12           x86_64     kernel:kernel-obs-build                  failed
OSU_SLE_12           x86_64     kernel:kernel-source                     succeeded
```

**Example osc r -s**

```
# osc r -s kernel-source
openSUSE_Tumbleweed  i586       kernel:kernel-source                     succeeded
openSUSE_Tumbleweed  x86_64     kernel:kernel-source                     succeeded
images               x86_64     kernel:kernel-source                     excluded
images               m68k       kernel:kernel-source                     excluded
images               ppc64le    kernel:kernel-source                     excluded
OSU_SLE_12           m68k       kernel:kernel-source                     unresolvable
OSU_SLE_12           x86_64     kernel:kernel-source                     succeeded
```