### PR TITLE
checkout / get deleted package files

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4280,6 +4280,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('-e', '--expand-link', action='store_true',
                         help='if a package is a link, check out the expanded '
                              'sources (no-op, since this became the default)')
+    @cmdln.option('-D', '--deleted', action='store_true',
+                        help='checkout an already deleted package. No meta information ')
     @cmdln.option('-u', '--unexpand-link', action='store_true',
                         help='if a package is a link, check out the _link file ' \
                              'instead of the expanded sources')
@@ -4364,6 +4366,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 project_dir = os.curdir
                 package = args[0]
 
+        if opts.deleted and package:
+            if not opts.output_dir:
+                raise oscerr.WrongOptions('-o | --output-dir is needed to get deleted sources')
+        elif opts.deleted and not package:
+            raise oscerr.WrongOptions('-D | --deleted can only be used with a package')
+
         rev, dummy = parseRevisionOption(opts.revision)
         if rev == None:
             rev = "latest"
@@ -4379,14 +4387,17 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             get_source_file(apiurl, project, package, filename, revision=rev, progress_obj=self.download_progress)
 
         elif package:
-            if opts.current_dir:
-                project_dir = None
-            checkout_package(apiurl, project, package, rev, expand_link=expand_link, \
-                             prj_dir=project_dir, service_files = opts.source_service_files, \
-                             server_service_files=opts.server_side_source_service_files, \
-                             progress_obj=self.download_progress, size_limit=opts.limit_size, \
-                             meta=opts.meta, outdir=opts.output_dir)
-            print_request_list(apiurl, project, package)
+            if opts.deleted:
+                checkout_deleted_package(apiurl, project, package, opts.output_dir)
+            else:
+                if opts.current_dir:
+                    project_dir = None
+                checkout_package(apiurl, project, package, rev, expand_link=expand_link, \
+                                 prj_dir=project_dir, service_files = opts.source_service_files, \
+                                 server_service_files=opts.server_side_source_service_files, \
+                                 progress_obj=self.download_progress, size_limit=opts.limit_size, \
+                                 meta=opts.meta, outdir=opts.output_dir)
+                print_request_list(apiurl, project, package)
 
         elif project:
             prj_dir = opts.output_dir if opts.output_dir else project

--- a/osc/core.py
+++ b/osc/core.py
@@ -7763,4 +7763,24 @@ def get_rpmlint_log(apiurl, proj, pkg, repo, arch):
     f = http_GET(u)
     return f.read()
 
+def checkout_deleted_package(apiurl, proj, pkg, dst):
+    pl = meta_get_filelist(apiurl, proj, pkg, deleted=True)
+    query = {}
+    query['deleted'] = 1
+
+    if os.path.isdir(dst):
+        print('Restoring in existing directory %s' % dst)
+    else:
+        print('Creating %s' % dst)
+        os.makedirs(dst)
+
+    for filename in pl:
+        print('Restoring %s to %s' % (filename, dst))
+        full_file_path = os.path.join(dst, filename)
+        u = makeurl(apiurl, ['source', proj, pkg, filename], query=query)
+        with open(full_file_path, 'wb') as f:
+            for data in streamfile(u):
+                f.write(data)
+    print('done.')
+
 # vim: sw=4 et


### PR DESCRIPTION
* new command getdeleted (restore)
  requires arguments project / package / destionation

  Examples:
  ```
  osc restore home:mstrigl foo deleted_foo
  osc restore -b home:mstrigl foo
  ```

* altered command do_checkout
  new option -D | --deleted. 
  Can only be used with PACKAGE and needs -o to work

* what happens:
  core function get_deleted_sources fetches the file list of the deleted
  package and saves it to given destdir. If destdir is not existent it
  creates the destination directory. Otherwise the files will be written
  in the existing directory.