### PR TITLE
fix triggerreason on empty packages.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5646,9 +5646,13 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         print(apiurl, project, package, repository, arch)
         xml = show_package_trigger_reason(apiurl, project, package, repository, arch)
         root = ET.fromstring(xml)
-        reason = root.find('explain').text
-        triggertime = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(int(root.find('time').text)))
-        print("%s (at %s)" % (reason, triggertime))
+        if root.find('explain') is None:
+            reason = "No triggerreason found"
+            print(reason)
+        else:
+            reason = root.find('explain').text
+            triggertime = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(int(root.find('time').text)))
+            print("%s (at %s)" % (reason, triggertime))
         if reason == "meta change":
             print("changed keys:")
             for package in root.findall('packagechange'):


### PR DESCRIPTION
When running osc triggerreason on newly created (empty) packages
the command failes with AttributeError: 'NoneType' object has no attribute 'text'
because root.find('explain') is NoneType.

Solution:

Check if root.find('explain') is None and print "No triggerreaseon found".
In this case also do not try to get the triggertime. It will result in the same error.

This fixes https://github.com/openSUSE/osc/issues/546