### PR TITLE
fix broken URLError handling in OscMirrorGroup.urlgrab()

### DIFF
--- a/osc/grabber.py
+++ b/osc/grabber.py
@@ -11,10 +11,12 @@ try:
     from urllib.request import HTTPError
     from urllib.parse import urlparse
     from urllib.parse import unquote
+    from urllib.error import URLError
 except ImportError:
     from urllib2 import HTTPError
     from urlparse import urlparse
     from urllib import unquote
+    from urllib2 import URLError
 
 
 class OscFileGrabber(object):
@@ -37,12 +39,12 @@ class OscMirrorGroup(object):
         self._mirrors = mirrors
 
     def urlgrab(self, url, filename=None, text=None):
-        tries = 0
         for mirror in self._mirrors:
             try:
                 self._grabber.urlgrab(mirror, filename, text)
                 return True
-            except HTTPError as e:
-                tries += 1
+            except (HTTPError, URLError) as e:
+                # try next mirror
+                pass
 
         return False


### PR DESCRIPTION
If urlgrab returns a URLError (for example if the Network is unreachable)
the for loop did not continue and the osc build aborts.

Now we also catch the URLError and try the next mirror and return False
correctly if no mirror could be reached. And then try to download it from
api.

removed the tries counter. Not needed anymore.