### PR TITLE
remove python 3.3 and 3.4 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
-- '3.4'
 - '3.6'
 addons:
   apt:


### PR DESCRIPTION
Those versions are not supported anymore and thus testing
is not needed anymore.