### PR TITLE
fix decoding for osc linkpac

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5142,7 +5142,7 @@ def link_pac(src_project, src_package, dst_project, dst_package, force, rev='', 
                                path_args=(quote_plus(dst_project), quote_plus(dst_package)),
                                template_args=None,
                                create_new=False, apiurl=apiurl)
-        root = ET.fromstring(''.join(dst_meta))
+        root = ET.fromstring(b''.join(dst_meta))
         if root.get('project') != dst_project:
             # The source comes from a different project via a project link, we need to create this instance
             meta_change = True


### PR DESCRIPTION
in def link_pac dst_meta is a list of bytes-like objects.
so b''.join(dst_meta) is needed

fixes https://github.com/openSUSE/osc/issues/664