### PR TITLE
pass --buildflavor to build script

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -604,6 +604,9 @@ def main(apiurl, opts, argv):
             pac = '_repository'
         else:
             pac = store_read_package(os.curdir)
+    if opts.multibuild_package:
+        buildargs.append('--buildflavor=%s' % opts.multibuild_package)
+        pac = pac + ":" + opts.multibuild_package
     if opts.shell:
         buildargs.append("--shell")
 


### PR DESCRIPTION
pass --buildflavor to build script if multibuild-package (-M) option is used. 

Fixes #293 (for local builds)