### PR TITLE
Check digest of modified files

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -1868,7 +1868,7 @@ class Package:
             filemeta = self.findfilebyname(n)
             state = ' '
             if conf.config['status_mtime_heuristic']:
-                if os.path.getmtime(localfile) != filemeta.mtime:
+                if os.path.getmtime(localfile) != filemeta.mtime and dgst(localfile) != filemeta.md5:
                     state = 'M'
             elif dgst(localfile) != filemeta.md5:
                 state = 'M'


### PR DESCRIPTION
this reverts a semantic change introduced by commit
48a35fed91d557fd89eed4297d2516776434d837
that caused files with updated timestamps to always be in "M" state.