### PR TITLE
fix decoding in interactive request mode

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -7528,7 +7528,7 @@ def request_interactive_review(apiurl, request, initial_cmd='', group=None,
                 if tmpfile is not None:
                     tmpfile.seek(0)
                     # the read bytes probably have a moderate size so the str won't be too large
-                    footer += '\n\n' + tmpfile.read()
+                    footer += '\n\n' + decode_it(tmpfile.read())
                 if msg is None:
                     try:
                         msg = edit_message(footer = footer, template=msg_template)


### PR DESCRIPTION
In interactive review mode:

If a diff is issued and the request is accepted with 'a -m ok'
the tmpfile with the diff will be read. This tmpfile.read() call
is now decoded properly.