### PR TITLE
Fix deletereq for repository

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2006,7 +2006,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         else:
             raise oscerr.WrongArgs('Please specify at least a project.')
 
-        if not opts.all and package is None:
+        if not opts.all and package is None and not opts.repository:
             raise oscerr.WrongOptions('No package name has been provided. Use --all option, if you want to request to delete the entire project.')
 
         if opts.repository:


### PR DESCRIPTION
Do not require --all if --repository is given. There
are no packages touched when removing a repository for
a home project.

fixes https://github.com/openSUSE/osc/issues/720