### PR TITLE
prepend request summary to diff in interactive mode

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -7216,11 +7216,13 @@ def request_interactive_review(apiurl, request, initial_cmd='', group=None,
             else:
                 repl = raw_input(prompt).strip()
             if repl == 'i' and src_actions:
+                req_summary = str(request) + '\n'
                 if not orequest is None and tmpfile:
                     tmpfile.close()
                     tmpfile = None
                 if tmpfile is None:
                     tmpfile = tempfile.NamedTemporaryFile(suffix='.diff')
+                    tmpfile.write(req_summary)
                     try:
                         diff = request_diff(apiurl, request.reqid)
                         tmpfile.write(diff)
@@ -7275,7 +7277,8 @@ def request_interactive_review(apiurl, request, initial_cmd='', group=None,
                     footer = 'changing request from state \'%s\' to \'%s\'\n\n' \
                         % (request.state.name, state)
                     msg_template = change_request_state_template(request, state)
-                footer += str(request)
+                if tmpfile is None:
+                    footer += str(request)
                 if tmpfile is not None:
                     tmpfile.seek(0)
                     # the read bytes probably have a moderate size so the str won't be too large


### PR DESCRIPTION
makes it easier for reviewers to get the summary information without the use to exit 
the diff mode.

@marcus-h: please review