### PR TITLE
extend cmd list for vc with args

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8980,8 +8980,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     raise oscerr.WrongOptions('\'%s\': is no file' % opts.file)
                 args = list(args)
                 if not args:
-                    cmd_list.append('')
-                cmd_list.append(opts.file)
+                    args.append('')
+                args.append(opts.file)
 
             if opts.just_edit:
                 cmd_list.append("-e")


### PR DESCRIPTION
If args is not none extend the list for the command
vc call with the args. Otherwise this will not work:

osc vc --file=proposed.changes package.changes

fixes boo#1155953