### PR TITLE
fix and unify building of local package cache

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -229,18 +229,28 @@ class Pac:
 
         self.mp['apiurl'] = apiurl
 
+        if self.mp['epoch'] is None:
+            epoch = None
+        else:
+            epoch = self.mp['epoch'].encode()
+
+        if self.mp['release'] is None:
+            release = None
+        else:
+            release = self.mp['release'].encode()
+
         if self.mp['name'].startswith('container:'):
             canonname = self.mp['name'] + '.tar.xz'
         elif pacsuffix == 'deb':
-            canonname = debquery.DebQuery.filename(self.mp['name'], self.mp['epoch'], self.mp['version'], self.mp['release'], self.mp['arch'])
+            canonname = debquery.DebQuery.filename(self.mp['name'].encode(), epoch, self.mp['version'].encode(), release, self.mp['arch'].encode())
         elif pacsuffix == 'arch':
-            canonname = archquery.ArchQuery.filename(self.mp['name'], self.mp['epoch'], self.mp['version'], self.mp['release'], self.mp['arch'])
+            canonname = archquery.ArchQuery.filename(self.mp['name'].encode(), epoch, self.mp['version'].encode(), release, self.mp['arch'].encode())
         else:
-            canonname = rpmquery.RpmQuery.filename(self.mp['name'], self.mp['epoch'], self.mp['version'], self.mp['release'], self.mp['arch'])
+            canonname = rpmquery.RpmQuery.filename(self.mp['name'].encode(), epoch, self.mp['version'].encode(), release, self.mp['arch'].encode())
 
-        self.mp['canonname'] = canonname
+        self.mp['canonname'] = decode_it(canonname)
         # maybe we should rename filename key to binary
-        self.mp['filename'] = node.get('binary') or canonname
+        self.mp['filename'] = node.get('binary') or decode_it(canonname)
         if self.mp['repopackage'] == '_repository':
             self.mp['repofilename'] = self.mp['name']
         else:

--- a/osc/util/debquery.py
+++ b/osc/util/debquery.py
@@ -229,9 +229,9 @@ class DebQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
     @staticmethod
     def filename(name, epoch, version, release, arch):
         if release:
-            return '%s_%s-%s_%s.deb' % (name, version, release, arch)
+            return b'%s_%s-%s_%s.deb' % (name, version, release, arch)
         else:
-            return '%s_%s_%s.deb' % (name, version, arch)
+            return b'%s_%s_%s.deb' % (name, version, arch)
 
 if __name__ == '__main__':
     import sys

--- a/osc/util/repodata.py
+++ b/osc/util/repodata.py
@@ -169,8 +169,12 @@ class RepoDataQueryResult(osc.util.packagequery.PackageQueryResult):
         return self.__parseEntryCollection('enhances')
 
     def canonname(self):
-        return osc.util.rpmquery.RpmQuery.filename(self.name(), None,
-            self.version(), self.release(), self.arch())
+        if self.release() is None:
+            release = None
+        else:
+            release = self.release().encode()
+        return osc.util.rpmquery.RpmQuery.filename(self.name().encode(), None,
+            self.version().encode(), release, self.arch().encode())
 
     def gettag(self, tag):
         # implement me, if needed

--- a/osc/util/rpmquery.py
+++ b/osc/util/rpmquery.py
@@ -287,12 +287,12 @@ class RpmQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
 
     def canonname(self):
         if self.is_nosrc():
-            arch = 'nosrc'
+            arch = b'nosrc'
         elif self.is_src():
-            arch = 'src'
+            arch = b'src'
         else:
             arch = self.arch()
-        return RpmQuery.filename(decode_it(self.name()), None, decode_it(self.version()), decode_it(self.release()), decode_it(arch))
+        return RpmQuery.filename(self.name(), None, self.version(), self.release(), arch)
 
     @staticmethod
     def query(filename):
@@ -374,7 +374,7 @@ class RpmQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
 
     @staticmethod
     def filename(name, epoch, version, release, arch):
-        return '%s-%s-%s.%s.rpm' % (name, version, release, arch)
+        return b'%s-%s-%s.%s.rpm' % (name, version, release, arch)
 
 def unpack_string(data, encoding=None):
     """unpack a '\\0' terminated string from data"""


### PR DESCRIPTION
* all filename functions now return bytes-like objects
* the caller does the decoding
* the caller in build.py passes encoded arguments

fixes https://github.com/openSUSE/osc/issues/613