### PR TITLE
handle empty release in rpmquery.py

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -246,7 +246,7 @@ class Pac:
         elif pacsuffix == 'arch':
             canonname = archquery.ArchQuery.filename(self.mp['name'].encode(), epoch, self.mp['version'].encode(), release, self.mp['arch'].encode())
         else:
-            canonname = rpmquery.RpmQuery.filename(self.mp['name'].encode(), epoch, self.mp['version'].encode(), release, self.mp['arch'].encode())
+            canonname = rpmquery.RpmQuery.filename(self.mp['name'].encode(), epoch, self.mp['version'].encode(), release or b'0', self.mp['arch'].encode())
 
         self.mp['canonname'] = decode_it(canonname)
         # maybe we should rename filename key to binary


### PR DESCRIPTION
This is very unlikely but in very rare cases this
can happen.

Builing kiwi images containing debian is one case.
In this case we do not know what is inside the kiwi
file and osc build assumes buildtype 'rpm' to generate
a package list which get's thrown away anyway.

Now we just check for release