### PR TITLE
warn user if python-progressbar is not installed

### DIFF
--- a/osc/meter.py
+++ b/osc/meter.py
@@ -3,10 +3,14 @@
 # and distributed under the terms of the GNU General Public Licence,
 # either version 2, or (at your option) any later version.
 
-import progressbar as pb
+try:
+    import progressbar as pb
+    have_pb_module = True
+except ImportError:
+    have_pb_module = False
 
 
-class TextMeter(object):
+class PBTextMeter(object):
 
     def start(self, basename, size=None):
         if size is None:
@@ -24,4 +28,18 @@ class TextMeter(object):
     def end(self):
         self.bar.finish()
 
+class NoPBTextMeter(object):
+    def start(self, *args, **kwargs):
+        print('Please install the progressbar module...')
+
+    def update(self, *args, **kwargs):
+        pass
+
+    def end(self, *args, **kwargs):
+        pass
+
+if have_pb_module:
+    TextMeter = PBTextMeter
+else:
+    TextMeter = NoPBTextMeter
 # vim: sw=4 et


### PR DESCRIPTION
On ImportError have_pb_module is false and the class NoPBTextMeter gets
returned which prints "Please install progressbar module..." on TextMeter.start()

fixes https://github.com/openSUSE/osc/issues/499 which also affects the master branch.

@marcus-h please review. Thanks.