### PR TITLE
Add support for Kerberos based authentication

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -38,5 +38,6 @@ if not os.isatty(sys.stdout.fileno()):
 
 osccli = commandline.Osc()
 
+babysitter.run_baby_sitter = True
 r = babysitter.run(osccli)
 sys.exit(r)

--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -42,6 +42,8 @@ except ImportError:
 
 # the good things are stolen from Matt Mackall's mercurial
 
+# this is set True from osc-wrapper.py
+run_baby_sitter = False
 
 def catchterm(*args):
     raise oscerr.SignalInterrupt
@@ -118,7 +120,7 @@ def run(prg, argv=None):
             print(e.hdrs, file=sys.stderr)
             print(body, file=sys.stderr)
 
-        if e.code in [400, 403, 404, 500]:
+        if e.code in [400, 401, 403, 404, 500]:
             if '<summary>' in body:
                 msg = body.split('<summary>')[1]
                 msg = msg.split('</summary>')[0]

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -120,6 +120,19 @@ class Osc(cmdln.Cmdln):
                       help='be quiet, not verbose')
         return optparser
 
+    def prompt_kerberos_usage(self):
+        prompt = "Use passwordless authentication? [%s] " % ("Y/n" if conf.prefer_kerberos() else "y/N")
+        return raw_input(prompt).strip().lower()
+
+    def use_kerberos(self):
+        if not conf.default_kerberos_realm():
+            return None
+        use = self.prompt_kerberos_usage()
+        return use == 'y' or (conf.prefer_kerberos() and len(use) == 0)
+
+    def prompt_kerberos_realm(self):
+        ans = raw_input("Kerberos realm: [%s] " % conf.default_kerberos_realm()).strip()
+        return ans if ans else conf.default_kerberos_realm()
 
     def postoptparse(self, try_again = True):
         """merge commandline options into the config"""
@@ -140,7 +153,10 @@ class Osc(cmdln.Cmdln):
             import getpass
             config = {}
             config['user'] = raw_input('Username: ')
-            config['pass'] = getpass.getpass()
+            if self.use_kerberos():
+                config['kerberos_realm'] = self.prompt_kerberos_realm()
+            else:
+                config['pass'] = getpass.getpass()
             if self.options.no_keyring:
                 config['use_keyring'] = '0'
             if self.options.no_gnome_keyring:
@@ -156,8 +172,13 @@ class Osc(cmdln.Cmdln):
             print(e.msg, file=sys.stderr)
             import getpass
             user = raw_input('Username: ')
-            passwd = getpass.getpass()
-            conf.add_section(e.file, e.url, user, passwd)
+            realm = None
+            if self.use_kerberos():
+                passwd = None
+                realm = self.prompt_kerberos_realm()
+            else:
+                passwd = getpass.getpass()
+            conf.add_section(e.file, e.url, user, passwd, realm)
             if try_again:
                 self.postoptparse(try_again = False)
 
@@ -4556,7 +4577,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         try:
             self._commit(subcmd, opts, args)
         except oscerr.ExtRuntimeError as e:
-            print("ERROR: service run failed", e, file=sys.stderr)
+            print("ERROR: service run failed: %s" % e, file=sys.stderr)
             return 1
         except oscerr.PackageNotInstalled as e:
             print("ERROR: please install %s " % e.args, end='')

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -61,6 +61,11 @@ except ImportError:
     from urllib2 import URLError, HTTPBasicAuthHandler, HTTPCookieProcessor, HTTPPasswordMgrWithDefaultRealm, ProxyHandler, AbstractBasicAuthHandler
     from urllib2 import AbstractHTTPHandler, build_opener, proxy_bypass, HTTPSHandler
 
+try:
+    import urllib2_kerberos
+except:
+    pass
+
 from . import OscConfigParser
 from osc import oscerr
 from .oscsslexcp import NoSecureSSLError
@@ -153,6 +158,10 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'exclude_glob': '.osc CVS .svn .* _linkerror *~ #*# *.orig *.bak *.changes.vctmp.*',
             # whether to keep passwords in plaintext.
             'plaintext_passwd': '1',
+            # Whether to prefer Kerberos based authentication.
+            'prefer_kerberos' : '0',
+            # The default Kerberos realm to use.
+            #'default_kerberos_realm': 'EXAMPLE.COM',
             # limit the age of requests shown with 'osc req list'.
             # this is a default only, can be overridden by 'osc req list -D NNN'
             # Use 0 for unlimted.
@@ -190,9 +199,10 @@ config = DEFAULTS.copy()
 boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'traceback', 'check_filelist', 'plaintext_passwd',
     'checkout_no_colon', 'checkout_rooted', 'check_for_request_on_action', 'linkcontrol', 'show_download_progress', 'request_show_interactive',
     'request_show_source_buildstatus', 'review_inherit_group', 'use_keyring', 'gnome_keyring', 'no_verify', 'builtin_signature_check',
