### PR TITLE
- support zstd arch linux files in local build

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -430,7 +430,7 @@ def get_prefer_pkgs(dirs, wanted_arch, type, cpio):
     if type == 'dsc' or type == 'collax' or type == 'livebuild':
         suffix = '*.deb'
     elif type == 'arch':
-        suffix = '*.pkg.tar.xz'
+        suffix = '*.pkg.tar.*'
 
     for dir in dirs:
         # check for repodata

--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -78,9 +78,9 @@ class Fetcher:
                         raise oscerr.APIError('CPIO archive is incomplete '
                                               '(see .errors file)')
                     if package == '_repository':
-                        n = re.sub(b'\.pkg\.tar\..z$', b'.arch', hdr.filename)
+                        n = re.sub(b'\.pkg\.tar\.(zst|.z)$', b'.arch', hdr.filename)
                         if n.startswith(b'container:'):
-                            n = re.sub(b'\.tar\..z$', b'.tar', hdr.filename)
+                            n = re.sub(b'\.tar\.(zst|.z)$', b'.tar', hdr.filename)
                             pac = pkgs[decode_it(n.rsplit(b'.', 1)[0])]
                             pac.canonname = hdr.filename
                         else:

--- a/osc/util/packagequery.py
+++ b/osc/util/packagequery.py
@@ -72,7 +72,8 @@ class PackageQuery:
         elif magic[:5] == b'<?xml':
             f.close()
             return None
-        elif magic[:5] == b'\375\067zXZ' or magic[:2] == b'\037\213':
+        # arch tar ball compressed with gz, xz or zst
+        elif magic[:5] == b'\375\067zXZ' or magic[:2] == b'\037\213' or magic[:5] == b'(\xb5/\xfd\x2f':
             from . import archquery
             pkgquery = archquery.ArchQuery(f)
         else:


### PR DESCRIPTION
Note: This requires a tar executable supporting zstd