### PR TITLE
osc shell/chroot is now handled via build script (working for chroot …

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.167
+  - osc shell/chroot/wipe is now handled via build script (working for chroot and KVM only atm)
+
 0.166.2
   - Don't enforce password reuse (boo#1156501)
   - Config option check_for_requests_on_action is now

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.167
   - osc shell/chroot/wipe is now handled via build script (working for chroot and KVM only atm)
+  - osc build --vm-type=qemu support for cross architecture builds
 
 0.166.2
   - Don't enforce password reuse (boo#1156501)

--- a/osc/build.py
+++ b/osc/build.py
@@ -46,15 +46,6 @@ change_personality = {
             'sparcv8': 'linux32',
         }
 
-# FIXME: qemu_can_build should not be needed anymore since OBS 2.3
-qemu_can_build = [ 'armv4l', 'armv5el', 'armv5l', 'armv6l', 'armv7l', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el',
-                   'sh4', 'mips', 'mipsel',
-                   'ppc', 'ppc64',
-                   's390', 's390x',
-                   'sparc64v', 'sparcv9v', 'sparcv9', 'sparcv8', 'sparc',
-                   'hppa',
-        ]
-
 can_also_build = {
              'aarch64': ['aarch64'], # only needed due to used heuristics in build parameter evaluation
              'armv6l': [                                         'armv4l', 'armv5l', 'armv6l', 'armv5el', 'armv6el'                       ],
@@ -879,13 +870,9 @@ def main(apiurl, opts, argv):
         if hostarch != bi.hostarch and not bi.hostarch in can_also_build.get(hostarch, []):
             print('Error: hostarch \'%s\' is required.' % (bi.hostarch), file=sys.stderr)
             return 1
-    elif hostarch != bi.buildarch:
+    elif hostarch != bi.buildarch and vm_type != "emulator" and vm_type != "qemu":
         if not bi.buildarch in can_also_build.get(hostarch, []):
-            # OBSOLETE: qemu_can_build should not be needed anymore since OBS 2.3
-            if vm_type != "emulator" and not bi.buildarch in qemu_can_build:
-                print('Error: hostarch \'%s\' cannot build \'%s\'.' % (hostarch, bi.buildarch), file=sys.stderr)
-                return 1
-            print('WARNING: It is guessed to build on hostarch \'%s\' for \'%s\' via QEMU.' % (hostarch, bi.buildarch), file=sys.stderr)
+            print('WARNING: It is guessed to build on hostarch \'%s\' for \'%s\' via QEMU user emulation.' % (hostarch, bi.buildarch), file=sys.stderr)
 
     rpmlist_prefers = []
     if prefer_pkgs:

--- a/osc/build.py
+++ b/osc/build.py
@@ -649,6 +649,8 @@ def main(apiurl, opts, argv):
         pac = pac + ":" + opts.multibuild_package
     if opts.shell:
         buildargs.append("--shell")
+    if opts.wipe:
+        buildargs.append("--wipe")
 
     orig_build_root = config['build-root']
     # make it possible to override configuration of the rc file

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6384,12 +6384,20 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         OPTS may be
 
-            osc shell --shell-cmd=COMMAND REPOSITORY ARCH
+            --noinit             # for faster run
+            --shell-cmd=COMMAND
 
         To clean up the build environment run
 
             osc wipe [OPTS]
             osc wipe [OPTS] REPOSITORY ARCH
+
+        You may set the used VM type in oscrc already, but you can also overwrite it for example
+        with
+
+            --vm-type=chroot     # for faster, but uncleaner and unsecure build
+            --vm-type=kvm        # for clean and secure build
+            --vm-type=qemu       # for slow cross architecture build using system emulator
 
         # Note:
         # Configuration can be overridden by envvars, e.g.


### PR DESCRIPTION
…and KVM only atm)

We had bugreports about not matching mount points when using "osc chroot", so using the build script implementation now only. This should work for chroot and KVM at least, but I might have missed some special cases. So please review :)