-    'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage']
+    'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage', 'prefer_kerberos']
 
-api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']
+api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'email',
+        'sslcertck', 'cafile', 'capath', 'trusted_prj', 'kerberos_realm']
 
 new_conf_template = """
 [general]
@@ -287,6 +297,12 @@ apiurl = %(apiurl)s
 # local files to ignore with status, addremove, ....
 #exclude_glob = %(exclude_glob)s
 
+# Prefer Kerberos based authentication over password login.
+#prefer_kerberos = %(prefer_kerberos)s
+
+# Define the Kerberos realm to use for Kerberose based authentication.
+#default_kerberos_realm = %(default_kerberos_realm)s
+
 # keep passwords in plaintext.
 # Set to 0 to obfuscate passwords. It's no real security, just
 # prevents most people from remembering your password if they watch
@@ -348,7 +364,8 @@ apiurl = %(apiurl)s
 
 [%(apiurl)s]
 user = %(user)s
-pass = %(pass)s
+%(auth_template)s
+
 # set aliases for this apiurl
 # aliases = foo, bar
 # email used in .changes, unless the one from osc meta prj <user> will be used
@@ -356,8 +373,6 @@ pass = %(pass)s
 # additional headers to pass to a request, e.g. for special authentication
 #http_headers = Host: foofoobar,
 #       User: mumblegack
-# Plain text password
-#pass =
 # Force using of keyring for this API
 #keyring = 1
 """
@@ -384,6 +399,12 @@ your credentials for this apiurl.
 
 cookiejar = None
 
+def copy_DEFAULTS():
+    c = DEFAULTS.copy()
+    # We never want to end up trying to use the default credentials.
+    c.pop('pass')
+    c.pop('user')
+    return c
 
 def parse_apisrv_url(scheme, apisrv):
     if apisrv.startswith('http://') or apisrv.startswith('https://'):
@@ -406,6 +427,44 @@ def is_known_apiurl(url):
     apiurl = urljoin(*parse_apisrv_url(None, url))
     return apiurl in config['api_host_options']
 
+def use_kerberos_for_url(url):
+    """Returns true if osc is currently configured to use Kerberos authentication."""
+
+    if urllib2_kerberos in sys.modules:
+        return False
+
+    try:
+        options = config['api_host_options'][extract_known_apiurl(url)]
+        return options['user'] and not options.get('pass', None) and not options.get('passx', None)
+    except:
+        return False
+
+def kerberos_realm_for_url(url):
+    """Returns the Kerberos realm for the given apiurl."""
+
+    if urllib2_kerberos in sys.modules:
+        return None
+
+    try:
+        options = config['api_host_options'][extract_known_apiurl(url)]
+        return options.get('kerberos_realm', None) or config['default_kerberos_realm']
+    except:
+        return None
+
+def prefer_kerberos():
+    """Returns True if Kerberos authentication should be preferred."""
+
+    rv = config['prefer_kerberos']
+
+    if type(rv) is bool:
+        return rv
+    else:
+        return rv != '0'
+
+def default_kerberos_realm():
+    """Returns the default Kerberos realm to use."""
+
+    return config.get('default_kerberos_realm', None)
 
 def extract_known_apiurl(url):
     """
@@ -470,13 +529,15 @@ def _build_opener(apiurl):
     if apiurl == _build_opener.last_opener[0]:
         return _build_opener.last_opener[1]
 
+    handlers = []
+
     # respect no_proxy env variable
     if proxy_bypass(apiurl):
         # initialize with empty dict
-        proxyhandler = ProxyHandler({})
+        handlers.append(ProxyHandler({}))
     else:
         # read proxies from env
-        proxyhandler = ProxyHandler()
+        handlers.append(ProxyHandler())
 
     # workaround for http://bugs.python.org/issue9639
     authhandler_class = HTTPBasicAuthHandler
@@ -511,11 +572,15 @@ def _build_opener(apiurl):
         authhandler_class = OscHTTPBasicAuthHandler
 
     options = config['api_host_options'][apiurl]
-    # with None as first argument, it will always use this username/password
-    # combination for urls for which arg2 (apisrv) is a super-url
-    authhandler = authhandler_class( \
-        HTTPPasswordMgrWithDefaultRealm())
-    authhandler.add_password(None, apiurl, options['user'], options['pass'])
+
+    if use_kerberos_for_url(apiurl):
+        r = options.get('kerberos_realm', None) or config['default_kerberos_realm']
+        handlers.insert(0, urllib2_kerberos.HTTPKerberosAuthHandler("%s@%s" % (options['user'], r)))
+    else:
+        # with None as first argument, it will always use this username/password
+        # combination for urls for which arg2 (apisrv) is a super-url
+        handlers.insert(0, authhandler_class(HTTPPasswordMgrWithDefaultRealm()))
+        handlers[0].add_password(None, apiurl, options['user'], options['pass'])
 
     if options['sslcertck']:
         try:
@@ -540,9 +605,9 @@ def _build_opener(apiurl):
         ctx = oscssl.mySSLContext()
         if ctx.load_verify_locations(capath=capath, cafile=cafile) != 1:
             raise oscerr.OscIOError(None, 'No CA certificates found')
-        opener = m2urllib2.build_opener(ctx, oscssl.myHTTPSHandler(ssl_context=ctx, appname='osc'), HTTPCookieProcessor(cookiejar), authhandler, proxyhandler)
+        opener = m2urllib2.build_opener(ctx, oscssl.myHTTPSHandler(ssl_context=ctx, appname='osc'), HTTPCookieProcessor(cookiejar), *handlers)
     else:
-        handlers = [HTTPCookieProcessor(cookiejar), authhandler, proxyhandler]
+        handlers = [HTTPCookieProcessor(cookiejar)] + handlers
         try:
             # disable ssl cert check in python >= 2.7.9
             ctx = ssl._create_unverified_context()
@@ -723,7 +788,7 @@ def write_initial_config(conffile, entries, custom_template=''):
     custom_template is an optional configuration template.
     """
     conf_template = custom_template or new_conf_template
