### PR TITLE
allow to pass any option to the build command

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -802,6 +802,9 @@ def main(apiurl, opts, argv):
     if bi.release:
         buildargs.append('--release=%s' % bi.release)
 
+    if opts.build_opt:
+        buildargs += opts.build_opt
+
     # real arch of this machine
     # vs.
     # arch we are supposed to build for

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5938,6 +5938,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='disable feature X for build')
     @cmdln.option('--define', metavar='\'X Y\'', action='append',
                   help='define macro X with value Y')
+    @cmdln.option('--build-opt', metavar='OPT', action='append',
+                  help='pass option OPT to the build command')
     @cmdln.option('--userootforbuild', action='store_true',
                   help='Run build as root. The default is to build as '
                   'unprivileged user. Note that a line "# norootforbuild" '


### PR DESCRIPTION
so that we do not have to patch osc for every parameter added to build
e.g. "--vm-custom-opt" in my case

similar in nature to gcc'c -Wl, option