### PR TITLE
quote the proj and pkg on checkout url

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4816,7 +4816,7 @@ def checkout_package(apiurl, project, package,
 
     # before we create directories and stuff, check if the package actually
     # exists
-    show_package_meta(apiurl, project, package, meta)
+    show_package_meta(apiurl, quote_plus(project), quote_plus(package), meta)
 
     isfrozen = False
     if expand_link:


### PR DESCRIPTION
fixes #240 
Now the # is quoted and the server returns an invalid package name error. 
This error is ok because OBS does not allow the '#'-sign in package names anyway.

```
# osc co mypack#123

Server returned an error: HTTP Error 400: Bad Request
Error getting meta for project 'home%3Amarco' package 'mypack%23123'
invalid package name 'mypack#123'
```

