### PR TITLE
consider arch when checking the disabled repos

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5846,13 +5846,17 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if subcmd == 'repos_only':
             for repo in get_repositories_of_project(apiurl, project):
-                if (disabled is None) or ((disabled is not None) and (repo not in disabled)):
+                if (disabled is None) or ((disabled is not None) and (repo not in [d['repo'] for d in disabled])):
                     print(repo)
         else:
             data = []
             for repo in get_repos_of_project(apiurl, project):
-                if (disabled is None) or ((disabled is not None) and (repo.name not in disabled)):
-                    data += [repo.name, repo.arch]
+                if disabled is not None:
+                    if ({'repo': repo.name, 'arch': repo.arch} in disabled
+                        or repo.name in [d['repo'] for d in disabled if d['arch'] is None]
+                        or repo.arch in [d['arch'] for d in disabled if d['repo'] is None]):
+                            continue
+                data += [repo.name, repo.arch]
 
             for row in build_table(2, data, width=2):
                 print(row)

--- a/osc/core.py
+++ b/osc/core.py
@@ -3554,7 +3554,12 @@ def show_package_disabled_repos(apiurl, prj, pac):
     try:
         root = ET.fromstring(''.join(m))
         elm = root.find('build')
-        r = [ node.get('repository') for node in elm.findall('disable')]
+        r = []
+        for node in elm.findall('disable'):
+            repo = node.get('repository')
+            arch = node.get('arch')
+            dis_r = {'repo': repo, 'arch': arch}
+            r.append(dis_r)
         return r
     except:
         return None
@@ -7182,7 +7187,7 @@ def request_interactive_review(apiurl, request, initial_cmd='', group=None,
             print('Type %s:' % action.type)
             disabled = show_package_disabled_repos(apiurl, action.src_project, action.src_package)
             for repo in get_repos_of_project(apiurl, action.src_project):
-                if disabled is None or repo.name not in disabled:
+                if (disabled is None) or (repo.name not in [d['repo'] for d in disabled]):
                     lintlog_entry = {
                                       'proj': action.src_project,
                                       'pkg': action.src_package,


### PR DESCRIPTION
At the moment just repo.name is considered. So if the repo is disabled for s390 all other repo / arch combination are not shown in the repo list for 

`osc repos`
`osc getbinaries`

To be able to change this r is now a list of dicts containing the name and arch of the disabled repo.

`None` for repo if a complete arch gets disabled
`None` for arch if a complete repo gets disabled

This is a proposal to fix https://github.com/openSUSE/osc/issues/351