### PR TITLE
improve help text for osc maintained

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -3336,6 +3336,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             home:USERNAME:branches:ATTRIBUTE:PACKAGE
         if nothing else specified.
 
+        If osc maintained or sm is issued only the relevant instances of a
+        package will be shown. No branch will be created. This is similar
+        to osc mbranch --dryrun.
+
         usage:
             osc sm [SOURCEPACKAGE] [-a ATTRIBUTE]
             osc mbranch [ SOURCEPACKAGE [ TARGETPROJECT ] ]


### PR DESCRIPTION
The help text does not indicate that only osc mbranch
really creates a branch.

osc maintained and osc sm are just aliases for osc mbranch --dryrun

fix for https://github.com/openSUSE/osc/issues/83