### PR TITLE
Fix typo in help message

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2191,7 +2191,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
             osc request accept [-m TEXT] ID
             osc request approve [-m TEXT] ID
-            osc request cancelapprove [-m TEXT] ID
+            osc request cancelapproval [-m TEXT] ID
             osc request decline [-m TEXT] ID
             osc request revoke [-m TEXT] ID
             osc request reopen [-m TEXT] ID


### PR DESCRIPTION
The help message suggests to use `osc request cancelapprove`. However the correct command is `osc request cancelapproval`.

Executing `osc request cancelapprove` leads to this error message:

> Unknown request action cancelapprove. Choose one of list, ls, log, show, decline, reopen, clone, accept, approve, **cancelapproval**, approvenew, wipe, setincident, supersede, revoke, checkout, co, priorize, prioritize.

