### PR TITLE
cleanup xpath. submit/* is ignored by the API since 2012

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4309,12 +4309,10 @@ def get_review_list(apiurl, project='', package='', byuser='', bygroup='', bypro
     if package:
         todo['package'] = package
     for kind, val in todo.items():
-        xpath_base = 'action/target/@%(kind)s=\'%(val)s\' or ' \
-                     'submit/target/@%(kind)s=\'%(val)s\''
+        xpath_base = 'action/target/@%(kind)s=\'%(val)s\''
 
         if conf.config['include_request_from_project']:
-            xpath_base = xpath_join(xpath_base, 'action/source/@%(kind)s=\'%(val)s\' or ' \
-                                                'submit/source/@%(kind)s=\'%(val)s\'', op='or', inner=True)
+            xpath_base = xpath_join(xpath_base, 'action/source/@%(kind)s=\'%(val)s\'', op='or', inner=True)
         xpath = xpath_join(xpath, xpath_base % {'kind': kind, 'val': val}, op='and', nexpr_parentheses=True)
 
     if conf.config['verbose'] > 1:
@@ -4398,19 +4396,15 @@ def get_request_list(apiurl, project='', package='', req_who='', req_state=('new
     if package:
         todo['package'] = package
     for kind, val in todo.items():
-        xpath_base = 'action/target/@%(kind)s=\'%(val)s\' or ' \
-                     'submit/target/@%(kind)s=\'%(val)s\''
-
+        xpath_base = 'action/target/@%(kind)s=\'%(val)s\''
         if conf.config['include_request_from_project']:
-            xpath_base = xpath_join(xpath_base, 'action/source/@%(kind)s=\'%(val)s\' or ' \
-                                                'submit/source/@%(kind)s=\'%(val)s\'', op='or', inner=True)
+            xpath_base = xpath_join(xpath_base, 'action/source/@%(kind)s=\'%(val)s\'', op='or', inner=True)
         xpath = xpath_join(xpath, xpath_base % {'kind': kind, 'val': val}, op='and', nexpr_parentheses=True)
 
     if req_type:
         xpath = xpath_join(xpath, 'action/@type=\'%s\'' % req_type, op='and')
     for i in exclude_target_projects:
-        xpath = xpath_join(xpath, '(not(action/target/@project=\'%(prj)s\' or ' \
-                                  'submit/target/@project=\'%(prj)s\'))' % {'prj': i}, op='and')
+        xpath = xpath_join(xpath, '(not(action/target/@project=\'%(prj)s\'))' % {'prj': i}, op='and')
 
     if conf.config['verbose'] > 1:
         print('[ %s ]' % xpath)

--- a/tests/test_prdiff.py
+++ b/tests/test_prdiff.py
@@ -17,8 +17,8 @@ def rdiff_url(pkg, oldprj, newprj):
         (newprj, pkg, pkg, oldprj.replace(':', '%3A'))
 
 def request_url(prj):
-    return API_URL + 'search/request?match=%%28state%%2F%%40name%%3D%%27new%%27+or+state%%2F%%40name%%3D%%27review%%27%%29+and+%%28action%%2Ftarget%%2F%%40project%%3D%%27%s%%27+or+submit%%2Ftarget%%2F%%40project%%3D%%27%s%%27+or+action%%2Fsource%%2F%%40project%%3D%%27%s%%27+or+submit%%2Fsource%%2F%%40project%%3D%%27%s%%27%%29' % \
-        tuple([prj.replace(':', '%3A')] * 4)
+    return API_URL + 'search/request?match=%%28state%%2F%%40name%%3D%%27new%%27+or+state%%2F%%40name%%3D%%27review%%27%%29+and+%%28action%%2Ftarget%%2F%%40project%%3D%%27%s%%27+or+action%%2Fsource%%2F%%40project%%3D%%27%s%%27%%29' % \
+        tuple([prj.replace(':', '%3A')] * 2)
 
 def GET_PROJECT_PACKAGES(*projects):
     def decorator(test_method):


### PR DESCRIPTION
remove submit/* parts from xpath. They are ignored anyway by the API since commit https://github.com/openSUSE/open-build-service/commit/b502316e28c256d4f3213c1bea09d7ed52f9a4c4

as discussed in https://github.com/openSUSE/open-build-service/issues/5571

So the xpath becomes a little bit cleaner and easier ti understand / debug. 

@marcus-h: Please review