### PR TITLE
fix lastbuildroot on builds not in WC

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -1295,7 +1295,8 @@ def main(apiurl, opts, argv):
         cmd = [ change_personality[bi.buildarch] ] + cmd
 
     # record our settings for later builds
-    osc.core.store_write_last_buildroot(os.curdir, repo, arch, vm_type)
+    if is_package_dir(os.curdir):
+        osc.core.store_write_last_buildroot(os.curdir, repo, arch, vm_type)
 
     try:
         rc = run_external(cmd[0], *cmd[1:])

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6442,7 +6442,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if project == opts.alternative_project:
             opts.alternative_project = None
 
-        if len(args) == 0:
+        if len(args) == 0 and is_package_dir(os.curdir):
             # build env not specified, just read from last build attempt
             lastbuildroot = store_read_last_buildroot(os.curdir)
             if lastbuildroot:


### PR DESCRIPTION
fix the lastbuildroot handling if the package is being build oustide of
a package directory and thus no .osc/ dir can be found.

We then just skip the store_write_last_buildroot and store_read_last_buildroot
calls.

fixes https://github.com/openSUSE/osc/issues/701