### PR TITLE
osc tr: show the time when the event happened

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5504,7 +5504,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         xml = show_package_trigger_reason(apiurl, project, package, repository, arch)
         root = ET.fromstring(xml)
         reason = root.find('explain').text
-        print(reason)
+        triggertime = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(int(root.find('time').text)))
+        print("%s (at %s)" % (reason, triggertime))
         if reason == "meta change":
             print("changed keys:")
             for package in root.findall('packagechange'):


### PR DESCRIPTION
It can be handy to have this information at hand - otherwise one needs an extra query on jobhist to find it out (preferably I'd also like to see 'who' caused the event, but that info is not stored at the moment)