### PR TITLE
add support for new staging api. (command osc ps)

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -484,6 +484,79 @@ class Serviceinfo:
 
         return 0
 
+class ProjectStaging:
+    """ProjectStaging actions and information
+    """
+    def __init__(self, apiurl):
+        self.apiurl = apiurl
+
+    def create(self, project, group):
+        groupxml = "<workflow managers='%s'/>" % group
+        u = makeurl(self.apiurl, ['staging', project, 'workflow'])
+        f = http_POST(u, data=groupxml)
+        return f
+
+    def delete(self, project):
+        try:
+            u = makeurl(self.apiurl, ['staging', project, 'workflow'])
+            f = http_DELETE(u)
+        except HTTPError:
+            return None
+        return f
+
+    def list(self, project):
+        try:
+            u = makeurl(self.apiurl, ['staging', project, 'staging_projects'])
+            f  = http_GET(u)
+        except HTTPError as e:
+            if e.code == 400:
+                return None
+            raise e
+        return f
+
+    def add(self, project, staging_list):
+        stagingxml = "<workflow>"
+        for stage in staging_list:
+            stagingxml += "<staging_project>%s</staging_project>" % stage
+        stagingxml += "</workflow>"
+        u = makeurl(self.apiurl, ['staging', project, 'staging_projects'])
+        f = http_POST(u, data=stagingxml)
+        return f
+
+    def show(self, project, stage):
+        u = makeurl(self.apiurl, ['staging', project, 'staging_projects', stage])
+        f  = http_GET(u)
+        return f
+
+    def accept(self, project, stage):
+        u = makeurl(self.apiurl, ['staging', project, 'staging_projects', stage, 'accept'])
+        f = http_POST(u)
+        return f
+
+    def add_request(self, project, stage, rqids):
+        requestxml = "<requests>"
+        for rq in rqids:
+            requestxml += "<number>%s</number>" % rq
+        requestxml += "</requests>"
+        u = makeurl(self.apiurl, ['staging', project, 'staging_projects', stage, 'staged_requests'])
+        f = http_POST(u, data=requestxml)
+        return f
+
+    def delete_requests(self, project, stage, rqids):
+        requestxml = "<requests>"
+        for rq in rqids:
+            requestxml += "<number>%s</number>" % rq
+        requestxml += "</requests>"
+        u = makeurl(self.apiurl, ['staging', project, 'staging_projects', stage, 'staged_requests'])
+        f = http_DELETE(u, data=requestxml)
+        return f
+
+    def list_requests(self, project, stage):
+        u = makeurl(self.apiurl, ['staging', project, 'staging_projects', stage, 'staged_requests'])
+        f = http_GET(u)
+        return f
+
+
 class Linkinfo:
     """linkinfo metadata (which is part of the xml representing a directory
     """


### PR DESCRIPTION
Create, Add, Delete staging projects
Add requests to staging

It can be issued within a project directory or with the
project as the first argument.

If you operate on a staging project or with requests the
staging project has to be given with `-s` and the request has
to be given with `-r`

You can add multiple requests / stagings comma serparated.
For example:
 ```
 -s myprj:Staging:A, myprj:Staging:B
  -r 1234, 12345
```

osc ps

For example:
    `linux:~/myproject/> osc ps create`
    or
    `osc ps create myproject`

STILL IN BETA

This fixes https://github.com/openSUSE/osc/issues/583