-    config = DEFAULTS.copy()
+    config = copy_DEFAULTS()
     config.update(entries)
     # at this point use_keyring and gnome_keyring are str objects
     if config['use_keyring'] == '1' and GENERIC_KEYRING:
@@ -744,18 +809,26 @@ def write_initial_config(conffile, entries, custom_template=''):
         config['user'] = ''
         config['pass'] = ''
         config['passx'] = ''
-    if not config['plaintext_passwd']:
-        config['pass'] = ''
+
+    if config.get('pass', None):
+        if not config['plaintext_passwd']:
+            config['pass'] = ''
+            config['auth_template'] = "pass = %s" % config['pass']
+        else:
+            config['passx'] = passx_encode(config['pass'])
+            config['auth_template'] = "passx = %s" % config['passx']
     else:
-        config['passx'] = passx_encode(config['pass'])
+        config['auth_template'] = 'kerberos_realm = %s\n# No password when using Kerberos.' \
+                % config['kerberos_realm'] if config['kerberos_realm'] else config['default_kerberos_realm']
+
+    config.setdefault('default_kerberos_realm', '')
 
     sio = StringIO(conf_template.strip() % config)
     cp = OscConfigParser.OscConfigParser(DEFAULTS)
     cp.readfp(sio)
     write_config(conffile, cp)
 
-
-def add_section(filename, url, user, passwd):
+def add_section(filename, url, user, passwd, krb_realm = None):
     """
     Add a section to config file for new api url.
     """
@@ -788,10 +861,14 @@ def add_section(filename, url, user, passwd):
         cp.set(url, 'user', user)
         if not config['plaintext_passwd']:
             cp.remove_option(url, 'pass')
-            cp.set(url, 'passx', passx_encode(passwd))
+            if passwd:
+                cp.set(url, 'passx', passx_encode(passwd))
         else:
             cp.remove_option(url, 'passx')
-            cp.set(url, 'pass', passwd)
+            if passwd:
+                cp.set(url, 'pass', passwd)
+    if not passwd:
+        cp.set(url, 'kerberos_realm', krb_realm if krb_realm else config['default_kerberos_realm'])
     write_config(filename, cp)
 
 
