### PR TITLE
return the obj if None type is passed to decode_it

### DIFF
--- a/osc/util/helper.py
+++ b/osc/util/helper.py
@@ -54,7 +54,7 @@ def decode_it(obj):
         based on the chardet module if possible
     """
 
-    if isinstance(obj, str):
+    if obj is None or isinstance(obj, str):
         return obj
     else:
         try:


### PR DESCRIPTION
If a obj of type None is passed to decode_it just return it and do not try to decode it as this will fail