### PR TITLE
Remove reference to non existing documentation

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2993,8 +2993,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         """${cmd_name}: Release sources and binaries
 
         This command is used to transfer sources and binaries without rebuilding them.
-        It requires defined release targets set to trigger="manual". Please refer the
-        release management chapter in the OBS book for details.
+        It requires defined release targets set to trigger="manual".
 
         usage:
             osc release [ SOURCEPROJECT [ SOURCEPACKAGE ] ]


### PR DESCRIPTION
The release management chapter in the OBS book is no where to be found.

Resolves: https://github.com/openSUSE/osc/issues/458