### PR TITLE
Add compatibility with Debian's obs-build

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -12,6 +12,7 @@ import sys
 import time
 import imp
 import inspect
+import os
 try:
     from urllib.parse import urlsplit
     from urllib.error import HTTPError
@@ -5867,7 +5868,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 with tempfile.NamedTemporaryFile() as f:
                     f.write(bc)
                     f.flush()
-                    recipe = return_external('/usr/lib/build/queryconfig', '--dist', f.name, 'type')
+                    # some distros like Debian rename and move build to obs-build
+                    if not os.path.isfile('/usr/lib/build/queryconfig') and os.path.isfile('/usr/lib/obs-build/queryconfig'):
+                        queryconfig = '/usr/lib/obs-build/queryconfig'
+                    else:
+                        queryconfig = '/usr/lib/build/queryconfig'
+                    recipe = return_external(queryconfig, '--dist', f.name, 'type')
                 recipe = recipe.strip()
                 if recipe == 'arch':
                     recipe = 'PKGBUILD'

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -183,6 +183,12 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'vc-cmd': '/usr/lib/build/vc'
 }
 
+# some distros like Debian rename and move build to obs-build
+if not os.path.isfile('/usr/bin/build') and os.path.isfile('/usr/bin/obs-build'):
+    DEFAULTS['build-cmd'] = '/usr/bin/obs-build'
+if not os.path.isfile('/usr/lib/build/vc') and os.path.isfile('/usr/lib/obs-build/vc'):
+    DEFAULTS['vc-cmd'] = '/usr/lib/obs-build/vc'
+
 # being global to this module, this dict can be accessed from outside
 # it will hold the parsed configuration
 config = DEFAULTS.copy()


### PR DESCRIPTION
In Debian and Ubuntu build is renamed to obs-build for disambiguation
purposes.
Add a simple check to use the correct paths if running on Debian and
use /usr/bin/obs-build and /usr/lib/obs-build if so.

This is a constant source of errors and confusion for a lot of our users. Hopefully this very simple fix can put an end to that.