### PR TITLE
do not decode diff before passing it to run_pager

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2510,7 +2510,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                             action.tgt_project.encode(), action.tgt_package.encode())
                         diff += submit_action_diff(apiurl, action)
                         diff += b'\n\n'
-                run_pager(decode_it(diff), tmp_suffix='')
+                run_pager(diff, tmp_suffix='')
 
         # checkout
         elif cmd == 'checkout' or cmd == 'co':


### PR DESCRIPTION
run_pager will take care of the bytes-like object and
will directly write it to sys.stdout.buffer.write() or
NamedTemporaryFile.