### PR TITLE
do not use complex path separator fixes #385

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -1503,9 +1503,10 @@ class Package:
         print('Transmitting file data', end=' ')
         filelist = self.__generate_commitlist(todo_send)
         sfilelist = self.__send_commitlog(msg, filelist, validate=True)
-        if sfilelist.get('error') and sfilelist.findall('.//entry[@hash]'):
+        hash_entries = [e for e in sfilelist.findall('entry') if e.get('hash') is not None] 
+        if sfilelist.get('error') and hash_entries:
             name2elem = dict([(e.get('name'), e) for e in filelist.findall('entry')])
-            for entry in sfilelist.findall('.//entry[@hash]'):
+            for entry in hash_entries:
                 filename = entry.get('name')
                 fileelem = name2elem.get(filename)
                 if filename not in sha256sums:


### PR DESCRIPTION
This is a fix for issue #385. osc commit breaks due to
the use of `sfilelist.findall('.//entry[@hash]')`

I now will iterate through the sfilelist and use

```
for entry in sfilelist.findall('entry'):
    if entry.get('hash'):
        ... execute hash code ...
```

This is a little bit slower, but should not break
on SLE11 anymore.