### PR TITLE
Remove compat code for Python < 2.6

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -593,14 +593,6 @@ def init_basicauth(config, config_mtime):
         HTTPConnection.send = filterhdrs(HTTPConnection.send, True, 'Cookie', 'Authorization')
         HTTPResponse.begin = filterhdrs(HTTPResponse.begin, False, 'header: Set-Cookie.*\n')
 
-    if sys.version_info < (2, 6):
-        # HTTPS proxy is not supported in old urllib2. It only leads to an error
-        # or, at best, a warning.
-        if 'https_proxy' in os.environ:
-            del os.environ['https_proxy']
-        if 'HTTPS_PROXY' in os.environ:
-            del os.environ['HTTPS_PROXY']
-
     if config['http_debug']:
         # brute force
         def urllib2_debug_init(self, debuglevel=0):


### PR DESCRIPTION
Python 2 is dead, Python < 2.6 even more