### PR TITLE
[python3] magic is now a bytestring in python3

### DIFF
--- a/osc/util/packagequery.py
+++ b/osc/util/packagequery.py
@@ -60,18 +60,18 @@ class PackageQuery:
         f.seek(0)
         extra_tags = ()
         pkgquery = None
-        if magic[:4] == '\xed\xab\xee\xdb':
+        if magic[:4] == b'\xed\xab\xee\xdb':
             from . import rpmquery
             pkgquery = rpmquery.RpmQuery(f)
             extra_tags = extra_rpmtags
-        elif magic == '!<arch>':
+        elif magic == b'!<arch>':
             from . import debquery
             pkgquery = debquery.DebQuery(f)
             extra_tags = extra_debtags
-        elif magic[:5] == '<?xml':
+        elif magic[:5] == b'<?xml':
             f.close()
             return None
-        elif magic[:5] == '\375\067zXZ' or magic[:2] == '\037\213':
+        elif magic[:5] == b'\375\067zXZ' or magic[:2] == b'\037\213':
             from . import archquery
             pkgquery = archquery.ArchQuery(f)
         else:


### PR DESCRIPTION
magic is a bytestring in python3