### PR TITLE
always run build using --statistics. I could have made this

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 0.163
   - add sendsysrq command (requires OBS 2.10)
   - add addcontainers command (requires OBS 2.10)
+  - enable statistics for local builds
   - add new options to diff command:
     --unexpand for local diffs only (bsc#1089025)
     --meta for diffing meta files

--- a/osc/build.py
+++ b/osc/build.py
@@ -542,6 +542,7 @@ def main(apiurl, opts, argv):
         raise oscerr.WrongArgs('Error: build description file named \'%s\' does not exist.' % build_descr)
 
     buildargs = []
+    buildargs.append('--statistics')
     if not opts.userootforbuild:
         buildargs.append('--norootforbuild')
     if opts.clean:


### PR DESCRIPTION
yet another option, but
* only very old build scripts don't know it, we should just require a recent one
* build script is ignoring it for chroot case

so why bother with another option?

But doing this via pull request for a second opinion