### PR TITLE
osc/core: parseRevisionOption(): cleanup and make logic consistent.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6841,7 +6841,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = args[0]
             package = args[1]
 
-        rev, rev_upper = parseRevisionOption(opts.revision)
+        rev, rev_upper = parseRevisionOption(opts.revision, allow_md5=False)
         if rev and not checkRevision(project, package, rev, apiurl, opts.meta):
             print('Revision \'%s\' does not exist' % rev, file=sys.stderr)
             sys.exit(1)

--- a/osc/core.py
+++ b/osc/core.py
@@ -6603,32 +6603,22 @@ def cmdbuild(apiurl, cmd, project, package=None, arch=None, repo=None, code=None
     return root.get('code')
 
 
-def parseRevisionOption(string):
+def parseRevisionOption(string, allow_md5=True):
     """
     returns a tuple which contains the revisions
     """
 
+    revisions = [None, None]
     if string:
-        if ':' in string:
-            splitted_rev = string.split(':')
-            try:
-                for i in splitted_rev:
-                    int(i)
-                return splitted_rev
-            except ValueError:
+        parts = string.split(':')
+        for i, revision in enumerate(parts[0:2], 0):
+            if revision.isdigit() or (allow_md5 and revision.isalnum() and len(revision) == 32):
+                revisions[i] = revision
+            elif revision != '' and revision != 'latest':
                 print('your revision \'%s\' will be ignored' % string, file=sys.stderr)
                 return None, None
-        else:
-            if string.isdigit():
-                return string, None
-            elif string.isalnum() and len(string) == 32:
-                # could be an md5sum
-                return string, None
-            else:
-                print('your revision \'%s\' will be ignored' % string, file=sys.stderr)
-                return None, None
-    else:
-        return None, None
+
+    return tuple(revisions)
 
 def checkRevision(prj, pac, revision, apiurl=None, meta=False):
     """


### PR DESCRIPTION
Handle multiple revisions the same as a single revision in terms of what
is allowed (digit, or 32 character string [md5]). Additionally, support
either blank or "latest" to mean latest revision (None).

This allows for new revision to be specified without old revision like the
following example:

osc rdiff ... -r :17

This is needed to complete openSUSE/openSUSE-release-tools#2144 which will alternatively have to wrap this logic to lookup current old revision before calling into `osc`. This is preferred since also usable from CLI directly.