### PR TITLE
added syntax check if no token opt is set

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -725,6 +725,8 @@ class Osc(cmdln.Cmdln):
             fd = urlopen(req, data=None)
             print(fd.read())
         else:
+            if args and args[0] in ['create', 'delete', 'trigger']:
+                raise oscerr.WrongArgs("Did you mean --" + args[0] + "?")
             # just list token
             for data in streamfile(url, http_GET):
                 sys.stdout.write(data)


### PR DESCRIPTION
Check if the user accidentally typed

`osc token create project package`

instead of 

`osc token --create project package`