### PR TITLE
Remove unused function dgst_from_string

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4706,18 +4706,6 @@ def get_binary_file(apiurl, prj, repo, arch,
     if target_filename.endswith('.AppImage'):
         os.chmod(target_filename, 0o755)
 
-def dgst_from_string(str):
-    # Python 2.5 depracates the md5 modules
-    # Python 2.4 doesn't have hashlib yet
-    try:
-        import hashlib
-        md5_hash = hashlib.md5()
-    except ImportError:
-        import md5
-        md5_hash = md5.new()
-    md5_hash.update(str)
-    return md5_hash.hexdigest()
-
 def dgst(file):
 
     #if not os.path.exists(file):


### PR DESCRIPTION
The function `dgst_from_string` does not appear to be used anywhere in the code base and existed only for compatibility reasons when Python 2.4 still was a thing.