### PR TITLE
fixes not working osc maintainer <prj>

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7938,9 +7938,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                             repl = raw_input('\nUse this container? (y/n) ')
                             if repl.lower() != 'y':
                                 searchresult = None
-                    else:
-                       print("Empty search result, you may want to search with other or all roles via -r ''")
-                       return
             elif opts.user:
                 searchresult = owner(apiurl, opts.user, "user", usefilter=filterroles, devel=None)
             elif opts.group:


### PR DESCRIPTION
fixes #150 

The retrun at this point breaks the call, because in most
cases `<prj>` is not a binary. And the code always checks for the
binary first and then returns if no binary with the name `<prj>`
is found.