### PR TITLE
fixed indentation of return[].

### DIFF
--- a/osc/util/rpmquery.py
+++ b/osc/util/rpmquery.py
@@ -166,7 +166,7 @@ class RpmQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
     def __reqprov(self, tag, flags, version, strong=None):
         pnames = self.header.gettag(tag)
         if not pnames:
-	    return []
+            return []
         pnames = pnames.data
         pflags = self.header.gettag(flags).data
         pvers = self.header.gettag(version).data


### PR DESCRIPTION
This will work in python2 and python3