### PR TITLE
make now() UTC aware for accept-in-hours

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -2860,7 +2860,7 @@ class Request:
 
         now = datetime.datetime.utcnow()
         now = now + datetime.timedelta(hours=hours)
-        self.accept_at = now.isoformat()
+        self.accept_at = now.isoformat() + '+00:00'
 
     @staticmethod
     def format_review(review, show_srcupdate=False):


### PR DESCRIPTION
just send the UTC time and the API will do the rest

could not use datetime.timezone.utc, because it is not python2 compatible. Therefore the
module pytz

fixes https://github.com/openSUSE/osc/issues/617