### PR TITLE
[python3] add exception if encoding fails and try ISO-8859-1

### DIFF
--- a/osc/util/helper.py
+++ b/osc/util/helper.py
@@ -61,5 +61,9 @@ def decode_it(obj):
             import chardet
             return obj.decode(chardet.detect(obj)['encoding'])
         except:
-            import locale
-            return obj.decode(locale.getlocale()[1])
+            try:
+                import locale
+                return obj.decode(locale.getlocale()[1])
+            except:
+                return obj.decode('latin-1')
+            


### PR DESCRIPTION
In some rare cases the chardet encoding detection detects
a wrong encoding standard. Then we switch to latin-1 which
covers most if utf-8 does not work.