### PR TITLE
improve handling of missing progressbar module

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -167,7 +167,8 @@ class Osc(cmdln.Cmdln):
         self.download_progress = None
         if conf.config.get('show_download_progress', False):
             from .meter import TextMeter
-            self.download_progress = TextMeter()
+            if TextMeter:
+                self.download_progress = TextMeter()
 
 
     def get_cmd_help(self, cmdname):

--- a/osc/core.py
+++ b/osc/core.py
@@ -4618,9 +4618,13 @@ def get_binary_file(apiurl, prj, repo, arch,
     progress_obj = None
     if progress_meter:
         from .meter import TextMeter
-        progress_obj = TextMeter()
+        if TextMeter:
+            progress_obj = TextMeter()
 
     target_filename = target_filename or filename
+
+    if progress_meter and not progress_obj:
+        print('Downloading %s' % target_filename)
 
     where = package or '_repository'
     u = makeurl(apiurl, ['build', prj, repo, arch, where, filename])

--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -25,6 +25,8 @@ import re
 
 from .meter import TextMeter
 
+if not TextMeter:
+    print('Please install the progressbar module')
 
 class Fetcher:
     def __init__(self, cachedir='/tmp', api_host_options={}, urllist=[],

--- a/osc/meter.py
+++ b/osc/meter.py
@@ -28,18 +28,9 @@ class PBTextMeter(object):
     def end(self):
         self.bar.finish()
 
-class NoPBTextMeter(object):
-    def start(self, *args, **kwargs):
-        print('Please install the progressbar module...')
-
-    def update(self, *args, **kwargs):
-        pass
-
-    def end(self, *args, **kwargs):
-        pass
 
 if have_pb_module:
     TextMeter = PBTextMeter
 else:
-    TextMeter = NoPBTextMeter
+    TextMeter = None
 # vim: sw=4 et


### PR DESCRIPTION
With the NoPBTextMeter class the build view gets broken.

Old view:
`1/11 (repo) filename`

New view:
```
Please install the progressbar module...
Please install the progressbar module...
Please install the progressbar module...
```

With this commit the old behavior is restored.

The getbinaries call now lists the file he downloads instead of just stating "Please install the progressbar module..." several times. (but only if not called with the option quiet)

@marcus-h: We can talk about this. But if it is ok for you, pleas merge ;) 