### PR TITLE
added commands for constraints/worker checking

### DIFF
--- a/dist/osc.complete
+++ b/dist/osc.complete
@@ -59,7 +59,7 @@ oscopts=(--version --help --debugger --post-mortem --traceback --http-full-debug
     --debug --apiurl -A --config -c --no-keyring --no-gnome-keyring --verbose --quiet)
 osccmds=(abortbuild add addremove aggregatepac api ar bco bl blt branch branchco
     bsdevelproject bse bugowner build buildconfig buildhist buildhistory buildinfo
-    buildlog buildlogtail cat changedevelreq changedevelrequest checkin checkout
+    buildlog buildlogtail cat changedevelreq changedevelrequest checkconstraints checkin checkout
     chroot ci co commit config copypac cr createincident createrequest creq del
     delete deletereq deleterequest dependson detachbranch develproject di diff
     distributions dists dr dropreq droprequest getbinaries getpac help importsrcpkg
@@ -73,7 +73,7 @@ osccmds=(abortbuild add addremove aggregatepac api ar bco bl blt branch branchco
     resolved results revert review rm rq rremove se search service setlinkrev
     signkey sm sr st status submitpac submitreq submitrequest tr triggerreason
     undelete unlock up update updatepacmetafromspec user vc whatdependson who whois
-    wipebinaries)
+    wipebinaries workerinfo)
 oscreq=(list log show accept decline revoke reopen setincident supersede approvenew
     checkout clone)
 oscrev=(show list add accept decline reopen supersede)
@@ -1396,7 +1396,7 @@ maintainer)
     opts=(--help --role --delete --set-bugowner-request --set-bugowner --all --add
 	  --devel-project --verbose --nodevelproject --email --bugowner --bugowner-only)
     if ((count == 1)) ; then
-	builtin compgen -W "${osccmds[*]}" -- "${cmdline[count]}"
+        builtin compgen -W "${osccmds[*]}" -- "${cmdline[count]}"
     elif ((count >= 2)) ; then
 	for ((off=2; off<=count; off++)) ; do
 	    while test "${cmdline[off+remove]::1}" = "-" ; do
@@ -1812,6 +1812,30 @@ diff|linkdiff)
 	builtin compgen -W "${opts[*]}" -- "${cmdline[count]}"
     fi
     ;;
+workerinfo)
+    opts=(--help)
+    if ((count == 1)) ; then
+        builtin compgen -W "${osccmds[*]} ${oscopts[*]}" -- "${cmdline[count]}"
+    elif ((count >= 2)) ; then
+        if test "${cmdline[count]::1}" = "-" ; then
+            builtin compgen -W "${opts[*]}" -- "${cmdline[count]}"
+        else
+            targets ${opts[*]} -- "${cmdline[count]}"
+        fi
+    fi
+    ;;
+checkconstraints)
+    opts=(--help --ignore-file)
+    if ((count == 1)) ; then
+        builtin compgen -W "${osccmds[*]} ${oscopts[*]}" -- "${cmdline[count]}"
+    elif ((count >= 2)) ; then
+        if test "${cmdline[count]::1}" = "-" ; then
+            builtin compgen -W "${opts[*]}" -- "${cmdline[count]}"
+        else
+            targets ${opts[*]} -- "${cmdline[count]}"
+        fi
+    fi
+    ;;
 *)
     opts=(--help)
     if ((count == 1)) ; then
@@ -1822,5 +1846,5 @@ diff|linkdiff)
 	else
 	    targets ${opts[*]} -- "${cmdline[count]}"
 	fi
-    fi 
+    fi
 esac

--- a/osc/core.py
+++ b/osc/core.py
@@ -5894,7 +5894,26 @@ def get_buildconfig(apiurl, prj, repository):
     f = http_GET(u)
     return f.read()
 
- 
+
+def get_worker_info(apiurl, worker):
+    u = makeurl(apiurl, ['worker', worker])
+    f = http_GET(u)
+
+    return f.read()
+
+
+def check_constraints(apiurl, prj, repository, arch, package, constraintsfile=None):
+    query = {'cmd': 'checkconstraints'}
+    query['project'] = prj
+    query['package'] = package
+    query['repository'] = repository
+    query['arch'] = arch
+    u = makeurl(apiurl, ['worker'], query)
+    f = http_POST(u, data=constraintsfile)
+    root = ET.fromstring(''.join(f))
+    return [node.get('name') for node in root.findall('entry')]
+
+
 def get_source_rev(apiurl, project, package, revision=None):
     # API supports ?deleted=1&meta=1&rev=4
     # but not rev=current,rev=latest,rev=top, or anything like this.


### PR DESCRIPTION
new osc commands workerinfo and checkconstraints:

`osc workerinfo <workername>`

genreates:

```
<worker hostarch="x86_64" registerserver="http://localhost:5252" workerid="workername">
  <hostlabel>TEST</hostlabel>
  <sandbox>chroot</sandbox>
  <linux>
    <version>4.1.34-33</version>
    <flavor>default</flavor>
  </linux>
  <hardware>
    <cpu>
      <flag>fpu</flag>
      [ ... ]
    </cpu>
    <processors>2</processors>
    <jobs>1</jobs>
  </hardware>
</worker>
```

osc checkconstraints must be called in a package directory. If a repository and a arch is given it returns the names of the workers that can build with the constraints. If no arch and repo is given it sums up the workers for each repo/arch. 

It automatically takes the _constraints file in the directory. The file can also be given as an argument. 
If no file is given or found (or ignored with **--ignore-file**) just the project constraints are used. 

Example output without repo/arch

```
# osc checkconstraints _constraints

Repository                Arch                      Worker
----------                ----                      ------
openSUSE_Leap_42.2        x86_64                    14
openSUSE_Leap_42.1        x86_64                    14
```

Example output with repo and arch

```
# osc checkconstraints openSUSE_Leap_42.1 x86_64 _constraints

Worker
------
x86_64:worker:1
x86_64:worker:2
x86_64:worker:3
[ ... ]
```

@marcus-h: Can you please review? I hope i didn't screw the indentation again. I also used pep8 to check if everything is fine. 
@adrianschroeter: Can you please have a look too?