### PR TITLE
Adding User prompt to enable keyring or not.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -139,14 +139,35 @@ class Osc(cmdln.Cmdln):
         except oscerr.NoConfigfile as e:
             print(e.msg, file=sys.stderr)
             print('Creating osc configuration file %s ...' % e.file, file=sys.stderr)
+
             import getpass
+
             config = {}
             config['user'] = raw_input('Username: ')
+            keyring_choice = str(raw_input('Enable Keyring? (Default: No): '))
+
+            if keyring_choice in ['yes', 'y', 'Yes', 'Y']:
+                try:
+                    import keyring
+                    self.options.no_keyring = False
+                except:
+                    try:
+                        import gnomekeyring
+                        self.options.no_gnome_keyring = False
+                    except: 
+                        print("No keyring available!")
+            #else:
+            #    print("Are you sure you don't want to enable keyring?")
+
             config['pass'] = getpass.getpass()
             if self.options.no_keyring:
                 config['use_keyring'] = '0'
+            else:
+                config['use_keyring'] = '1'
             if self.options.no_gnome_keyring:
                 config['gnome_keyring'] = '0'
+            else:
+                config['gnome_keyring'] = '1'
             if self.options.apiurl:
                 config['apiurl'] = self.options.apiurl
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -144,30 +144,27 @@ class Osc(cmdln.Cmdln):
 
             config = {}
             config['user'] = raw_input('Username: ')
-            keyring_choice = str(raw_input('Enable Keyring? (Default: No): '))
 
-            if keyring_choice in ['yes', 'y', 'Yes', 'Y']:
-                try:
-                    import keyring
-                    self.options.no_keyring = False
-                except:
-                    try:
-                        import gnomekeyring
-                        self.options.no_gnome_keyring = False
-                    except: 
-                        print("No keyring available!")
-            #else:
-            #    print("Are you sure you don't want to enable keyring?")
+            # Check if the keyrings available on the system or not using conf.GENERIC_KEYRING and conf.GNOME_KEYRING 
+            # If yes, Ask the user to enable the keyring or not
+            # Set the 'use_keyring' or 'use_gnome_keyring' variable to 1 if user choose Yes else pass to use Defaults value
+            if conf.GENERIC_KEYRING or conf.GNOME_KEYRING:
+                keyring_choice = str(raw_input("Keyring utility is found on your system. Would you like to Enable keyring? (Default: No): "))
+                if keyring_choice.lower() in ['y', 'yes']:
+                    # Set the use_keyring variable
+                    if conf.GENERIC_KEYRING:
+                        config['use_keyring'] = '1'
+                    elif conf.GNOME_KEYRING:
+                        config['gnome_keyring'] = '1'
+            else:
+                print("\nWarning: No keyring available! Password will be saved in plain text.")
+                print(" To use keyring, please install python-keyring or gnome-keyring on your system and try again.\n")
 
             config['pass'] = getpass.getpass()
             if self.options.no_keyring:
                 config['use_keyring'] = '0'
-            else:
-                config['use_keyring'] = '1'
             if self.options.no_gnome_keyring:
                 config['gnome_keyring'] = '0'
-            else:
-                config['gnome_keyring'] = '1'
             if self.options.apiurl:
                 config['apiurl'] = self.options.apiurl
 

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -328,7 +328,7 @@ apiurl = %(apiurl)s
 #traceback = 1
 
 # use KDE/Gnome/MacOS/Windows keyring for credentials if available
-#use_keyring = 1
+use_keyring = %(use_keyring)s
 
 # check for unversioned/removed files before commit
 #check_filelist = 1


### PR DESCRIPTION
This patch is referenced to Issue: #406. A user prompt is added to commandline.py  file. 
@lethliel @marcus-h 
Please review this patch. I have few doubts regarding the patch, if anyone can help: 
* Since config file is created using a template, so if the user choose to enable keyring, same config file template is used with the use_keyring commented which might be confusing. So, should we create another template for keyring enabled scenario?
* An error occurred when the keyring is enabled by the user, which is resolved by installing keyrings.alt package. If there is any better way, can anyone help me?
> Traceback (most recent call last):
  File "osc-wrapper.py", line 41, in <module>
    r = babysitter.run(osccli)
  File "/home/matrix/projects/opensuse/osc_test/osc/osc/babysitter.py", line 61, in run
    return prg.main(argv)
  File "/home/matrix/projects/opensuse/osc_test/osc/osc/cmdln.py", line 336, in main
    self.postoptparse()
  File "/home/matrix/projects/opensuse/osc_test/osc/osc/commandline.py", line 177, in postoptparse
    conf.write_initial_config(e.file, config)
  File "/home/matrix/projects/opensuse/osc_test/osc/osc/conf.py", line 747, in write_initial_config
    keyring.set_password(host, config['user'], config['pass'])
  File "/home/matrix/projects/opensuse/osc_test/osc/requirements/local/lib/python2.7/site-packages/keyring/core.py", line 47, in set_password
    _keyring_backend.set_password(service_name, username, password)
  File "/home/matrix/projects/opensuse/osc_test/osc/requirements/local/lib/python2.7/site-packages/keyring/backends/fail.py", line 23, in get_password
    raise RuntimeError(msg)
RuntimeError: No recommended backend was available. Install the keyrings.alt package if you want to use the non-recommended backends. See README.rst for details.

If I am missing something in the patch, please guide me on improving it.
Thanks