### PR TITLE
print release_project on maintenancerequests

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -3283,7 +3283,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             target_project = project.get('name')
             if opts.incident:
                 target_project += ":" + opts.incident
-            print('Using target project \'%s\'' % target_project)
+            release_in = ''
+            if release_project is not None:
+                release_in = '. (release in \'%s\')' % release_project
+            print('Using target project \'%s\'%s' % (target_project, release_in))
 
         if not opts.message:
             opts.message = edit_message()


### PR DESCRIPTION
When creating maintenance requests print out the relese_project
if already known at this point.

fixes https://github.com/openSUSE/osc/issues/188