### PR TITLE
filter excluded repos for package by default

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4995,6 +4995,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='generate output in CSV format')
     @cmdln.option('', '--format', default='%(repository)s|%(arch)s|%(state)s|%(dirty)s|%(code)s|%(details)s',
                         help='format string for csv output')
+    @cmdln.option('--show-excluded', action='store_true',
+                        help='show repos that are excluded for this package')
     def do_results(self, subcmd, opts, *args):
         """${cmd_name}: Shows the build results of a package or project
 
@@ -5044,7 +5046,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         kwargs = {'apiurl': apiurl, 'project': project, 'package': package,
                   'lastbuild': opts.last_build, 'repository': opts.repo,
-                  'arch': opts.arch, 'wait': opts.watch}
+                  'arch': opts.arch, 'wait': opts.watch, 'showexcl': opts.show_excluded}
         if opts.multibuild_package:
             opts.no_multibuild = False
             kwargs['multibuild_packages'] = opts.multibuild_package

--- a/osc/core.py
+++ b/osc/core.py
@@ -5543,9 +5543,12 @@ def get_results(apiurl, project, package, verbose=False, printJoin='', *args, **
     r = []
     printed = False
     multibuild_packages = kwargs.pop('multibuild_packages', [])
+    show_excluded = kwargs.pop('showexcl', False)
     for results in get_package_results(apiurl, project, package, **kwargs):
         r = []
         for res, is_multi in result_xml_to_dicts(results):
+            if not show_excluded and res['code'] == 'excluded':
+                continue
             if '_oldstate' in res:
                 oldstate = res['_oldstate']
                 continue


### PR DESCRIPTION
This changes the default behavior to **not** show the excluded repos. 
It is more clearer, especially in large multibuild environments.
