### PR TITLE
add and implement ccache option for getbinaies

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7224,6 +7224,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='also fetch source packages')
     @cmdln.option('--debug', action="store_true",
                   help='also fetch debug packages')
+    @cmdln.option('--ccache', action="store_true",
+                  help='allow fetching ccache archive')
     def do_getbinaries(self, subcmd, opts, *args):
         """${cmd_name}: Download binaries to a local directory
 
@@ -7304,7 +7306,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         for arch in arches:
             for pac in package:
                 binaries = get_binarylist(apiurl, project, repository, arch,
-                                          package=pac, verbose=True)
+                                          package=pac, verbose=True, withccache=opts.ccache)
                 if not binaries:
                     print('no binaries found: Either the package %s ' \
                                         'does not exist or no binaries have been built.' % pac, file=sys.stderr)

--- a/osc/core.py
+++ b/osc/core.py
@@ -5654,9 +5654,12 @@ def get_repos_of_project(apiurl, prj):
         for node2 in node.findall('arch'):
             yield Repo(node.get('name'), node2.text)
 
-def get_binarylist(apiurl, prj, repo, arch, package=None, verbose=False):
+def get_binarylist(apiurl, prj, repo, arch, package=None, verbose=False, withccache=False):
     what = package or '_repository'
-    u = makeurl(apiurl, ['build', prj, repo, arch, what])
+    query = {}
+    if withccache:
+        query['withccache'] = 1
+    u = makeurl(apiurl, ['build', prj, repo, arch, what], query=query)
     f = http_GET(u)
     tree = ET.parse(f)
     if not verbose:


### PR DESCRIPTION
If this option is used, the api is asked to list ccache archive if
present, osc will then download the archive.