### PR TITLE
[python3] fix decoding in addGitSource

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -7058,7 +7058,7 @@ def addGitSource(url):
 
     # for pretty output
     xmlindent(s)
-    f = open(service_file, 'wb')
+    f = open(service_file, 'w')
     f.write(ET.tostring(s, encoding=ET_ENCODING))
     f.close()
     if addfile:


### PR DESCRIPTION
open the file with mode 'w' instead of 'wb'. The 'b' is not needed.
Neither in python2 nor in python3.

Fixes github issue https://github.com/openSUSE/osc/issues/507