### PR TITLE
[python3] return value when adding attrs is bytes

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1032,7 +1032,7 @@ class Osc(cmdln.Cmdln):
             d = '<attributes><attribute namespace=\'%s\' name=\'%s\' >%s</attribute></attributes>' % (aname[0], aname[1], values)
             url = makeurl(apiurl, attributepath)
             for data in streamfile(url, http_POST, data=d):
-                sys.stdout.write(data)
+                sys.stdout.write(decode_it(data))
 
         # upload file
         if opts.file:


### PR DESCRIPTION
When adding attribute with osc meta attribute <prj> -a <attr> -s '<val>'
the api call gets executed successfull but the return value needs to be
decoded to print it correctly.