### PR TITLE
fixes osc checkout error with checkout_rooted=1

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4799,16 +4799,19 @@ def checkout_package(apiurl, project, package,
                 # if project roots were previously inconsistent
                 root_dots = "../../"
             if is_project_dir(root_dots):
+                oldproj = store_read_project(root_dots)
                 if conf.config['checkout_no_colon']:
-                    oldproj = store_read_project(root_dots)
                     n = len(oldproj.split(':'))
                 else:
                     n = 1
+                if root_dots == '.':
+                    root_dots = ''
                 root_dots = root_dots + "../" * n
 
     if root_dots != '.':
         if conf.config['verbose']:
-            print("found root of %s at %s" % (oldproj, root_dots))
+            print("%s is project dir of %s. Root found at %s" %
+                  (prj_dir, oldproj, os.path.abspath(root_dots)))
         prj_dir = root_dots + prj_dir
 
     if not pathname:


### PR DESCRIPTION
This fixes a bug reported from Martin Wilck (see bsc#1012592)
He submitted the patch via bugzilla. Just added the following part: 

```
if root_dots == '.':
     root_dots = ''
```

Otherwise root_dots would be `...` and the new path would be **...**/\<proj\>/\<pack\>/
