### PR TITLE
Fix -n / --name flag on importsrcpkg command.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7900,6 +7900,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             title = opts.title
         if opts.name:
             pac = opts.name
+        elif pac is not None:
+            pac = pac.decode()
         if opts.description:
             descr = opts.description
 
@@ -7908,7 +7910,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print('please specify a package name with the \'--name\' option. ' \
                                 'The automatic detection failed', file=sys.stderr)
             sys.exit(1)
-        pac = pac.decode()
         if conf.config['do_package_tracking']:
             createPackageDir(os.path.join(project.dir, pac), project)
         else:


### PR DESCRIPTION
osc importsrcpkg -n <pacname> does not work as expected.  If the option is supplied, osc
mistakenly tries to "decode" the pac object.  This patch limits the decode
call when pac is not a string.