### PR TITLE
core: remove retry limit on log print

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -6132,7 +6132,6 @@ def print_buildlog(apiurl, prj, package, repository, arch, offset=0, strip_time=
         query['last'] = 1
     if lastsucceeded:
         query['lastsucceeded'] = 1
-    retry_count = 0
     while True:
         query['start'] = offset
         start_offset = offset
@@ -6142,9 +6141,6 @@ def print_buildlog(apiurl, prj, package, repository, arch, offset=0, strip_time=
                 offset += len(data)
                 print_data(data, strip_time)
         except IncompleteRead as e:
-            if retry_count >= 3:
-                raise e
-            retry_count += 1
             data = e.partial
             if len(data):
                 offset += len(data)


### PR DESCRIPTION
If this limit is in place, invoking `buildlog` almost always fails with `IncompleteRead(X bytes read)`. If I remove the retry limit, the `buildlog` just prints the full log as intended. The same applies to `blt`.

Honestly, I do not get why this limit is even in place here. If it is there for some reason, then it either should be increased or another solution should be found because `buildlog` should not fail when it can succeed.

Please review.

Thanks.

Signed-off-by: Oleksandr Natalenko <oleksandr@redhat.com>