### PR TITLE
Use html.escape instead removed cgi.escape

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1241,7 +1241,7 @@ class Osc(cmdln.Cmdln):
         if len(args) < 2 and is_project_dir(os.getcwd()):
             if opts.diff:
                 raise oscerr.WrongOptions('\'--diff\' is not supported in a project working copy')
-            import cgi
+            import html 
             project = store_read_project(os.curdir)
 
             sr_ids = []
@@ -1295,7 +1295,7 @@ class Osc(cmdln.Cmdln):
                         (project, target_prj_block, options_block)
                 actionxml += s
                 xml = """<request> %s <state name="new"/> <description>%s</description> </request> """ % \
-                        (actionxml, cgi.escape(opts.message or ""))
+                        (actionxml, html.escape(opts.message or "", quote=False))
                 u = makeurl(apiurl, ['request'], query='cmd=create&addrevision=1')
                 f = http_POST(u, data=xml)
 
@@ -1874,7 +1874,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         import cgi
         xml = """<request> %s <state name="new"/> <description>%s</description> </request> """ % \
-              (actionsxml, cgi.escape(opts.message or ""))
+              (actionsxml, html.escape(opts.message or "", quote=False))
         u = makeurl(apiurl, ['request'], query='cmd=create')
         f = http_POST(u, data=xml)
 
@@ -1966,7 +1966,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         else:
             r.add_action('add_role', tgt_project=project, tgt_package=package,
               person_name=user, person_role=role)
-        r.description = cgi.escape(opts.message or '')
+        r.description = html.escape(opts.message or '', quote=False)
         r.create(apiurl)
         print(r.reqid)
 
@@ -2083,7 +2083,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         r = Request()
         r.add_action('change_devel', src_project=devel_project, src_package=devel_package,
             tgt_project=project, tgt_package=package)
-        r.description = cgi.escape(opts.message)
+        r.description = html.escape(opts.message, quote=False)
         r.create(self.get_api_url())
         print(r.reqid)
 
@@ -2649,7 +2649,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                                                                 project, package)
                                     msg = "%s (forwarded request %s from %s)" % (rq.description, reqid, rq.creator)
                                     rid = create_submit_request(apiurl, action.tgt_project, action.tgt_package,
-                                                                project, package, cgi.escape(msg))
+                                                                project, package, html.escape(msg, quote=False))
                                     print(msg)
                                     print("New request #", rid)
                                     for req in reqs:
@@ -8221,7 +8221,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
                 import cgi
                 xml = """<request> %s <state name="new"/> <description>%s</description> </request> """ % \
-                      (requestactionsxml, cgi.escape(message or ""))
+                      (requestactionsxml, html.escape(message or "", quote=False))
                 u = makeurl(apiurl, ['request'], query='cmd=create')
                 f = http_POST(u, data=xml)
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -1450,7 +1450,7 @@ class Package:
 
         if not skip_local_service_run:
             r = self.run_source_services(mode="trylocal", verbose=verbose)
-            if r is not 0:
+            if r != 0:
                 # FIXME: it is better to raise this in Serviceinfo.execute with more
                 # information (like which service/command failed)
                 raise oscerr.ServiceRuntimeError('A service failed with error: %d' % r)
@@ -4177,18 +4177,18 @@ def clone_request(apiurl, reqid, msg=None):
 
 # create a maintenance release request
 def create_release_request(apiurl, src_project, message=''):
-    import cgi
+    import html
     r = Request()
     # api will complete the request
     r.add_action('maintenance_release', src_project=src_project)
     # XXX: clarify why we need the unicode(...) stuff
-    r.description = cgi.escape(unicode(message, 'utf8'))
+    r.description = html.escape(unicode(message, 'utf8'), quote=False)
     r.create(apiurl)
     return r
 
 # create a maintenance incident per request
 def create_maintenance_request(apiurl, src_project, src_packages, tgt_project, tgt_releaseproject, opt_sourceupdate, message='', enforce_branching=False, rev=None):
-    import cgi
+    import html
     r = Request()
     if src_packages:
         for p in src_packages:
@@ -4196,7 +4196,7 @@ def create_maintenance_request(apiurl, src_project, src_packages, tgt_project, t
     else:
         r.add_action('maintenance_incident', src_project=src_project, tgt_project=tgt_project, tgt_releaseproject=tgt_releaseproject, opt_sourceupdate = opt_sourceupdate)
     # XXX: clarify why we need the unicode(...) stuff
-    r.description = cgi.escape(unicode(message, 'utf8'))
+    r.description = html.escape(unicode(message, 'utf8'), quote=False)
     r.create(apiurl, addrevision=True, enforce_branching=enforce_branching)
     return r
 
@@ -4205,7 +4205,7 @@ def create_submit_request(apiurl,
                          dst_project=None, dst_package=None,
                          message="", orev=None, src_update=None, dst_updatelink=None):
 
-    import cgi
+    import html
     options_block = ""
     package = ""
     if src_package:
@@ -4241,9 +4241,9 @@ def create_submit_request(apiurl,
        orev or show_upstream_rev(apiurl, src_project, src_package),
        targetxml,
        options_block,
-       cgi.escape(message))
+       html.escape(message, quote=False))
 
-    # Don't do cgi.escape(unicode(message, "utf8"))) above.
+    # Don't do html.escape(unicode(message, "utf8"))) above.
     # Promoting the string to utf8, causes the post to explode with:
     #   uncaught exception: Fatal error: Start tag expected, '&lt;' not found at :1.
     # I guess, my original workaround was not that bad.


### PR DESCRIPTION
Fixes:

`Traceback (most recent call last):
  File "/usr/bin/osc", line 41, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python3.8/site-packages/osc/babysitter.py", line 64, in run
    return prg.main(argv)
  File "/usr/lib/python3.8/site-packages/osc/cmdln.py", line 344, in main
    return self.cmd(args)
  File "/usr/lib/python3.8/site-packages/osc/cmdln.py", line 367, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python3.8/site-packages/osc/cmdln.py", line 501, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python3.8/site-packages/osc/cmdln.py", line 1232, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/usr/lib/python3.8/site-packages/osc/commandline.py", line 1458, in do_submitrequest
    result = create_submit_request(apiurl,
  File "/usr/lib/python3.8/site-packages/osc/core.py", line 4244, in create_submit_request
    cgi.escape(message))
AttributeError: module 'cgi' has no attribute 'escape'
`
`cgi.escape` was deprecated in python 3.2