### PR TITLE
print web url links for creating requests

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1460,7 +1460,15 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                        dst_project, dst_package,
                                        opts.message, orev=rev,
 				       src_update=src_update, dst_updatelink=opts.update_link)
+
         print('created request id', result)
+        if conf.config['print_web_links']:
+            root = ET.fromstring(b''.join(show_configuration(apiurl)))
+            node = root.find('obs_url')
+            if node is None or not node.text:
+                raise oscerr.APIError('obs_url configuration element expected')
+            obs_url = node.text
+            print('%s/request/show/%s' % (obs_url, result))
 
         if supersede_existing:
             for req in reqs:

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -151,6 +151,8 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'exclude_glob': '.osc CVS .svn .* _linkerror *~ #*# *.orig *.bak *.changes.vctmp.*',
             # whether to keep passwords in plaintext (deprecated (see creds manager)).
             'plaintext_passwd': '0',
+            # whether to print Web UI links to directly insert in browser (where possible)
+            'print_web_links': '0',
             # limit the age of requests shown with 'osc req list'.
             # this is a default only, can be overridden by 'osc req list -D NNN'
             # Use 0 for unlimted.
@@ -198,7 +200,7 @@ boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'tr
     'checkout_no_colon', 'checkout_rooted', 'check_for_request_on_action', 'linkcontrol', 'show_download_progress', 'request_show_interactive',
     'request_show_source_buildstatus', 'review_inherit_group', 'use_keyring', 'gnome_keyring', 'no_verify', 'builtin_signature_check',
     'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage',
-    'status_mtime_heuristic']
+    'status_mtime_heuristic', 'print_web_links']
 integer_opts = ['build-jobs']
 
 api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']


### PR DESCRIPTION
This will print the direct url to show the created request.
New general bool option 'print_web_links' must be set to enable
this.

Right now this is only for creating requests. More to follow.

fixes https://github.com/openSUSE/osc/issues/194