### PR TITLE
fix checkout_no_colon on project level

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4505,6 +4505,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         elif project:
             prj_dir = opts.output_dir if opts.output_dir else project
+            if not opts.output_dir and conf.config['checkout_no_colon']:
+                prj_dir = prj_dir.replace(':', '/')
             if sys.platform[:3] == 'win':
                 prj_dir = prj_dir.replace(':', ';')
             if os.path.exists(prj_dir):


### PR DESCRIPTION
prj_dir was not altered when issuing osc co on
project level.

Solution: Replace ":" with "/" on project level

fixes https://github.com/openSUSE/osc/issues/671

Thanks to @mook