### PR TITLE
fixes broken osc results on project level

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5725,9 +5725,9 @@ def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=Non
     pacs = sorted(list(set(pacs)))
     for node in root.findall('result'):
         # filter architecture and repository
-        if arch != None and node.get('arch') not in arch:
+        if arch and node.get('arch') not in arch:
             continue
-        if repo != None and node.get('repository') not in repo:
+        if repo and node.get('repository') not in repo:
             continue
         if node.get('dirty') == "true":
             state = "outdated"


### PR DESCRIPTION
osc results on project level returns an empty line. 
This bug was introduced with https://github.com/openSUSE/osc/commit/2d327df4e78427ae9588490346c536ed21667ce0

Since then arch and repo are not strings anymore but lists. 
So `arch != None` and `repo != None` were always true even if the lists were empty.