### PR TITLE
 Exit 3 if osc prjresults has not successful 

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5240,7 +5240,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('-q', '--hide-legend', action='store_true',
                         help='hide the legend')
     @cmdln.option('-w', '--watch', action='store_true',
-                        help='watch the results until all finished building, only supported with --xml')
+                        help='watch the results until all finished building')
     @cmdln.option('-c', '--csv', action='store_true',
                         help='csv output')
     @cmdln.option('', '--xml', action='store_true', default=False,
@@ -5278,26 +5278,22 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             wd = os.curdir
             project = store_read_project(wd)
 
-        if opts.xml:
-            kwargs = {}
-            if opts.repo:
-                kwargs['repository'] = opts.repo
-            if opts.arch:
-                kwargs['arch'] = opts.arch
-            kwargs['wait'] = opts.watch
-            for results in get_package_results(apiurl, project, **kwargs):
+        kwargs = {}
+        if opts.repo:
+            kwargs['repository'] = opts.repo
+        if opts.arch:
+            kwargs['arch'] = opts.arch
+        kwargs['wait'] = opts.watch
+
+        for results in get_package_results(apiurl, project, **kwargs):
+            if opts.xml:
                 print(results)
-            return
-
-        if opts.watch:
-            print('Please implement support for osc prjresults --watch without --xml.')
-            return 2
-
-        print('\n'.join(get_prj_results(apiurl, project, hide_legend=opts.hide_legend, \
+            else:
+                print('\n'.join(format_prj_results(results, hide_legend=opts.hide_legend, \
                                         csv=opts.csv, status_filter=opts.status_filter, \
                                         name_filter=opts.name_filter, repo=opts.repo, \
                                         arch=opts.arch, vertical=opts.vertical, \
-                                        show_excluded=opts.show_excluded)))
+                                        show_excluded=opts.show_excluded))+'\n')
 
     @cmdln.option('-q', '--hide-legend', action='store_true',
                         help='hide the legend')

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5261,6 +5261,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     def do_prjresults(self, subcmd, opts, *args):
         """${cmd_name}: Shows project-wide build results
 
+        Exit value will be 3 if the repositories / architectures are not
+        finshed and successful.
+
         Usage:
             osc prjresults (inside working copy)
             osc prjresults PROJECT
@@ -5285,7 +5288,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             kwargs['arch'] = opts.arch
         kwargs['wait'] = opts.watch
 
+        last = None
         for results in get_package_results(apiurl, project, **kwargs):
+            last = results
             if opts.xml:
                 print(results)
             else:
@@ -5294,6 +5299,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                         name_filter=opts.name_filter, repo=opts.repo, \
                                         arch=opts.arch, vertical=opts.vertical, \
                                         show_excluded=opts.show_excluded))+'\n')
+        if last and is_package_results_success(last):
+            return
+        return 3
 
     @cmdln.option('-q', '--hide-legend', action='store_true',
                         help='hide the legend')

--- a/osc/core.py
+++ b/osc/core.py
@@ -5765,9 +5765,12 @@ def get_package_results(apiurl, project, package=None, wait=False, *args, **kwar
                 waiting = True
                 break
             else:
-                pkg = result.find('status')
-                if pkg is not None and pkg.get('code') in waiting_states:
-                    waiting = True
+                packages = result.find('status')
+                for p in packages:
+                    if p.get('code') in waiting_states:
+                        waiting = True
+                        break
+                if waiting:
                     break
                 
         if not wait or not waiting:

--- a/osc/core.py
+++ b/osc/core.py
@@ -5778,12 +5778,16 @@ def get_package_results(apiurl, project, package=None, wait=False, *args, **kwar
 
 
 def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=None, name_filter=None, arch=None, repo=None, vertical=None, show_excluded=None):
-    #print '----------------------------------------'
+    """ this function is only needed for backward/api compatibility; use get_package_results() and format_prj_results() instead"""
+    xml_string = show_prj_results_meta(apiurl, prj)
+    return format_prj_results(xml_string, hide_legend, csv, status_filter, name_filter, arch, repo, vertical, show_excluded)
+
+def format_prj_results(xml_string, hide_legend=False, csv=False, status_filter=None, name_filter=None, arch=None, repo=None, vertical=None, show_excluded=None):
     global buildstatus_symbols
 
     r = []
 
-    f = show_prj_results_meta(apiurl, prj)
+    f = xml_string
     root = ET.fromstring(''.join(f))
 
     pacs = []

--- a/osc/core.py
+++ b/osc/core.py
@@ -5776,6 +5776,23 @@ def get_package_results(apiurl, project, package=None, wait=False, *args, **kwar
             yield xml 
     yield xml
 
+def is_package_results_success(xmlstring):
+    ok = ('succeeded', 'disabled', 'excluded', 'published', 'unpublished')
+
+    root = ET.fromstring(xmlstring)
+    for result in root.findall('result'):
+        if result.get('dirty') is not None:
+            return False
+        if result.get('code') not in ok:
+            return False
+        if result.get('state') not in ok:
+            return False
+        packages = result.find('status')
+        for p in packages:
+            if p.get('code') not in ok:
+                return False
+    return True
+
 
 def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=None, name_filter=None, arch=None, repo=None, vertical=None, show_excluded=None):
     """ this function is only needed for backward/api compatibility; use get_package_results() and format_prj_results() instead"""

--- a/tests/results_fixtures/result-dirty.txt
+++ b/tests/results_fixtures/result-dirty.txt
@@ -1,0 +1,6 @@
+ python-MarkupSafe
+    SLE_12_SP3 x86_64 (outdated)
+    SLE_12_SP4 x86_64 (publishing)
+    openSUSE_Leap_15.0 x86_64 (broken)
+    openSUSE_Leap_42.3 x86_64 (published)
+

--- a/tests/results_fixtures/result-false.xml
+++ b/tests/results_fixtures/result-false.xml
@@ -1,0 +1,16 @@
+<resultlist state="f1cfebfd13354bcb8e792cb85f6218d8">
+  <result project="testproject" repository="openSUSE_Leap_42.3" arch="x86_64" code="published" state="published">
+   <status package="python-MarkupSafe" code="disabled" />
+  </result>
+  <result project="testproject" repository="openSUSE_Leap_15.0" arch="x86_64" code="excluded" state="succeeded">
+    <status package="python-MarkupSafe" code="disabled" />
+  </result>
+  <result project="testproject" repository="SLE_12_SP4" arch="x86_64" code="disabled" state="disabled">
+    <status package="python-MarkupSafe" code="disabled" />
+  </result>
+  <result project="testproject" repository="SLE_12_SP3" arch="x86_64" code="blocked" state="blocked">
+    <status package="python-MarkupSafe" code="blocked">
+      <details>python-setuptools</details>
+    </status>
+  </result>
+</resultlist>

--- a/tests/results_fixtures/result.txt
+++ b/tests/results_fixtures/result.txt
@@ -1,0 +1,6 @@
+ python-MarkupSafe
+    SLE_12_SP3 x86_64 (published)
+    SLE_12_SP4 x86_64 (published)
+    openSUSE_Leap_15.0 x86_64 (published)
+    openSUSE_Leap_42.3 x86_64 (published)
+

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -29,13 +29,18 @@ class TestResults(OscTestCase):
         return open(os.path.join(self._get_fixtures_dir(), filename), 'r').read()
 
     @GET('http://localhost/build/testproject/_result', file='result.xml')
-    def testPrjresults(self):
+    def testPrjresultsXml(self):
         out = self._run_osc('prjresults', '--xml', 'testproject')
         self.assertEqualMultiline(out, self._get_fixture('result.xml')+'\n')
 
+    @GET('http://localhost/build/testproject/_result', file='result.xml')
+    def testPrjresults(self):
+        out = self._run_osc('prjresults', 'testproject', '--hide-legend')
+        self.assertEqualMultiline(out, self._get_fixture('result.txt'))
+
     @GET('http://localhost/build/testproject/_result', file='result-dirty.xml')
     @GET('http://localhost/build/testproject/_result?oldstate=c57e2ee592dbbf26ebf19cc4f1bc1e83', file='result.xml')
-    def testPrjresultsWatch(self):
+    def testPrjresultsWatchXml(self):
         out = self._run_osc('prjresults', '--watch', '--xml', 'testproject')
         self.assertEqualMultiline(out, self._get_fixture('result-dirty.xml')+'\n'+self._get_fixture('result.xml')+'\n')
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -36,13 +36,19 @@ class TestResults(OscTestCase):
     @GET('http://localhost/build/testproject/_result', file='result.xml')
     def testPrjresults(self):
         out = self._run_osc('prjresults', 'testproject', '--hide-legend')
-        self.assertEqualMultiline(out, self._get_fixture('result.txt'))
+        self.assertEqualMultiline(out, self._get_fixture('result.txt')+'\n')
 
     @GET('http://localhost/build/testproject/_result', file='result-dirty.xml')
     @GET('http://localhost/build/testproject/_result?oldstate=c57e2ee592dbbf26ebf19cc4f1bc1e83', file='result.xml')
     def testPrjresultsWatchXml(self):
         out = self._run_osc('prjresults', '--watch', '--xml', 'testproject')
         self.assertEqualMultiline(out, self._get_fixture('result-dirty.xml')+'\n'+self._get_fixture('result.xml')+'\n')
+
+    @GET('http://localhost/build/testproject/_result', file='result-dirty.xml')
+    @GET('http://localhost/build/testproject/_result?oldstate=c57e2ee592dbbf26ebf19cc4f1bc1e83', file='result.xml')
+    def testPrjresultsWatch(self):
+        out = self._run_osc('prjresults', '--watch', 'testproject', '--hide-legend')
+        self.assertEqualMultiline(out, self._get_fixture('result-dirty.txt')+'\n'+self._get_fixture('result.txt')+'\n')
 
     @GET('http://localhost/build/testproject/_result?package=python-MarkupSafe&multibuild=1&locallink=1', file='result.xml')
     def testResults(self):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -18,47 +18,58 @@ class TestResults(OscTestCase):
         return os.path.join(os.path.dirname(__file__), self._get_fixtures_name())
 
     def _run_osc(self, *args):
-        """Runs osc, returning captured STDOUT as a string."""
+        """Runs osc, returning (exit value, captured STDOUT as a string)."""
         cli = osc.commandline.Osc()
         argv = ['osc', '--no-keyring', '--no-gnome-keyring']
         argv.extend(args)
-        cli.main(argv=argv)
-        return sys.stdout.getvalue()
+        exit = cli.main(argv=argv)
+        return (exit, sys.stdout.getvalue())
 
     def _get_fixture(self, filename):
         return open(os.path.join(self._get_fixtures_dir(), filename), 'r').read()
 
     @GET('http://localhost/build/testproject/_result', file='result.xml')
     def testPrjresultsXml(self):
-        out = self._run_osc('prjresults', '--xml', 'testproject')
+        _, out = self._run_osc('prjresults', '--xml', 'testproject')
         self.assertEqualMultiline(out, self._get_fixture('result.xml')+'\n')
 
     @GET('http://localhost/build/testproject/_result', file='result.xml')
+    def testPrjresultsSuccess(self):
+        exit, _ = self._run_osc('prjresults', '--xml', 'testproject')
+        self.assertEqual(exit, None)
+
+    @GET('http://localhost/build/testproject/_result', file='result-false.xml')
+    def testPrjresultsFailure(self):
+        exit, out = self._run_osc('prjresults', '--xml', 'testproject')
+        self.assertEqual(exit, 3)
+        self.assertEqualMultiline(out, self._get_fixture('result-false.xml')+'\n')
+
+    @GET('http://localhost/build/testproject/_result', file='result.xml')
     def testPrjresults(self):
-        out = self._run_osc('prjresults', 'testproject', '--hide-legend')
+        _, out = self._run_osc('prjresults', 'testproject', '--hide-legend')
         self.assertEqualMultiline(out, self._get_fixture('result.txt')+'\n')
 
     @GET('http://localhost/build/testproject/_result', file='result-dirty.xml')
     @GET('http://localhost/build/testproject/_result?oldstate=c57e2ee592dbbf26ebf19cc4f1bc1e83', file='result.xml')
     def testPrjresultsWatchXml(self):
-        out = self._run_osc('prjresults', '--watch', '--xml', 'testproject')
+        _, out = self._run_osc('prjresults', '--watch', '--xml', 'testproject')
         self.assertEqualMultiline(out, self._get_fixture('result-dirty.xml')+'\n'+self._get_fixture('result.xml')+'\n')
 
     @GET('http://localhost/build/testproject/_result', file='result-dirty.xml')
     @GET('http://localhost/build/testproject/_result?oldstate=c57e2ee592dbbf26ebf19cc4f1bc1e83', file='result.xml')
     def testPrjresultsWatch(self):
-        out = self._run_osc('prjresults', '--watch', 'testproject', '--hide-legend')
+        _, out = self._run_osc('prjresults', '--watch', 'testproject', '--hide-legend')
         self.assertEqualMultiline(out, self._get_fixture('result-dirty.txt')+'\n'+self._get_fixture('result.txt')+'\n')
 
     @GET('http://localhost/build/testproject/_result?package=python-MarkupSafe&multibuild=1&locallink=1', file='result.xml')
     def testResults(self):
-        out = self._run_osc('results', '--xml', 'testproject', 'python-MarkupSafe')
+        _, out = self._run_osc('results', '--xml', 'testproject', 'python-MarkupSafe')
         self.assertEqualMultiline(out, self._get_fixture('result.xml'))
 
     @GET('http://localhost/build/testproject/_result?package=python-MarkupSafe&multibuild=1&locallink=1', file='result-dirty.xml')
     @GET('http://localhost/build/testproject/_result?package=python-MarkupSafe&oldstate=c57e2ee592dbbf26ebf19cc4f1bc1e83&multibuild=1&locallink=1', file='result.xml')
     def testResultsWatch(self):
-        out = self._run_osc('results', '--watch', '--xml', 'testproject', 'python-MarkupSafe')
+        _, out = self._run_osc('results', '--watch', '--xml', 'testproject', 'python-MarkupSafe')
         self.assertEqualMultiline(out, self._get_fixture('result-dirty.xml')+self._get_fixture('result.xml'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Exit with value 3 if the osc prjresults has repositories / architectures
that are not finished and succesful.

Test osc prjresults

Split formating from api call in get_prj_results
This will be needed to support osc prjresults --watch without --xml.

Support osc prjresults --watch without --xml 

osc result: check all packages for wait states
The first package could be in a state that doesn't need waiting. Before
5e03ffc this worked, as only one
package was asked of the server. I.e. osc prjresults didn't use this
function, only osc results.