### PR TITLE
[python3] fix adding dirs as compressed archive

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -7144,10 +7144,11 @@ def addFiles(filenames, prj_obj = None):
         todo = [os.path.join(p, elm)
                 for p, dirnames, fnames in os.walk(filename, followlinks=False)
                 for elm in dirnames + fnames]
+        enc_todo = [b'%s' % elem.encode() for elem in todo]
         with open(archive, 'w') as f:
             cpio_proc = subprocess.Popen(['cpio', '-o', '-H', 'newc', '-0'],
                                          stdin=subprocess.PIPE, stdout=f)
-            cpio_proc.communicate('\0'.join(todo))
+            cpio_proc.communicate(b'\0'.join(enc_todo))
         pacs.extend(findpacs([archive]))
 
     for pac in pacs:


### PR DESCRIPTION
The content in the todo dict are strings. In python3 the communicate
method expects a bytes-like object not a string.

Solution: Encode every element in todo to a new dict (enc_todo) and
pass this instead of todo

This fixes https://github.com/openSUSE/osc/issues/543