### PR TITLE
print error and exit if p.apiurl != -A <apiurl> using osc sr

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1311,6 +1311,10 @@ class Osc(cmdln.Cmdln):
             p = findpacs(os.curdir)[0]
             src_project = p.prjname
             src_package = p.name
+            if self.options.apiurl and self.options.apiurl != p.apiurl:
+                print('The apiurl for the working copy of this package is %s' % p.apiurl)
+                print('You cannot use this command with the -A %s option.' % self.options.apiurl)
+                sys.exit(1)
             apiurl = p.apiurl
             if len(args) == 0 and p.islink():
                 dst_project = p.linkinfo.project


### PR DESCRIPTION
Print error and exit if `osc -A <apiurl> sr` is issued on a
package with a different apiurl in its working copy. 

This leads to unexpected behavior, because the SR is created for the package
apiurl, not the apiurl given by the -A command line option.

Fixes https://github.com/openSUSE/osc/issues/445