### PR TITLE
be sure that destination does not exist before overwriting content

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5145,9 +5145,10 @@ def link_pac(src_project, src_package, dst_project, dst_package, force, rev='', 
         if root.get('project') != dst_project:
             # The source comes from a different project via a project link, we need to create this instance
             meta_change = True
-    except:
+    except HTTPError as e:
+        if e.code != 404:
+           raise
         meta_change = True
-
     if meta_change:
         if missing_target:
             dst_meta = '<package name="%s"><title/><description/></package>' % dst_package
@@ -5239,7 +5240,9 @@ def aggregate_pac(src_project, src_package, dst_project, dst_package, repo_map =
         if root.get('project') != dst_project:
             # The source comes from a different project via a project link, we need to create this instance
             meta_change = True
-    except:
+    except HTTPError as e:
+        if e.code != 404:
+           raise
         meta_change = True
 
     if meta_change:


### PR DESCRIPTION
we used to crash on utf encoding errors, be sure not to replace meta
data in that case