### PR TITLE
reworked meter.py based on discussion in PR 503

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -33,7 +33,7 @@ except ImportError:
 
 from .conf import config, cookiejar
 
-from .meter import TextMeter
+from .meter import create_text_meter
 
 change_personality = {
             'i686':  'linux32',
@@ -305,10 +305,9 @@ def get_preinstall_image(apiurl, arch, cache_dir, img_info):
                 print('packagecachedir is not writable for you?', file=sys.stderr)
                 print(e, file=sys.stderr)
                 sys.exit(1)
-        if sys.stdout.isatty() and TextMeter:
-            progress_obj = TextMeter()
-        else:
-            progress_obj = None
+        progress_obj = None
+        if sys.stdout.isatty():
+            progress_obj = create_text_meter(use_pb_fallback=False)
         gr = OscFileGrabber(progress_obj=progress_obj)
         try:
             gr.urlgrab(url, filename=ifile_path_part, text='fetching image')

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -166,9 +166,8 @@ class Osc(cmdln.Cmdln):
         self.options.verbose = conf.config['verbose']
         self.download_progress = None
         if conf.config.get('show_download_progress', False):
-            from .meter import TextMeter
-            if TextMeter:
-                self.download_progress = TextMeter()
+            from .meter import create_text_meter
+            self.download_progress = create_text_meter()
 
 
     def get_cmd_help(self, cmdname):

--- a/osc/core.py
+++ b/osc/core.py
@@ -4617,14 +4617,10 @@ def get_binary_file(apiurl, prj, repo, arch,
                     progress_meter = False):
     progress_obj = None
     if progress_meter:
-        from .meter import TextMeter
-        if TextMeter:
-            progress_obj = TextMeter()
+        from .meter import create_text_meter
+        progress_obj = create_text_meter()
 
     target_filename = target_filename or filename
-
-    if progress_meter and not progress_obj:
-        print('Downloading %s' % target_filename)
 
     where = package or '_repository'
     u = makeurl(apiurl, ['build', prj, repo, arch, where, filename])

--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -23,19 +23,15 @@ from . import oscerr
 import tempfile
 import re
 
-from .meter import TextMeter
-
-if not TextMeter:
-    print('Please install the progressbar module')
+from .meter import create_text_meter
 
 class Fetcher:
     def __init__(self, cachedir='/tmp', api_host_options={}, urllist=[],
             http_debug=False, cookiejar=None, offline=False, enable_cpio=True):
         # set up progress bar callback
-        if sys.stdout.isatty() and TextMeter:
-            self.progress_obj = TextMeter()
-        else:
-            self.progress_obj = None
+        self.progress_obj = None
+        if sys.stdout.isatty():
+            self.progress_obj = create_text_meter(use_pb_fallback=False)
 
         self.cachedir = cachedir
         self.urllist = urllist

--- a/osc/meter.py
+++ b/osc/meter.py
@@ -29,8 +29,30 @@ class PBTextMeter(object):
         self.bar.finish()
 
 
+class NoPBTextMeter(object):
+    _complained = False
+
+    def start(self, basename, size=None):
+        if not self._complained:
+            print('Please install the progressbar module')
+            NoPBTextMeter._complained = True
+        print('Processing: %s' % basename)
+
+    def update(self, *args, **kwargs):
+        pass
+
+    def end(self, *args, **kwargs):
+        pass
+
+
+def create_text_meter(*args, **kwargs):
+    use_pb_fallback = kwargs.pop('use_pb_fallback', True)
+    if have_pb_module or use_pb_fallback:
+        return TextMeter(*args, **kwargs)
+    return None
+
 if have_pb_module:
     TextMeter = PBTextMeter
 else:
-    TextMeter = None
+    TextMeter = NoPBTextMeter
 # vim: sw=4 et


### PR DESCRIPTION
as discussed in PR https://github.com/openSUSE/osc/pull/502

* new function create_text_meter with fallback selection
* NoPBTextMeter.start() will print the basename (if not stated otherise with
  basename = None)
* The callers that should use an alternare TextMeter class now call create_text_meter()
* The callers that should not use and alternate TextMeter (because of different handling,
  like build.py) call create_text_meter(use_pb_fallback=False)

@marcus-h: please comment :-)