### PR TITLE
switch shebang of wrapper script to python3

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # this wrapper exists so it can be put into /usr/bin, but still allows the
 # python module to be called within the source directory during development


### PR DESCRIPTION
The osc-wrapper script in git master should use python3 as default.