### PR TITLE
fix build with alternative prj and multibuild

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -646,8 +646,7 @@ def main(apiurl, opts, argv):
             pac = store_read_package(os.curdir)
     if opts.multibuild_package:
         buildargs.append('--buildflavor=%s' % opts.multibuild_package)
-        if pac != '_repository':
-            pac = pac + ":" + opts.multibuild_package
+        pac = pac + ":" + opts.multibuild_package
     if opts.shell:
         buildargs.append("--shell")
 


### PR DESCRIPTION
building with alternative project (pac='_repository')
and multibuild did not work correctly, because the buildflavor
was not submitted to the src server.

With commit 2390823d649a3b0b6bf3b7bd07713c4426932bed in open-build-service
it is now possible to submit the build flavor like this: `_repository:<flavor>`

The obs commit also enables `osc buildinfo --alternative-prject -M <flavor>`
to show the correct buildinfo for the flavor.