### PR TITLE
fix missing newline in osc r -v

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5704,7 +5704,7 @@ def get_results(apiurl, project, package, verbose=False, printJoin='', *args, **
             if verbose and res['details'] != '':
                 if res['code'] in ('unresolvable', 'expansion error'):
                     lines = res['details'].split(',')
-                    res['status'] += ': ' + '\n     '.join(lines)
+                    res['status'] += ': \n      ' + '\n     '.join(lines)
                 else:
                     res['status'] += ': %s' % res['details']
             elif res['code'] in ('scheduled', ) and res['details']:


### PR DESCRIPTION
This adds a newline after unresolvable: So the messages are now well printed.

before:
```
osc results -v
Arch                 i586       unresolvable: nothing provides python2
      nothing provides python2-m2crypto
      nothing provides urlgrabber
      nothing provides binutils
      nothing provides gcc                                                                                           
      nothing provides glibc                                                                                         
      nothing provides libtool
```

after:
```
osc results -v
Debian_8.0           x86_64     succeeded
Arch                 i586       unresolvable: 
      nothing provides python2
      nothing provides python2-m2crypto
      nothing provides urlgrabber
      nothing provides binutils
      nothing provides gcc
      nothing provides glibc
      nothing provides libtool
```
