### PR TITLE
fix oscssl.py not verifying TLS cert verification [CVE-2013-3685]

### DIFF
--- a/osc/oscssl.py
+++ b/osc/oscssl.py
@@ -199,13 +199,13 @@ class myHTTPSHandler(M2Crypto.m2urllib2.HTTPSHandler):
 
         if target_host != host:
             request_uri = urldefrag(full_url)[0]
-            h = httpslib.ProxyHTTPSConnection(host=host, ssl_context=self.ctx)
+            h = myProxyHTTPSConnection(host=host, ssl_context=self.ctx)
         else:
             try:     # up to python-3.2
                 request_uri = req.get_selector()
             except AttributeError:  # from python-3.3
                 request_uri = req.selector
-            h = httpslib.HTTPSConnection(host=host, ssl_context=self.ctx)
+            h = myHTTPSConnection(host=host, ssl_context=self.ctx)
         # End our change
         h.set_debuglevel(self._debuglevel)
 


### PR DESCRIPTION
use own implementation of HTTPSConnection (myHTTPSConnection)
instead the one provided by M2Crypto (httpslib.HTTPConnection)

all credits go to @wfrisch

fixes https://github.com/openSUSE/osc/issues/596
reported in bug https://bugzilla.suse.com/show_bug.cgi?id=1142518