### PR TITLE
- allow "osc r --vertical" for projects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.168.0
   - MR creation honors orev now (bsc#1160446)
+  - allow "osc r --vertical" for projects
 
 0.167.2
   - fix regression in osc chroot

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5248,6 +5248,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='Disable results for all direct affect packages inside of the project')
     @cmdln.option('-M', '--multibuild-package', action='append', default=[],
                         help='Only show results for the specified multibuild package')
+    @cmdln.option('-V', '--vertical', action='store_true',
+                        help='list packages vertically instead horizontally for entire project')
     @cmdln.option('-w', '--watch', action='store_true',
                         help='watch the results until all finished building')
     @cmdln.option('', '--xml', action='store_true', default=False,
@@ -5292,7 +5294,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             opts.hide_legend = None
             opts.name_filter = None
             opts.status_filter = None
-            opts.vertical = None
             opts.show_non_building = None
             opts.show_excluded = None
             return self.do_prjresults('prjresults', opts, *args)


### PR DESCRIPTION
dunno about others, but the default horizontal listing is not really
usable. This is at least true if you have more packages than
repostories.