### PR TITLE
fix getbinaries in commandline (progress_meter)

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7289,7 +7289,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                     package = pac,
                                     target_filename = fname,
                                     target_mtime = i.mtime,
-                                    progress_meter = opts.quiet)
+                                    progress_meter = not opts.quiet)
 
 
     @cmdln.option('-b', '--bugowner', action='store_true',


### PR DESCRIPTION
progress_meter = opts.quiet is wrong, because if -q is not
set progress_meter will be false and no output will be shown.

This is fixed by using a new var use_progress_meter. 

This fixes an issue reported by @bugfinder 