### PR TITLE
suggest correct python*-m2crypto flavour

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -526,7 +526,10 @@ def _build_opener(apiurl):
             from M2Crypto import m2urllib2
         except ImportError as e:
             print(e)
-            raise NoSecureSSLError('M2Crypto is needed to access %s in a secure way.\nPlease install python-m2crypto.' % apiurl)
+            if sys.version_info[0] < 3:
+                raise NoSecureSSLError('M2Crypto is needed to access %s in a secure way.\nPlease install python-m2crypto.' % apiurl)
+            else:
+                raise NoSecureSSLError('M2Crypto is needed to access %s in a secure way.\nPlease install python3-m2crypto or try "pip3 install M2Crypto"' % apiurl)
 
         cafile = options.get('cafile', None)
         capath = options.get('capath', None)


### PR DESCRIPTION
When running with old python2, the suggestion to install package 'python-m2crypto' was correct.
With modern python3 these days, the suggestion should be 'python3-m2crypto' 
Also mention "pip3 install M2Crypto" as an alternative, when no such package is available. E.g. Ubuntu 18.04 and up only have python-m2crypto but no pyhton3-m2crypto