### PR TITLE
Better errmsg oscci editor not presentosc ci improve error message on fail

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4773,6 +4773,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         try:
             self._commit(subcmd, opts, args)
         except oscerr.ExtRuntimeError as e:
+            pattern = re.compile("No such file")
+            if "No such file" in e.msg:
+                editor = os.getenv('EDITOR', default=get_default_editor())
+                print("Editor %s not found" % editor)
+                return 1
             print("ERROR: service run failed", e, file=sys.stderr)
             return 1
         except oscerr.PackageNotInstalled as e:


### PR DESCRIPTION
The error message if the call of _commit is just:
"ERROR: service run failed"

One option why this can fail is that the user Editor in env('EDITOR')
is not present.

We check now if e.msg gives a hint about "not found file" and then
error out with a better error message

fixes https://github.com/openSUSE/osc/issues/559