### PR TITLE
make 'osc copypac --keep-link' description easier to understand

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2880,7 +2880,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('-k', '--keep-maintainers', action='store_true',
                         help='keep original maintainers. Default is remove all and replace with the one calling the script.')
     @cmdln.option('-K', '--keep-link', action='store_true',
-                        help='keep the source link in target, this also expands the source')
+                        help='If the target package is a link, the link is kept, but may be updated. If the source package is a link, its expanded version is considered.')
     @cmdln.option('-d', '--keep-develproject', action='store_true',
                         help='keep develproject tag in the package metadata')
     @cmdln.option('-r', '--revision', metavar='rev',


### PR DESCRIPTION
Make the --keep-link documentation for `osc copypac` easier to understand.

See [this mail thread](https://lists.opensuse.org/opensuse-buildservice/2018-09/msg00004.html) for my initial question and Marcus very helpful explanation .