### PR TITLE
custom exception if importing m2crypto fails

### DIFF
--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -22,8 +22,10 @@ try:
     from M2Crypto.SSL.Checker import SSLVerificationError
     from M2Crypto.SSL import SSLError as SSLError
 except:
-    SSLError = None
-    SSLVerificationError = None
+    class SSLError(Exception):
+        pass
+    class SSLVerificationError(Exception):
+        pass
 
 try:
     # import as RPMError because the class "error" is too generic


### PR DESCRIPTION
Tested on a system without python3-m2crypto and this resolves this issue.

fixes #743