### PR TITLE
packagequery and repodata bytes fixes

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -480,7 +480,7 @@ def create_deps(pkgqs):
         d = p.supplements()
         if d:
             depfile.append(b's:%s%s' % (id, b' '.join(d)))
-        depfile.append(b'I:%s%s-%s 0-%s' % (id, p.name(), p.evr().encode(), p.arch()))
+        depfile.append(b'I:%s%s-%s 0-%s' % (id, p.name(), p.evr(), p.arch()))
     return depfile
 
 

--- a/osc/util/packagequery.py
+++ b/osc/util/packagequery.py
@@ -151,14 +151,14 @@ class PackageQueryResult:
         raise NotImplementedError
 
     def evr(self):
-        evr = decode_it(self.version())
+        evr = self.version()
 
         if self.release():
-            evr += "-" + decode_it(self.release())
+            evr += b"-" + self.release()
 
         epoch = self.epoch()
         if epoch is not None and epoch != 0:
-            evr = epoch + ":" + evr 
+            evr = epoch + b":" + evr 
         return evr 
 
 


### PR DESCRIPTION
Cleanup the packagequery and repodata module a bit:
- Return bytes in packagequery.PackageQueryResult.evr() instead of a str
- Convert repodata.RepoDataQueryResult to a bytes API

Fixes: #760 ("osc build fails when called with --prefer-pkgs where the
           passed directory is a repodata repository or a subdirectory of one")