### PR TITLE
- Fix handling of "--yes" argument to "osc sr"

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1334,7 +1334,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             return
         supersede_existing = False
         reqs = []
-        if not opts.supersede:
+        if not opts.supersede and not opts.yes:
             (supersede_existing, reqs) = check_existing_requests(apiurl,
                                                                  src_project,
                                                                  src_package,


### PR DESCRIPTION
Passing `--yes` option to `osc sr` was still prompting for superseding existing submitrequests, if any. Added a small check to skip checking for existing requests if `--yes` is passed.

**NOTE**: I couldn't test if this change affects maintenance requests.