### PR TITLE
results --xml causes a stack trace

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5470,7 +5470,7 @@ def get_binarylist_published(apiurl, prj, repo, arch):
     return r
 
 
-def show_results_meta(apiurl, prj, package=None, lastbuild=None, repository=[], arch=[], oldstate=None, multibuild=False, locallink=False):
+def show_results_meta(apiurl, prj, package=None, lastbuild=None, repository=[], arch=[], oldstate=None, multibuild=False, locallink=False, showexcl=False):
     query = {}
     if package:
         query['package'] = package
@@ -5482,6 +5482,8 @@ def show_results_meta(apiurl, prj, package=None, lastbuild=None, repository=[], 
         query['multibuild'] = 1
     if locallink:
         query['locallink'] = 1
+    if showexcl:
+        query['showexcl'] = 1
     u = makeurl(apiurl, ['build', prj, '_result'], query=query)
     for repo in repository:
         u = u + '&repository=%s' % repo


### PR DESCRIPTION
Quick hack to make 
<pre>
osc results --xml openSUSE:Tools osc
</pre>
work again, instead of printing a stack trace like this:
<pre>
Traceback (most recent call last):
  File "/usr/bin/osc", line 41, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python2.7/dist-packages/osc/babysitter.py", line 61, in run
    return prg.main(argv)
  File "/usr/lib/python2.7/dist-packages/osc/cmdln.py", line 343, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/dist-packages/osc/cmdln.py", line 366, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/dist-packages/osc/cmdln.py", line 500, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/dist-packages/osc/cmdln.py", line 1230, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/usr/lib/python2.7/dist-packages/osc/commandline.py", line 5056, in do_results
    for xml in get_package_results(**kwargs):
  File "/usr/lib/python2.7/dist-packages/osc/core.py", line 5609, in get_package_results
    xml = ''.join(show_results_meta(apiurl, project, package, *args, **kwargs))
TypeError: show_results_meta() got an unexpected keyword argument 'showexcl'
</pre>

The results --xml syntax worked fine with at least osc version 0.153