### PR TITLE
[python3] fix decoding issue in debquery.py

### DIFF
--- a/osc/util/debquery.py
+++ b/osc/util/debquery.py
@@ -229,9 +229,9 @@ class DebQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
     @staticmethod
     def filename(name, epoch, version, release, arch):
         if release:
-            return b'%s_%s-%s_%s.deb' % (name, version, release, arch)
+            return '%s_%s-%s_%s.deb' % (name, version, release, arch)
         else:
-            return b'%s_%s_%s.deb' % (name, version, arch)
+            return '%s_%s_%s.deb' % (name, version, arch)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
name, version, release and arch are strings, not bytes