### PR TITLE
Replace osc-wrapper.py with entry_points.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 tags
 build
 *junit-xml-results
+*.egg
+osc.egg-info/*

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ To install from git, do
 
     ./setup.py build
     ./setup.py install
-    # create a symlink `osc` in your path pointing to osc-wrapper.py.
-    ln -s osc-wrapper.py /usr/local/bin/osc
 
 Alternatively, you can directly use `./osc-wrapper.py` from the source directory,
 which is easier if you develop on osc.

--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -1,46 +1,9 @@
 #!/usr/bin/env python3
 
-# this wrapper exists so it can be put into /usr/bin, but still allows the
-# python module to be called within the source directory during development
+"""
+This wrapper allows osc to be called from the source directory during development.
+"""
 
-import locale
-import sys
-import os
+import osc.babysitter
 
-from osc import commandline, babysitter
-
-try:
-    # this is a hack to make osc work as expected with utf-8 characters,
-    # no matter how site.py is set...
-    reload(sys)
-    loc = locale.getpreferredencoding()
-    if not loc:
-        loc = sys.getpreferredencoding()
-    sys.setdefaultencoding(loc)
-    del sys.setdefaultencoding
-except NameError:
-    #reload, neither setdefaultencoding are in python3
-    pass
-
-# avoid buffering output on pipes (bnc#930137)
-# Note: the following only applies to python2
-# Basically, a "print('foo')" call is translated to a corresponding
-# fwrite call that writes to the stdout stream (cf. string_print
-# (Objects/stringobject.c) and builtin_print (Python/bltinmodule.c));
-# If no pipe is used, stdout is a tty/refers to a terminal =>
-# the stream is line buffered (see _IO_file_doallocate (libio/filedoalloc.c)).
-# If a pipe is used, stdout does not refer to a terminal anymore =>
-# the stream is fully buffered by default (see _IO_file_doallocate).
-# The following fdopen call makes stdout line buffered again (at least on
-# systems that support setvbuf - if setvbuf is not supported, the stream
-# remains fully buffered (see PyFile_SetBufSize (Objects/fileobject.c))).
-if not os.isatty(sys.stdout.fileno()):
-    sys.stdout = os.fdopen(sys.stdout.fileno(), sys.stdout.mode, 1)
-
-if not os.isatty(sys.stderr.fileno()):
-    sys.stderr = os.fdopen(sys.stderr.fileno(), sys.stderr.mode, 1)
-
-osccli = commandline.Osc()
-
-r = babysitter.run(osccli)
-sys.exit(r)
+osc.babysitter.main()

--- a/setup.py
+++ b/setup.py
@@ -101,9 +101,13 @@ setuptools.setup(
     url='http://en.opensuse.org/openSUSE:OSC',
     download_url='https://github.com/openSUSE/osc',
     packages=['osc', 'osc.util'],
-    scripts=['osc-wrapper.py'],
     data_files=data_files,
     install_requires=['cryptography', 'urllib3'],
+    entry_points={
+      'console_scripts': [
+          'osc=osc.babysitter:main'
+          ],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
I think that playing with locale should be unnecessary, unless the configuration of the system is seriously wrong.

This allows simple
```sh
$ python3 setup.py clean build install --user
```
to work as expected.

Also, are you sure you have to force compiled ``.egg`` on everybody?