### PR TITLE
fix output in http_debug mode for pubkey not found

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -286,7 +286,7 @@ class Fetcher:
 
             if try_parent:
                 if self.http_debug:
-                    print("can't fetch key for %s: %s" % (i, e.strerror), file=sys.stderr)
+                    print("can't fetch key for %s" % (i), file=sys.stderr)
                     print("url: %s" % url, file=sys.stderr)
 
                 if os.path.exists(dest):


### PR DESCRIPTION
Variable e is not known at the time of the call and
e.strerror is None nevertheless. So just ommit e.strerror.

fixes https://github.com/openSUSE/osc/issues/675