### PR TITLE
tmpfs as new password store backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
     - diffstat
 sudo: false
 script: cd tests; python suite.py
+install:
+- pip install fs
 deploy:
   provider: pypi
   user: suse


### PR DESCRIPTION
With the new TmpFSCredentialsManager it is possible
to store the password in /run/user/<uid> and to keep it
while the session lasts.

As soon as the session is terminated, the directory with
the suffix 'osc' will be deleted and the user has to enter
his password again.