### PR TITLE
some improvements to the TLS stack

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -203,7 +203,7 @@ boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'tr
     'status_mtime_heuristic']
 integer_opts = ['build-jobs']
 
-api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']
+api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj', 'tls_ciphers']
 
 new_conf_template = """
 [general]
@@ -551,6 +551,7 @@ def _build_opener(apiurl):
         if not cafile and not capath:
             raise oscerr.OscIOError(None, 'No CA certificates found. (You may want to install ca-certificates-mozilla package)')
         ctx = oscssl.mySSLContext()
+        ctx.set_cipher_list(options.get('tls_ciphers', 'DEFAULT'))
         if ctx.load_verify_locations(capath=capath, cafile=cafile) != 1:
             raise oscerr.OscIOError(None, 'No CA certificates found. (You may want to install ca-certificates-mozilla package)')
         opener = m2urllib2.build_opener(ctx, oscssl.myHTTPSHandler(ssl_context=ctx, appname='osc'), HTTPCookieProcessor(cookiejar), authhandler, proxyhandler)
@@ -976,7 +977,7 @@ def get_config(override_conffile=None,
                                     'pass': password,
                                     'http_headers': http_headers}
 
-        optional = ('realname', 'email', 'sslcertck', 'cafile', 'capath')
+        optional = ('realname', 'email', 'sslcertck', 'cafile', 'capath', 'tls_ciphers')
         for key in optional:
             if cp.has_option(url, key):
                 if key == 'sslcertck':
@@ -996,6 +997,9 @@ def get_config(override_conffile=None,
             api_host_options[apiurl]['trusted_prj'] = cp.get(url, 'trusted_prj').split(' ')
         else:
             api_host_options[apiurl]['trusted_prj'] = []
+
+        if cp.has_option(url, 'tls_ciphers'):
+            api_host_options[apiurl]['tls_ciphers'] = cp.get(url, 'tls_ciphers')
 
     # add the auth data we collected to the config dict
     config['api_host_options'] = api_host_options

--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -24,6 +24,20 @@ except ImportError:
     from httplib import HTTPSConnection
 
 from .core import raw_input
+from . import conf
+
+def make_safe_file_name(fname):
+    import os.path
+    # remove all directory separators
+    fname = fname.replace(os.path.sep, '')
+    if os.path.altsep:
+        fname = fname.replace(os.path.altsep, '')
+
+    # we don't want any hidden files
+    if fname[0] == '.':
+        fname = '_' + fname
+
+    return fname
 
 class TrustedCertStore:
     _tmptrusted = {}
@@ -38,7 +52,8 @@ class TrustedCertStore:
             self.host += "_%d" % port
         import os
         self.dir = os.path.expanduser('~/.config/%s/trusted-certs' % app)
-        self.file = self.dir + '/%s.pem' % self.host
+
+        self.file = self.dir + '/' + make_safe_file_name('%s.pem' % self.host)
 
     def is_known(self):
         if self.host in self._tmptrusted:
@@ -163,7 +178,6 @@ class mySSLContext(SSL.Context):
     def __init__(self):
         SSL.Context.__init__(self, 'sslv23')
         self.set_options(m2.SSL_OP_NO_SSLv2 | m2.SSL_OP_NO_SSLv3)
-        self.set_cipher_list("ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH")
         self.set_session_cache_mode(m2.SSL_SESS_CACHE_CLIENT)
         self.verrs = None
         #self.set_info_callback() # debug

--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -358,6 +358,7 @@ def verify_certificate(connection):
                 print("WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!", file=sys.stderr)
                 print("IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!", file=sys.stderr)
                 print("offending certificate is at '%s'" % tc.file, file=sys.stderr)
+                connection.close()
                 raise SSLVerificationError("remote host identification has changed")
 
         # if http_debug is set we redirect sys.stdout to an StringIO
@@ -369,6 +370,7 @@ def verify_certificate(connection):
         print(file=out)
 
         if not verrs.could_ignore():
+            connection.close()
             raise SSLVerificationError("Certificate validation error cannot be ignored")
 
         if not verrs.chain_ok:


### PR DESCRIPTION
`e11f52cfa61bd5f5e7255d86592ea17453b8e0df`: manually close the TLS connection before raising TLS errors. This is already done in some instances before such an exception is raised, but not in all. I don't really think there's any way those connections could be reused later, but it won't hurt and better safe than sorry.

`a6ee7834894e8d195ea443ba988bda24fd36751b`: here, I moved some code for the TLS validation around. Before, the `verify_cb` allowed connection setup for pretty much any certificate error, but stored these errors for later in order to abort the connection for some fatal errors or ask the user for a decision in case of some other errors. With this change, the `verify_cb` immediately returns an error in case of those fatal errors, so that the encrypted connection is never fully set up. In case of the non-fatal errors, the behavior is unchanged. I'm personally not quite happy how this code (before and after) is kind of circumventing the normal TLS validation flow of OpenSSL, but since overriding TLS errors is a useful feature (at least for testing) and very old Python versions seem to still be supported by this project (with much less useful tls support in the standard library), I don't really see how to avoid that.

`532d90442e9ba3c6f3fc8574d55f00e20290b688`: This removes the hard-coded list of TLS ciphers. That list had some bad stuff in it (RC4 is broken, but thankfully removed in current versions of OpenSSL; and it disabled epheremal Diffie-Hellman). Instead of updating the cipher list to be what's considered good today, I've removed it -- as evidenced here, such lists tend to get out of  date, and the defaults should always be fine. To be completely sure that this doesn't break with weirdly configured servers, I've made the list of TLS ciphers configurable (the `tls_ciphers` option in a server section). That also means people can configure a more paranoid list of ciphers if they want to.