### PR TITLE
[python3] osc maintainer -s now works with python3

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -6977,7 +6977,7 @@ def setBugowner(apiurl, prj, pac, user=None, group=None):
         group=user.replace('group:', '')
         user=None
     if data:
-        root = ET.fromstring(''.join(data))
+        root = ET.fromstring(b''.join(data))
         for group_element in root.getiterator('group'):
             if  group_element.get('role') == "bugowner":
                 root.remove(group_element)


### PR DESCRIPTION
data is a bytes-like object now and needs to be joined into a
bytes-like object.

Fixes https://github.com/openSUSE/osc/issues/577