### PR TITLE
fix getbinaries quiet logic

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4665,7 +4665,7 @@ def get_binary_file(apiurl, prj, repo, arch,
                     target_mtime = None,
                     progress_meter = False):
     progress_obj = None
-    if progress_meter:
+    if not progress_meter:
         from .meter import create_text_meter
         progress_obj = create_text_meter()
 


### PR DESCRIPTION
opts.quiet is passed to get_binary_file which is False by default.
So the following `if progress_meter` is always False unless -q is given.

So it needs to be `if not progress_meter`.

This was reported by @bugfinder 