### PR TITLE
fix getbinaries with DOD binaries

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -384,7 +384,10 @@ class Osc(cmdln.Cmdln):
 
                 if opts.verbose:
                     for f in result[1]:
-                        print("%9d %s %-40s" % (f.size, shorttime(f.mtime), f.name))
+                        if f.size is None and f.mtime is None:
+                            print("%9s %12s %-40s" % ('unknown', 'unknown', f.name))
+                        else:
+                            print("%9d %s %-40s" % (f.size, shorttime(f.mtime), f.name))
                 else:
                     for f in result[1]:
                         print(indent+f)

--- a/osc/core.py
+++ b/osc/core.py
@@ -5587,8 +5587,8 @@ def get_binarylist(apiurl, prj, repo, arch, package=None, verbose=False):
         for node in tree.findall('binary'):
             f = File(node.get('filename'),
                      None,
-                     int(node.get('size')),
-                     int(node.get('mtime')))
+                     int(node.get('size') or 0) or None,
+                     int(node.get('mtime') or 0) or None)
             l.append(f)
         return l
 


### PR DESCRIPTION
getbinaries of dod binaries do not have a size or mtime.
This will break. So just set to None and print unkown instead.

Example output:

` unknown unknown noarch/python3-websocket-client-0.44.0-1.5.noarch.rpm
`

Example: 

```
# osc ls -lb SUSE:SLE-15:GA

Traceback (most recent call last):
  File "/usr/bin/osc", line 41, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python2.7/site-packages/osc/babysitter.py", line 61, in run
    return prg.main(argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 344, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 367, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 501, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 1232, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/usr/lib/python2.7/site-packages/osc/commandline.py", line 377, in do_list
    results.append((repo, get_binarylist(apiurl, project, repo.name, repo.arch, package=package, verbose=opts.verbose)))
  File "/usr/lib/python2.7/site-packages/osc/core.py", line 5588, in get_binarylist
    int(node.get('size')),
ValueError: invalid literal for int() with base 10: ''
```

This PR fixes this

