### PR TITLE
only assign issue detail if text for tag exists

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4843,7 +4843,8 @@ def get_request_issues(apiurl, reqid):
         for cissue in collection:
             issue = {}
             for issue_detail in cissue.iter():
-                issue[issue_detail.tag] = issue_detail.text.strip()
+                if issue_detail.text:
+                    issue[issue_detail.tag] = issue_detail.text.strip()
             issue_list.append(issue)
     return issue_list
 


### PR DESCRIPTION
check if issue_detail.text exists for issue_detail.tag before assigning it. 
This will fix the crashes reported in #369 

@marcus-h please review