### PR TITLE
[python3] fix outupt of status on attribute deletion

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1102,7 +1102,7 @@ class Osc(cmdln.Cmdln):
                 attributepath.append(opts.attribute)
                 u = makeurl(apiurl, attributepath)
                 for data in streamfile(u, http_DELETE):
-                    sys.stdout.write(data)
+                    sys.stdout.write(decode_it(data))
             else:
                 raise oscerr.WrongOptions('The --delete switch is only for pattern metadata or attributes.')
 


### PR DESCRIPTION
On osc meta attribute --attribue <name> --delete the returned
data is encoded. Therefore the sys.stdout.write(data) call fails.

Solution: Decode data

--> sys.stdout.write(decode_it(data))

reported by @bugfinder 