### PR TITLE
[python3] add helper functions for python3 support

### DIFF
--- a/osc/util/helper.py
+++ b/osc/util/helper.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2018 SUSE Linux.  All rights reserved.
+# This program is free software; it may be used, copied, modified
+# and distributed under the terms of the GNU General Public Licence,
+# either version 2, or (at your option) any later version.
+
+
+def cmp_to_key(mycmp):
+    """ Converts a cmp= function into a key= function.
+    """
+
+    class K(object):
+        def __init__(self, obj, *args):
+            self.obj = obj
+
+        def __lt__(self, other):
+            return mycmp(self.obj, other.obj) < 0
+
+        def __gt__(self, other):
+            return mycmp(self.obj, other.obj) > 0
+
+        def __eq__(self, other):
+            return mycmp(self.obj, other.obj) == 0
+
+        def __le__(self, other):
+            return mycmp(self.obj, other.obj) <= 0
+
+        def __ge__(self, other):
+            return mycmp(self.obj, other.obj) >= 0
+
+        def __ne__(self, other):
+            return mycmp(self.obj, other.obj) != 0
+
+        def __hash__(self):
+            raise TypeError('hash not implemented')
+
+    return K
+
+
+def decode_list(ilist):
+    """ Decodes the elements of a list if needed
+    """
+
+    dlist = []
+    for elem in ilist:
+        if not isinstance(elem, str):
+            dlist.append(decode_it(elem))
+        else:
+            dlist.append(elem)
+    return dlist
+
+
+def decode_it(obj):
+    """ Decodes the given object if obj is not a string
+        based on the chardet module if possible
+    """
+
+    if isinstance(obj, str):
+        return obj
+    else:
+        try:
+            import chardet
+            return obj.decode(chardet.detect(obj)['encoding'])
+        except:
+            import locale
+            return obj.decode(locale.getlocale()[1])

--- a/tests/suite.py
+++ b/tests/suite.py
@@ -24,6 +24,7 @@ import test_setlinkrev
 import test_prdiff
 import test_conf
 import test_results
+import test_helpers
 
 suite = unittest.TestSuite()
 suite.addTests(test_addfiles.suite())
@@ -42,6 +43,7 @@ suite.addTests(test_setlinkrev.suite())
 suite.addTests(test_prdiff.suite())
 suite.addTests(test_conf.suite())
 suite.addTests(test_results.suite())
+suite.addTests(test_helpers.suite())
 
 if have_xmlrunner:
     result = xmlrunner.XMLTestRunner(output=os.path.join(os.getcwd(), 'junit-xml-results')).run(suite)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,35 @@
+import unittest
+from osc.util.helper import decode_it, decode_list
+
+def suite():
+    return unittest.makeSuite(TestResults)
+
+class TestResults(unittest.TestCase):
+    def testDecodeList(self):
+        strlist = ['Test1', 'Test2', 'Test3']
+        mixlist = ['Test1', b'Test2', 'Test3']
+        byteslist = [b'Test1', b'Test2', b'Test3']
+
+        out = decode_list(strlist)
+        self.assertListEqual(out, strlist)
+
+        out = decode_list(mixlist)
+        self.assertListEqual(out, strlist)
+
+        out = decode_list(byteslist)
+        self.assertListEqual(out, strlist)
+
+
+    def testDecodeIt(self):
+        bytes_obj = b'Test the decoding'
+        string_obj = 'Test the decoding'
+
+        out = decode_it(bytes_obj)
+        self.assertEqual(out, string_obj)
+
+        out = decode_it(string_obj)
+        self.assertEqual(out, string_obj)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This functions are used in the whole code and are
mandatory for the python3 support to work. In python2
case nothing is touched.

* cmp_to_key:
  converts a cmp= into a key= function

* decode_list:
  decodes each element of a list. This is needed if
  we have a mixed list with strings and bytes.

* decode_it:
  Takes the input and checks if it is not a string.
  Then it uses chardet to get the encoding.