### PR TITLE
[python3] fix osc lbl non utf8 encoding

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5591,9 +5591,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         logfile = os.path.join(buildroot, '.build.log')
         if not os.path.isfile(logfile):
             raise oscerr.OscIOError(None, 'logfile \'%s\' does not exist' % logfile)
-        f = open(logfile, 'r')
+        f = open(logfile, 'rb')
         f.seek(offset)
         data = f.read(BUFSIZE)
+        data = decode_it(data)
         while len(data):
             if opts.strip_time or conf.config['buildlog_strip_time']:
                 data = buildlog_strip_time(data)


### PR DESCRIPTION
data can contain non-utf8 chars. So passing data to
the decode_it function will solve this problem.

fixes https://github.com/openSUSE/osc/issues/585