### PR TITLE
[python3] reactivate python3.x tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
 - '2.7'
-#- '3.3'
-#- '3.4'
-#- 3.5-dev
+- '3.3'
+- '3.4'
+- '3.6'
 addons:
   apt:
     packages:


### PR DESCRIPTION
The python3.x tests were deactivated because they wouldn't have
worked anyway. This is the last PR that should be activated within
the python3 PR stack.