### PR TITLE
build: qemu (without kvm) can build any architectures

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -864,7 +864,7 @@ def main(apiurl, opts, argv):
     elif hostarch != bi.buildarch:
         if not bi.buildarch in can_also_build.get(hostarch, []):
             # OBSOLETE: qemu_can_build should not be needed anymore since OBS 2.3
-            if vm_type != "emulator" and not bi.buildarch in qemu_can_build:
+            if vm_type != "emulator" and vm_type != "qemu" and not bi.buildarch in qemu_can_build:
                 print('Error: hostarch \'%s\' cannot build \'%s\'.' % (hostarch, bi.buildarch), file=sys.stderr)
                 return 1
             print('WARNING: It is guessed to build on hostarch \'%s\' for \'%s\' via QEMU.' % (hostarch, bi.buildarch), file=sys.stderr)


### PR DESCRIPTION
With https://github.com/openSUSE/obs-build/pull/503 we can build any architectures with qemu (without KVM)
