### PR TITLE
Imported "Disable ssl session resumption" and a few other patches from master branch

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8902,7 +8902,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         Examples:
             osc revert <modified file(s)>
-            ose revert .
+            osc revert .
         Note: this only works for package working copies
 
         ${cmd_usage}

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2201,16 +2201,16 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = None
             if len(args) > 0:
                 project = args[0]
+            elif opts.project:
+                project = opts.project
+                if opts.package:
+                    package = opts.package
             elif not opts.mine and not opts.user and not opts.group:
                 try:
                     project = store_read_project(os.curdir)
                     package = store_read_package(os.curdir)
                 except oscerr.NoWorkingCopy:
                     pass
-            elif opts.project:
-                project = opts.project
-                if opts.package:
-                    package = opts.package
 
             if len(args) > 1:
                 package = args[1]

--- a/osc/core.py
+++ b/osc/core.py
@@ -5743,7 +5743,7 @@ def get_results(apiurl, project, package, verbose=False, printJoin='', *args, **
             if verbose and res['details'] != '':
                 if res['code'] in ('unresolvable', 'expansion error'):
                     lines = res['details'].split(',')
-                    res['status'] += ': ' + '\n     '.join(lines)
+                    res['status'] += ': \n      ' + '\n     '.join(lines)
                 else:
                     res['status'] += ': %s' % res['details']
             elif res['code'] in ('scheduled', ) and res['details']:

--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -173,7 +173,6 @@ class mySSLContext(SSL.Context):
 
 class myHTTPSHandler(M2Crypto.m2urllib2.HTTPSHandler):
     handler_order = 499
-    saved_session = None
 
     def __init__(self, *args, **kwargs):
         self.appname = kwargs.pop('appname', 'generic')
@@ -209,8 +208,6 @@ class myHTTPSHandler(M2Crypto.m2urllib2.HTTPSHandler):
             h = httpslib.HTTPSConnection(host=host, ssl_context=self.ctx)
         # End our change
         h.set_debuglevel(self._debuglevel)
-        if self.saved_session:
-            h.set_session(self.saved_session)
 
         headers = dict(req.headers)
         headers.update(req.unredirected_hdrs)
@@ -223,9 +220,6 @@ class myHTTPSHandler(M2Crypto.m2urllib2.HTTPSHandler):
         headers["Connection"] = "close"
         try:
             h.request(req.get_method(), request_uri, req.data, headers)
-            s = h.get_session()
-            if s:
-                self.saved_session = s
             r = h.getresponse()
         except socket.error as err:  # XXX what error?
             raise URLError(err)


### PR DESCRIPTION
This pull request imports the following patches from `master` branch:
https://github.com/openSUSE/osc/commit/b730f880cfe85a8547f569355a21706f27ebfa78 Disable ssl session resumption (by marcus-h)
https://github.com/openSUSE/osc/commit/6bd8572cf7deca61a650192acf718d0becb99ddf Fix typo in "osc revert" help (by jonsger)
https://github.com/openSUSE/osc/commit/b7ada2cb5b0af23154e71f99d5e2a593f339ca0c Fix missing newline in osc r -v (by lethliel)
https://github.com/openSUSE/osc/commit/eb2647fd4f033edd3fbc04733c3089125f116fdc Fix order of options validation (by lethliel)