### PR TITLE
submitreq entire project fix

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1228,7 +1228,7 @@ class Osc(cmdln.Cmdln):
                     sr_ids.append(result)
                 else:
                     s = """<action type="submit"> <source project="%s" package="%s" /> <target project="%s" package="%s" /> %s </action>"""  % \
-                        (project, p, t, p, options_block)
+                        (project, p, target_project, p, options_block)
                     actionxml += s
 
             if actionxml != "":


### PR DESCRIPTION
`osc submitreq TARGETPROJ`
bails out with unbound variable t. This is true. The variable should be target_project.
Am I the first user to try that feature? :-)