### PR TITLE
Add ccache argument for oscrc

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -619,7 +619,7 @@ def main(apiurl, opts, argv):
             buildargs.append('--icecream=%s' % num)
             xp.append('icecream')
             xp.append('gcc-c++')
-    if opts.ccache:
+    if opts.ccache or config['ccache']:
         buildargs.append('--ccache')
         xp.append('ccache')
     if opts.linksources:

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -119,6 +119,7 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'build-jobs': str(_get_processors()),
             'builtin_signature_check': '1',     # by default use builtin check for verify pkgs
             'icecream': '0',
+            'ccache': '0',
 
             'buildlog_strip_time': '0',  # strips the build time from the build log
 
@@ -200,7 +201,7 @@ boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'tr
     'checkout_no_colon', 'checkout_rooted', 'check_for_request_on_action', 'linkcontrol', 'show_download_progress', 'request_show_interactive',
     'request_show_source_buildstatus', 'review_inherit_group', 'use_keyring', 'gnome_keyring', 'no_verify', 'builtin_signature_check',
     'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage',
-    'status_mtime_heuristic', 'print_web_links']
+    'status_mtime_heuristic', 'print_web_links', 'ccache']
 integer_opts = ['build-jobs']
 
 api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']
@@ -276,6 +277,9 @@ apiurl = %(apiurl)s
 
 # strip leading build time information from the build log
 # buildlog_strip_time = 1
+
+# Enable ccache in build roots.
+# ccache = 1
 
 # extra packages to install when building packages locally (osc build)
 # this corresponds to osc build's -x option and can be overridden with that


### PR DESCRIPTION
This fixes #776, adding support for ccache to the oscrc configuration to make it easier for people to use in daily workflows. 