### PR TITLE
append --norootforbuild as default

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -537,7 +537,7 @@ def calculate_build_root(apihost, prj, pac, repo, arch):
                             % {'repo': repo, 'arch': arch, 'project': prj, 'package': pac, 'apihost': apihost}
     return buildroot
 
-def run_build(*args):
+def run_build(opts, *args):
     cmd = [config['build-cmd']]
     cmd += args
 
@@ -548,6 +548,8 @@ def run_build(*args):
         cmd = sucmd + ['-s', cmd[0], 'root', '--'] + cmd[1:]
     else:
         cmd = sucmd + cmd
+    if not opts.userootforbuild:
+        cmd.append('--norootforbuild')
     return run_external(cmd[0], *cmd[1:])
 
 def main(apiurl, opts, argv):

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6470,7 +6470,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             build_args = ['--root=' + build_root, '--noinit', '--shell']
             if opts.wipe:
                 build_args.append('--wipe')
-            sys.exit(osc.build.run_build(*build_args))
+            sys.exit(osc.build.run_build(opts, *build_args))
         elif subcmd in ('shell', 'chroot') or opts.shell:
             print('--shell in combination with build-type %s is experimental.' % vm_chroot)
             print('The semantics may change at any time!')


### PR DESCRIPTION
pass opts to run_build and check if norootforbuild
needs to be appended to cmd. (if opts.userootforbuild is not set)

@marcus-h please review

https://github.com/openSUSE/obs-build/pull/543 needed to work completely