### PR TITLE
added function to get rpmlint log content

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5211,6 +5211,26 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         print("See 'osc help prjresults'.", file=sys.stderr)
         return 2
 
+    @cmdln.alias('rpmlint')
+    @cmdln.alias('lint')
+    def do_rpmlintlog(self, subcmd, opts, *args):
+        """${cmd_name}: Shows the rpmlint logfile
+
+        Shows the rpmlint logfile to analyse if there are any problems
+        with the spec file and the built binaries.
+
+        usage:
+            osc rpmlintlog project package repository arch
+        """
+        apiurl = self.get_api_url()
+
+        if len(args) == 4:
+            project, package, repository, arch = args
+        else:
+            raise oscerr.WrongArgs('please provide project package repository arch.')
+
+        print(get_rpmlint_log(apiurl, project, package, repository, arch))
+
     @cmdln.alias('bl')
     @cmdln.alias('blt')
     @cmdln.alias('buildlogtail')

--- a/osc/core.py
+++ b/osc/core.py
@@ -7548,4 +7548,9 @@ def delete_comment(apiurl, cid):
     ret = ET.fromstring(f.read()).find('summary')
     return ret.text
 
+def get_rpmlint_log(apiurl, proj, pkg, repo, arch):
+    u = makeurl(apiurl, ['build', proj, repo, arch, pkg, 'rpmlint.log'])
+    f = http_GET(u)
+    return f.read()
+
 # vim: sw=4 et


### PR DESCRIPTION
Provide function to show the content of rpmlint.log.
The core function get_rpmlint_log will later be used in the interactive
request mode to provide the rpmlint logs to the reviewer.

I add the osc rpmlint | rpmlintlog | lint command also.