### PR TITLE
do not add key to buildinfo if not existent

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -272,7 +272,7 @@ class Fetcher:
                 elif not self.offline:
                     OscFileGrabber().urlgrab(url, dest)
                 # not that many keys usually
-                if i not in buildinfo.prjkeys:
+                if i not in buildinfo.prjkeys and not try_parent:
                     buildinfo.keys.append(dest)
                     buildinfo.prjkeys.append(i)
             except KeyboardInterrupt:


### PR DESCRIPTION
fixes issue: https://github.com/openSUSE/osc/issues/471

Add the key_path only to buildinfo(bi) if it exists (try_parent == false)