### PR TITLE
Import urldefrag function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-0.166.0
-  -
+0.165.1
+  - fix oscssl "urldefrag is not defined error"
 
 0.165.0
   - full python3 compatibility

--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -13,12 +13,12 @@ import sys
 import inspect
 
 try:
-    from urllib.parse import urlparse, splithost, splitport, splittype
+    from urllib.parse import urlparse, splithost, splitport, splittype, urldefrag
     from urllib.request import addinfourl
     from http.client import HTTPSConnection
 except ImportError:
     #python 2.x
-    from urlparse import urlparse
+    from urlparse import urlparse, urldefrag
     from urllib import addinfourl, splithost, splitport, splittype
     from httplib import HTTPSConnection
 


### PR DESCRIPTION
The function was not imported and so osc crashed when executed behind a proxy

fixes https://github.com/openSUSE/osc/issues/534