### PR TITLE
cast bytes object to string during os.path.join

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -176,7 +176,7 @@ class Fetcher:
                     sys.exit(1)
                 canonname = pac_obj.binary
 
-        fullfilename = os.path.join(destdir, canonname)
+        fullfilename = os.path.join(destdir, decode_it(canonname))
         if pac_obj is not None:
             pac_obj.canonname = canonname
             pac_obj.fullfilename = fullfilename


### PR DESCRIPTION
this makes sure not to mix objects to prevent a TypeError

TypeError: Can't mix strings and bytes in path components

Fixes#567

Signed-off-by: Maximilian Meister <mmeister@suse.de>