### PR TITLE
improve SSLError message

### DIFF
--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -172,6 +172,8 @@ def run(prg, argv=None):
     except RPMError as e:
         print(e, file=sys.stderr)
     except SSLError as e:
+        if 'tlsv1' in str(e):
+            print('The python on this system does not support TLSv1.2', file=sys.stderr)
         print("SSL Error:", e, file=sys.stderr)
     except SSLVerificationError as e:
         print("Certificate Verification Error:", e, file=sys.stderr)


### PR DESCRIPTION
Improve the SSLError message if a version mismatch (TLSv1) is
detected and give the user a hint what is wrong.

(Basically the API does not supprt TLS <= 1.2 and the python
version does not support TLS >= 1.2)