### PR TITLE
fix diff of files with non-ASCII/non-UTF8 chars

### DIFF
--- a/osc/util/helper.py
+++ b/osc/util/helper.py
@@ -66,4 +66,23 @@ def decode_it(obj):
                 return obj.decode(locale.getlocale()[1])
             except:
                 return obj.decode('latin-1')
-            
+
+def compat_diff_bytes(dfunc, a, b, fromfile=b'', tofile=b'',
+               fromfiledate=b'', tofiledate=b'', n=3, lineterm=b'\n'):
+
+    import difflib
+
+    def decode(s):
+        return s.decode('ascii', 'surrogateescape')
+
+    a = list(map(decode, a))
+    b = list(map(decode, b))
+    fromfile = decode(fromfile)
+    tofile = decode(tofile)
+    fromfiledate = decode(fromfiledate)
+    tofiledate = decode(tofiledate)
+    lineterm = decode(lineterm)
+
+    lines = dfunc(a, b, fromfile, tofile, fromfiledate, tofiledate, n, lineterm)
+    for line in lines:
+        yield line.encode('ascii', 'surrogateescape')


### PR DESCRIPTION
When diffing a file that already contains a character that
can not be decoded using ASCII or UTF-8 the diff crashes with
UnicodeDecodeError: 'utf-8' codec can't decode byte ...

The solution:

Open the source file as binary and use difflib.diff_bytes in case
we run python >= 3.0

Before we return the diff list we decode it again.

This fixes https://github.com/openSUSE/osc/issues/540