### PR TITLE
added --blame switch to osc meta command

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -738,6 +738,8 @@ class Osc(cmdln.Cmdln):
                         help='include defined attribute defaults')
     @cmdln.option('--attribute-project', action='store_true',
                         help='include project values, if missing in packages ')
+    @cmdln.option('--blame', action='store_true',
+                        help='show author and time of each line')
     @cmdln.option('-f', '--force', action='store_true',
                         help='force the save operation, allows one to ignores some errors like depending repositories. For prj meta only.')
     @cmdln.option('-F', '--file', metavar='FILE',
@@ -889,14 +891,14 @@ class Osc(cmdln.Cmdln):
         # show
         if not opts.edit and not opts.file and not opts.delete and not opts.create and not opts.set:
             if cmd == 'prj':
-                sys.stdout.write(''.join(show_project_meta(apiurl, project, opts.revision)))
+                sys.stdout.write(''.join(show_project_meta(apiurl, project, rev=opts.revision, blame=opts.blame)))
             elif cmd == 'pkg':
-                sys.stdout.write(''.join(show_package_meta(apiurl, project, package)))
+                sys.stdout.write(''.join(show_package_meta(apiurl, project, package, blame=opts.blame)))
             elif cmd == 'attribute':
                 sys.stdout.write(''.join(show_attribute_meta(apiurl, project, package, subpackage,
                                          opts.attribute, opts.attribute_defaults, opts.attribute_project)))
             elif cmd == 'prjconf':
-                sys.stdout.write(''.join(show_project_conf(apiurl, project, opts.revision)))
+                sys.stdout.write(''.join(show_project_conf(apiurl, project, rev=opts.revision, blame=opts.blame)))
             elif cmd == 'user':
                 r = get_user_meta(apiurl, user)
                 if r:

--- a/osc/core.py
+++ b/osc/core.py
@@ -3396,9 +3396,11 @@ def meta_get_project_list(apiurl, deleted=None):
     return sorted([ node.get('name') for node in root if node.get('name')])
 
 
-def show_project_meta(apiurl, prj, rev=None):
+def show_project_meta(apiurl, prj, rev=None, blame=None):
+    query = {}
+    if blame:
+        query['view'] = "blame"
     if rev:
-        query = {}
         query['rev'] = rev
         url = makeurl(apiurl, ['source', prj, '_project', '_meta'], query)
         try:
@@ -3413,16 +3415,23 @@ def show_project_meta(apiurl, prj, rev=None):
             e.osc_msg = 'BuildService API error: %s' % error_help
             raise
     else:
-        url = makeurl(apiurl, ['source', prj, '_meta'])
+        if blame:
+            url = makeurl(apiurl, ['source', prj, '_project', '_meta'], query)
+        else:
+            url = makeurl(apiurl, ['source', prj, '_meta'])
         f = http_GET(url)
     return f.readlines()
 
-def show_project_conf(apiurl, prj, rev=None):
+def show_project_conf(apiurl, prj, rev=None, blame=None):
     query = {}
+    url = None
     if rev:
         query['rev'] = rev
-
-    url = makeurl(apiurl, ['source', prj, '_config'], query)
+    if blame:
+        query['view'] = "blame"
+        url = makeurl(apiurl, ['source', prj, '_project', '_config'], query=query)
+    else:
+        url = makeurl(apiurl, ['source', prj, '_config'], query=query)
     f = http_GET(url)
     return f.readlines()
 
@@ -3437,9 +3446,12 @@ def show_package_trigger_reason(apiurl, prj, pac, repo, arch):
         raise
 
 
-def show_package_meta(apiurl, prj, pac, meta=False):
+def show_package_meta(apiurl, prj, pac, meta=False, blame=None):
     query = {}
     if meta:
+        query['meta'] = 1
+    if blame:
+        query['view'] = "blame"
         query['meta'] = 1
 
     # The fake packages _project has no _meta file


### PR DESCRIPTION
added the --blame switch to the meta command. 
It is now possible to blame project meta, project conf and package meta data

usage:

```
osc meta prj --blame
osc meta pkg --blame
osc meta projconf --blame
```