### PR TITLE
fix decoding for osc cat

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8426,7 +8426,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 if isinstance(data, str):
                     sys.stdout.write(data)
                 else:
-                    sys.stdout.write(decode_it(data))
+                    sys.stdout.buffer.write(data)
 
 
     # helper function to download a file from a specific revision


### PR DESCRIPTION
use sys.stdout.buffer.write() to print encoded data
correctly

fixes https://github.com/openSUSE/osc/issues/624