### PR TITLE
simplified class metafile __init__ method

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -3660,12 +3660,19 @@ class metafile:
         self.url = url
         self.change_is_required = change_is_required
         (fd, self.filename) = tempfile.mkstemp(prefix = 'osc_metafile.', suffix = file_ext)
-        if not input or isinstance(input[0], str) or isinstance(input, str):
-            f = os.fdopen(fd, 'w')
-            f.write(''.join(input))
+
+        open_mode = 'w'
+        input_as_str = None
+
+        if not isinstance(input, list):
+            input = [input]
+        if isinstance(input[0], str):
+            input_as_str = ''.join(input)
         else:
-            f = os.fdopen(fd, 'wb')
-            f.write(b''.join(input))
+            open_mode = 'wb'
+            input_as_str = b''.join(input)
+        f = os.fdopen(fd, open_mode)
+        f.write(input_as_str)
         f.close()
         self.hash_orig = dgst(self.filename)
 


### PR DESCRIPTION
simplified and fixed the `__init__` method of the metafile class.
input can be string, bytes-like object, list of strings or list
of bytes-like objects now.

Based on the input now always a list is generated and joined to
a string for writing in the fd. (This is ugly but needed for
compat reasons)

fixes https://github.com/openSUSE/osc/issues/579
Thanks to @darix 