### PR TITLE
Fix typo in "osc revert" help

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8937,7 +8937,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         Examples:
             osc revert <modified file(s)>
-            ose revert .
+            osc revert .
         Note: this only works for package working copies
 
         ${cmd_usage}


### PR DESCRIPTION
I think we call it `osc` :)