### PR TITLE
improve error message if file is not a valid rpm

### DIFF
--- a/osc/util/rpmquery.py
+++ b/osc/util/rpmquery.py
@@ -114,7 +114,7 @@ class RpmQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
         data = self.__file.read(self.LEAD_SIZE)
         leadmgc, = struct.unpack('!I', data[:4])
         if leadmgc != self.LEAD_MAGIC:
-            raise RpmError(self.__path, 'invalid lead magic \'%s\'' % leadmgc)
+            raise RpmError(self.__path, 'not a rpm (invalid lead magic \'%s\')' % leadmgc)
         sigtype, = struct.unpack('!h', data[78:80])
         if sigtype != self.HEADERSIG_TYPE:
             raise RpmError(self.__path, 'invalid header signature \'%s\'' % sigtype)


### PR DESCRIPTION
The current error message is quite confusing and nobody knows what
"invalid lead magic" means.

@marcus-h: please review and merge