### PR TITLE
[RFC] improved build recipe guessing

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -7310,6 +7310,32 @@ def run_external(filename, *args, **kwargs):
             raise
         raise oscerr.ExtRuntimeError(e.strerror, filename)
 
+def return_external(filename, *args, **kwargs):
+    """Executes the program filename via subprocess.check_output.
+
+    *args are additional arguments which are passed to the
+    program filename. **kwargs specify additional arguments for
+    the subprocess.check_output function.
+    if no args are specified the plain filename is passed
+    to subprocess.check_output (this can be used to execute a shell
+    command). Otherwise [filename] + list(args) is passed
+    to the subprocess.check_output function.
+
+    Returns the output of the command.
+
+    """
+    if args:
+        cmd = [filename] + list(args)
+    else:
+        cmd = filename
+
+    try:
+        return subprocess.check_output(cmd, **kwargs)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        raise oscerr.ExtRuntimeError(e.strerror, filename)
+
 # backward compatibility: local role filtering
 def filter_role(meta, user, role):
     """


### PR DESCRIPTION
A try to improve the build recipe guessing.

**Prerequisites:**

- there need to be multiple build recipes (e.g. pack1.spec pack1.dsc PKGBUILD)
- when calling `obs build` a repository and an arch needs to be given
- it doesn't work with multiple build recipes of the same type

**How the build recipe is determined:** 

1. get the build configuration (based on repository)
2. decide, based on repotype or patterntype, which recipe to use
3. Look for a recipe file in directory for this type


Please share your thoughts about this approach and if this is a thing we want. 