### PR TITLE
add option pkg-ccache to be passed to build-cmd

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -622,6 +622,9 @@ def main(apiurl, opts, argv):
     if opts.ccache or config['ccache']:
         buildargs.append('--ccache')
         xp.append('ccache')
+    if opts.pkg_ccache:
+        buildargs.append('--pkg-ccache=%s' % opts.pkg_ccache)
+        xp.append('ccache')
     if opts.linksources:
         buildargs.append('--linksources')
     if opts.baselibs:

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6303,6 +6303,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='use N parallel build jobs with icecream')
     @cmdln.option('--ccache', action='store_true',
                   help='use ccache to speed up rebuilds')
+    @cmdln.option('--pkg-ccache', metavar='/path/to/_ccache.tar',
+                  help='path to an existing uncompressed archive ccache. Using this option implies --ccache')
     @cmdln.option('--with', metavar='X', dest='_with', action='append',
                   help='enable feature X for build')
     @cmdln.option('--without', metavar='X', action='append',


### PR DESCRIPTION
this option is a /path/to/_ccache.tar. The patch just forwards that
option to the build script.