### PR TITLE
babysitter: fix RPMError fallback when running in Python3

### DIFF
--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -30,7 +30,8 @@ try:
     from rpm import error as RPMError
 except:
     # if rpm-python isn't installed (we might be on a debian system):
-    RPMError = None
+    class RPMError(Exception):
+        pass
 
 try:
     from http.client import HTTPException, BadStatusLine


### PR DESCRIPTION
After (successfully) running an 'osc vc' the following exception trace
comes up, when no rpm python module is available:

```
no changes made
Traceback (most recent call last):
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/babysitter.py", line 62, in run
    return prg.main(argv)
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/cmdln.py", line 344, in main
    return self.cmd(args)
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/cmdln.py", line 367, in cmd
    retval = self.onecmd(argv)
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/cmdln.py", line 501, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/cmdln.py", line 1232, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/commandline.py", line 8924, in do_vc
    sys.exit(vc.returncode)
SystemExit: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mgerstner/bin/osc", line 41, in <module>
    r = babysitter.run(osccli)
  File "/home/mgerstner/.local/lib64/python3.6/site-packages/osc/babysitter.py", line 172, in run
    except RPMError as e:
TypeError: catching classes that do not inherit from BaseException is not allowed
```

To fix this change the fallback RPMError from None to an actual
Exception-derived type.