### PR TITLE
Small documentation fix to clarify attribute usage.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -802,7 +802,7 @@ class Osc(cmdln.Cmdln):
             osc meta <prj|pkg|prjconf|user|group|pattern> [-m|--message TEXT] -e|--edit ARGS...
             osc meta <prj|pkg|prjconf|user|group|pattern> [-m|--message TEXT] -F|--file ARGS...
             osc meta pattern --delete PRJ PATTERN
-            osc meta attribute PRJ [PKG [SUBPACKAGE]] [--attribute ATTRIBUTE] [--create|--delete|--set [value_list]]
+            osc meta attribute PRJ [PKG [SUBPACKAGE]] [--attribute ATTRIBUTE] [--create [--set <value_list>]|--delete|--set <value_list>]
         ${cmd_option_list}
         """
 


### PR DESCRIPTION
The `osc meta attribute` usage help is not 100% clear how to create and set an `attribute`.

If an ATTRIBUTE needs a value during creation the `--set` option needs to be added. Right now the create/delete/set options are shown with an or operator.

The `value_list` for the `--set` operator is not optional, therefore `[value_list]` needs to be replaced with `<value_list>` to make this clear.