### PR TITLE
add meaningful error if no attribute name

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -288,6 +288,8 @@ class Serviceinfo:
 
         for service in services:
             name = service.get('name')
+            if name is None:
+                error("invalid service definition. Attribute name missing.", service)
             if len(name) < 3 or '/' in name:
                 error("invalid service name: %s" % name, service)
             mode = service.get('mode', '')


### PR DESCRIPTION
fixes #360 

When committing a _service file which contains a service definition without name attribute, the commit fails now with a clearer error message: 

```
Traceback (most recent call last):
  
[SNIP]

  File "/home/marco/git_r/osc/osc/core.py", line 292, in read
    error("invalid service definition. Attribute name missing.", service)
  File "/home/marco/git_r/osc/osc/core.py", line 281, in error
    raise ValueError("%s\n\n%s" % (data, msg))
ValueError: invalid service format:
<service />
  

invalid service definition. Attribute name missing.
```