@@ -952,6 +1029,9 @@ def get_config(override_conffile=None,
         api_host_options[apiurl] = {'user': user,
                                     'pass': password,
                                     'http_headers': http_headers}
+
+        if cp.has_option(url, 'kerberos_realm'):
+            api_host_options[apiurl]['kerberos_realm'] = cp.get(url, 'kerberos_realm')
 
         optional = ('email', 'sslcertck', 'cafile', 'capath')
         for key in optional:

--- a/osc/urllib2_kerberos.py
+++ b/osc/urllib2_kerberos.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+
+# urllib2 with kerberos proof of concept
+
+# Copyright 2008 Lime Nest LLC
+# Copyright 2008 Lime Spot LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import logging
+import sys
+import urllib2 as u2
+
+import kerberos as k
+
+def getLogger():
+    log = logging.getLogger("http_kerberos_auth_handler")
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
+    return log
+
+log = getLogger()
+
+class AbstractKerberosAuthHandler:
+    """auth handler for urllib2 that does Kerberos HTTP Negotiate Authentication
+    """
+
+    def negotiate_value(self, headers):
+        """checks for "Negotiate" in proper auth header
+        """
+        authreq = headers.get(self.auth_header, None)
+
+        if authreq:
+            rx = re.compile('(?:.*,)*\s*Negotiate\s*([^,]*),?', re.I)
+            mo = rx.search(authreq)
+            if mo:
+                return mo.group(1)
+            else:
+                log.debug("regex failed on: %s" % authreq)
+
+        else:
+            log.debug("%s header not found" % self.auth_header)
+
+        return None
+
+    def __init__(self):
+        self.retried = 0
+        self.context = None
+
+    def generate_request_header(self, req, headers, neg_value):
+        self.retried += 1
+        log.debug("retry count: %d" % self.retried)
+
+        host = req.get_host()
+        log.debug("req.get_host() returned %s" % host)
+
+        tail, sep, head = host.rpartition(':')
+        domain = tail if tail else head
+                
+        result, self.context = k.authGSSClientInit("HTTP@%s" % domain)
+
+        if result < 1:
+            log.warning("authGSSClientInit returned result %d" % result)
+            return None
+
+        log.debug("authGSSClientInit() succeeded")
+
+        result = k.authGSSClientStep(self.context, neg_value)
+
+        if result < 0:
+            log.warning("authGSSClientStep returned result %d" % result)
+            return None
+
+        log.debug("authGSSClientStep() succeeded")
+
+        response = k.authGSSClientResponse(self.context)
+        log.debug("authGSSClientResponse() succeeded")
+        
+        return "Negotiate %s" % response
+
+    def authenticate_server(self, headers):
+        neg_value = self.negotiate_value(headers)
+        if neg_value is None:
+            log.critical("mutual auth failed. No negotiate header")
+            return None
+
+        result = k.authGSSClientStep(self.context, neg_value)
+
+        if  result < 1:
+            # this is a critical security warning
+            # should change to a raise --Tim
+            log.critical("mutual auth failed: authGSSClientStep returned result %d" % result)
+            pass
+
+    def clean_context(self):
+        if self.context is not None:
+            log.debug("cleaning context")
+            k.authGSSClientClean(self.context)
+            self.context = None
+
+    def http_error_auth_reqed(self, host, req, headers):
+        neg_value = self.negotiate_value(headers) #Check for auth_header
+        if neg_value is not None:
+            if not self.retried > 0:
+                return self.retry_http_kerberos_auth(req, headers, neg_value)
+            else:
+                return None
+        else:
+            self.retried = 0
+
+    def retry_http_kerberos_auth(self, req, headers, neg_value):
+        try:
+            neg_hdr = self.generate_request_header(req, headers, neg_value)
+
+            if neg_hdr is None:
+                log.debug("neg_hdr was None")
+                return None
+
+            req.add_unredirected_header(self.authz_header, neg_hdr)
+            resp = self.parent.open(req)
+
+            self.authenticate_server(resp.info())
+
+            return resp
+
+        except k.GSSError, e:
+            log.critical("GSSAPI Error: %s/%s" % (e[0][0], e[1][0]))
+            return None
+
+        finally:
+            self.clean_context()
+            self.retried = 0
+
+class ProxyKerberosAuthHandler(u2.BaseHandler, AbstractKerberosAuthHandler):
+    """Kerberos Negotiation handler for HTTP proxy auth
+    """
+
+    authz_header = 'Proxy-Authorization'
+    auth_header = 'proxy-authenticate'
+
+    handler_order = 480 # before Digest auth
+
+    def http_error_407(self, req, fp, code, msg, headers):
+        log.debug("inside http_error_407")
+        host = req.get_host()
+        retry = self.http_error_auth_reqed(host, req, headers)
+        self.retried = 0
+        return retry
+
+class HTTPKerberosAuthHandler(u2.BaseHandler, AbstractKerberosAuthHandler):
+    """Kerberos Negotiation handler for HTTP auth
+    """
+
+    authz_header = 'Authorization'
+    auth_header = 'www-authenticate'
+
+    handler_order = 480 # before Digest auth
+
+    def http_error_401(self, req, fp, code, msg, headers):
+        log.debug("inside http_error_401")
+        host = req.get_host()
+        retry = self.http_error_auth_reqed(host, req, headers)
+        self.retried = 0
+        return retry
+
+def test():
+    log.setLevel(logging.DEBUG)
+    log.info("starting test")
+    opener = u2.build_opener()
+    opener.add_handler(HTTPKerberosAuthHandler())
+    resp = opener.open(sys.argv[1])
+    print dir(resp), resp.info(), resp.code
+    
+
+if __name__ == '__main__':
+    test()
+


### PR DESCRIPTION
The osc part of the Kerberos support PR in open-build-service: https://github.com/openSUSE/open-build-service/pull/2467

Note the potential license issue with urllib2_kerberos. This could perhaps be avoided by removing it from the osc's source tree and relying the environment to provide it?