### PR TITLE
Fix single service disabled run

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6938,18 +6938,20 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             osc service COMMAND (inside working copy)
             osc service run [SOURCE_SERVICE]
             osc service runall
-            osc service localrun
-            osc service disabledrun
+            osc service manualrun [SOURCE_SERVICE]
+            osc service localrun [SOURCE_SERVICE]
+            osc service disabledrun [SOURCE_SERVICE]
             osc service remoterun [PROJECT PACKAGE]
             osc service merge [PROJECT PACKAGE]
             osc service wait [PROJECT PACKAGE]
 
             COMMAND can be:
-            run         r  run defined services locally, it takes an optional parameter to run only a
+            run         r  run defined services with modes "trylocal", "localonly", or no mode set locally, may take an optional parameter to run only a
                            specified source service. In case parameters exist for this one in _service file
                            they are used.
             runall      ra run all services independent of the used mode
-            manualrun   mr run all services with mode "manual"
+            manualrun   mr run all services with mode "manual", may take an optional parameter to run only a
+                           specified source service
             remoterun   rr trigger a re-run on the server side
             merge          commits all server side generated files and drops the _service definition
             wait           waits until the service finishes and returns with an error if it failed

--- a/osc/core.py
+++ b/osc/core.py
@@ -422,10 +422,13 @@ class Serviceinfo:
                     os.unlink(ent)
 
         allservices = self.services or []
-        if singleservice and not singleservice in allservices:
+        service_names = [s['name'] for s in allservices]
+        if singleservice and singleservice not in service_names:
             # set array to the manual specified singleservice, if it is not part of _service file
-            data = { 'name' : singleservice, 'command' : [ singleservice ], 'mode' : '' }
+            data = { 'name' : singleservice, 'command' : [ singleservice ], 'mode' : callmode }
             allservices = [data]
+        elif singleservice:
+            allservices = [s for s in allservices if s['name'] == singleservice]
 
         if not allservices:
             # short-circuit to avoid a potential http request in vc_export_env
@@ -449,8 +452,6 @@ class Serviceinfo:
         ret = 0
         for service in allservices:
             if callmode != "all":
-                if singleservice and service['name'] != singleservice:
-                    continue
                 if service['mode'] == "buildtime":
                     continue
                 if service['mode'] == "serveronly" and callmode != "local":


### PR DESCRIPTION
Fix single service disabled run

Without this patch, running an individual service that has parameters
defined in the _service file fails:

  $ osc service run obs_scm
  Please specify valid --scm=... options
  Aborting: service call failed:  /usr/lib/obs/service/obs_scm --outdir [snipped]

This is because although the service is defined in the _service file and
the "scm" parameter is set in it, the service wasn't being found in the
data structure and so the service executable wasn't being called with
the parameters supplied in the _service file. This patch corrects the
issue with the services data structure so that the service data isn't
overridden if it is defined in the _service file. A side effect of this
correction is that instead of overriding the service mode with '', the
mode is set and then does not fall into any permissible callmode
category. We assume that explicit use of "service run <service>" means
the user wants the given service to run now rather than under some
automatic condition, and moreover this was the behavior for services
without parameters before this change, so this patch also changes the
conditional to ignore the mode set in the _service file.