### PR TITLE
fix list of backends for old python-keyring

### DIFF
--- a/osc/credentials.py
+++ b/osc/credentials.py
@@ -199,7 +199,10 @@ class KeyringCredentialsDescriptor(AbstractCredentialsManagerDescriptor):
         self._keyring_backend = keyring_backend
 
     def name(self):
-        return self._keyring_backend.name
+        if hasattr(self._keyring_backend, 'name'):
+            return self._keyring_backend.name
+        else:
+            return self._keyring_backend.__class__.__name__
 
     def description(self):
         return 'Backend provided by python-keyring'


### PR DESCRIPTION
old python-keyring classes have no name method.
This is used instead:

return self._keyring_backend.__class__.__name__