### PR TITLE
Handle bytes vs. str error when parsing meta (#683)

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7973,7 +7973,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                        'name': pac,
                                        'user': user}), apiurl=apiurl)
                 if data:
-                    data = ET.fromstring(''.join(data))
+                    data = ET.fromstring(parse_meta_to_string(data))
                     data.find('title').text = ''.join(title)
                     data.find('description').text = ''.join(descr)
                     data.find('url').text = url


### PR DESCRIPTION
In all the cases where meta_exists returns either
string data, bytes data or a list, the output needs
to be parsed correctly.

Signed-off-by: Kristoffer Grönlund <kgronlund@suse.com>