### PR TITLE
core: Switch from platform.linux_distribution() to distro.id()

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4022,11 +4022,8 @@ def get_default_editor():
     if system == 'Windows':
         return 'notepad'
     if system == 'Linux':
-        try:
-            # Python 2.6
-            dist = platform.linux_distribution()[0]
-        except AttributeError:
-            dist = platform.dist()[0]
+        import distro
+        dist = distro.id()
         if dist == 'debian':
             return 'editor'
         elif dist == 'fedora':
@@ -4040,11 +4037,8 @@ def get_default_pager():
     if system == 'Windows':
         return 'less'
     if system == 'Linux':
-        try:
-            # Python 2.6
-            dist = platform.linux_distribution()[0]
-        except AttributeError:
-            dist = platform.dist()[0]
+        import distro
+        dist = distro.id()
         if dist == 'debian':
             return 'pager'
         return 'less'


### PR DESCRIPTION
The `platform.linux_distribution()` and `platform.dist()` methods have been removed in Python 3.8.

The suggested replacement is using the third party `distro` module.