### PR TITLE
fix handling of empty prjconfig meta

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -3666,7 +3666,7 @@ class metafile:
 
         if not isinstance(input, list):
             input = [input]
-        if isinstance(input[0], str):
+        if input and isinstance(input[0], str):
             input_as_str = ''.join(input)
         else:
             open_mode = 'wb'


### PR DESCRIPTION
if prjconfig meta is empty the class metafile init
fails with
```
if isinstance(input[0], str):
IndexError: list index out of range

```
This is because input is an empty list and has no
`[0]` index.

This can be fixed by changing this line to:
`if input and isinstance(input[0], str):`