### PR TITLE
RFC: show build results of multibuild packages by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.157
   - add unpublish command (requires OBS 2.8)
+  - results: show multibuild results by default
 
 0.156
   - highlight scheduled jobs with dispatch problems (due to constraints)

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4977,8 +4977,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='Show results only for specified architecture(s)')
     @cmdln.option('-v', '--verbose', action='store_true', default=False,
                         help='more verbose output')
-    @cmdln.option('-m', '--multibuild', action='store_true', default=False,
-                        help='Show results for all packages in multibuild')
+    @cmdln.option('--no-multibuild', action='store_true', default=False,
+                        help='Disable results for all direct affect packages inside of the project')
     @cmdln.option('-M', '--multibuild-package', action='append', default=[],
                         help='Only show results for the specified multibuild package')
     @cmdln.option('-w', '--watch', action='store_true', default=False,
@@ -5040,9 +5040,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   'lastbuild': opts.last_build, 'repository': opts.repo,
                   'arch': opts.arch, 'wait': opts.watch}
         if opts.multibuild_package:
-            opts.multibuild = True
+            opts.no_multibuild = False
             kwargs['multibuild_packages'] = opts.multibuild_package
-        kwargs['multibuild'] = kwargs['locallink'] = opts.multibuild
+        if not opts.no_multibuild:
+            kwargs['multibuild'] = kwargs['locallink'] = True
         if opts.xml or opts.csv:
             for xml in get_package_results(**kwargs):
                 if opts.xml:


### PR DESCRIPTION
Be in sync with webui. Also it is assumed that a user wants to see
all build results of the source change he did and not only for a subset.

This turns around the default behaviour, so please comment on this :)