### PR TITLE
Fix and standardize ElementTree imports for Python 3.9

### DIFF
--- a/README
+++ b/README
@@ -24,10 +24,6 @@ Alternatively, you can directly use osc-wrapper.py from the source dir
 (which is easier if you develop on osc).
 
 
-The program needs the cElementTree python module installed. On SUSE, the
-respective package is called python-elementtree (before 10.2: python-xml).
-
-
 
 CONFIGURATION:
 

--- a/osc/build.py
+++ b/osc/build.py
@@ -28,9 +28,12 @@ import osc.conf
 from . import oscerr
 import subprocess
 try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
     from xml.etree import cElementTree as ET
 except ImportError:
-    import cElementTree as ET
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
 
 from .conf import config, cookiejar
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -47,11 +47,13 @@ except ImportError:
     from cStringIO import StringIO
     from httplib import IncompleteRead
 
-
 try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
     from xml.etree import cElementTree as ET
 except ImportError:
-    import cElementTree as ET
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
 
 from . import oscerr
 from . import conf
@@ -816,7 +818,7 @@ class Project:
 
     def read_packages(self):
         """
-        Returns an ``xml.etree.cElementTree`` object representing the
+        Returns an ``xml.etree.ElementTree`` object representing the
         parsed contents of the project's ``.osc/_packages`` XML file.
         """
         global store

--- a/osc/util/repodata.py
+++ b/osc/util/repodata.py
@@ -5,11 +5,13 @@ information instead of scanning individual rpms."""
 import gzip
 import os.path
 
-# cElementTree can be standard or 3rd-party depending on python version
 try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
     from xml.etree import cElementTree as ET
 except ImportError:
-    import cElementTree as ET
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
 
 # project modules
 import osc.util.rpmquery

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,7 +4,13 @@ import shutil
 import tempfile
 import os
 import sys
-from xml.etree import cElementTree as ET
+try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
+    from xml.etree import cElementTree as ET
+except ImportError:
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
 EXPECTED_REQUESTS = []
 
 if sys.version_info[0:2] in ((2, 6), (2, 7)):

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -3,7 +3,13 @@ import osc.oscerr
 import os
 import sys
 from common import GET, PUT, POST, DELETE, OscTestCase
-from xml.etree import cElementTree as ET
+try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
+    from xml.etree import cElementTree as ET
+except ImportError:
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
 try:
     from urllib.error import HTTPError
 except ImportError:

--- a/tests/test_repairwc.py
+++ b/tests/test_repairwc.py
@@ -3,7 +3,13 @@ import osc.oscerr
 import os
 import sys
 from common import GET, PUT, POST, DELETE, OscTestCase
-from xml.etree import cElementTree as ET
+try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
+    from xml.etree import cElementTree as ET
+except ImportError:
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
 FIXTURES_DIR = os.path.join(os.getcwd(), 'repairwc_fixtures')
 
 def suite():

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,3 +1,11 @@
+try:
+    # Works up to Python 3.8, needed for Python < 3.3 (inc 2.7)
+    from xml.etree import cElementTree as ET
+except ImportError:
+    # will import a fast implementation from 3.3 onwards, needed
+    # for 3.9+
+    from xml.etree import ElementTree as ET
+
 import osc.core
 import osc.oscerr
 import os
@@ -252,7 +260,6 @@ class TestRequest(OscTestCase):
 
     def test_action_from_xml1(self):
         """create action from xml"""
-        from xml.etree import cElementTree as ET
         xml = """<action type="add_role">
   <target package="bar" project="foo" />
   <person name="user" role="reader" />
@@ -270,7 +277,6 @@ class TestRequest(OscTestCase):
 
     def test_action_from_xml2(self):
         """create action from xml"""
-        from xml.etree import cElementTree as ET
         xml = """<action type="submit">
   <source package="bar" project="foo" />
   <target package="bar" project="foobar" />
@@ -292,7 +298,6 @@ class TestRequest(OscTestCase):
 
     def test_action_from_xml3(self):
         """create action from xml (with acceptinfo element)"""
-        from xml.etree import cElementTree as ET
         xml = """<action type="submit">
   <source package="bar" project="testprj" />
   <target package="baz" project="foobar" />
@@ -316,13 +321,11 @@ class TestRequest(OscTestCase):
 
     def test_action_from_xml_unknown_type(self):
         """try to create action from xml with unknown type"""
-        from xml.etree import cElementTree as ET
         xml = '<action type="foo"><source package="bar" project="foo" /></action>'
         self.assertRaises(osc.oscerr.WrongArgs, osc.core.Action.from_xml, ET.fromstring(xml))
 
     def test_read_request1(self):
         """read in a request"""
-        from xml.etree import cElementTree as ET
         xml = open(os.path.join(self._get_fixtures_dir(), 'test_read_request1.xml'), 'r').read().strip()
         r = osc.core.Request()
         r.read(ET.fromstring(xml))
@@ -354,7 +357,6 @@ class TestRequest(OscTestCase):
 
     def test_read_request2(self):
         """read in a request (with reviews)"""
-        from xml.etree import cElementTree as ET
         xml = open(os.path.join(self._get_fixtures_dir(), 'test_read_request2.xml'), 'r').read().strip()
         r = osc.core.Request()
         r.read(ET.fromstring(xml))
@@ -393,7 +395,6 @@ class TestRequest(OscTestCase):
 
     def test_read_request3(self):
         """read in a request (with an "empty" comment+description)"""
-        from xml.etree import cElementTree as ET
         xml = """<request creator="xyz" id="2">
   <action type="set_bugowner">
     <target project="foo" />
@@ -430,7 +431,6 @@ class TestRequest(OscTestCase):
 
     def test_request_list_view1(self):
         """test the list_view method"""
-        from xml.etree import cElementTree as ET
         xml = open(os.path.join(self._get_fixtures_dir(), 'test_request_list_view1.xml'), 'r').read().strip()
         exp = """\
     62  State:new        By:Admin        When:2010-12-29T14:57:25
@@ -448,7 +448,6 @@ class TestRequest(OscTestCase):
 
     def test_request_list_view2(self):
         """test the list_view method (with history elements and description)"""
-        from xml.etree import cElementTree as ET
         xml = open(os.path.join(self._get_fixtures_dir(), 'test_request_list_view2.xml'), 'r').read().strip()
         r = osc.core.Request()
         r.read(ET.fromstring(xml))
@@ -462,7 +461,6 @@ class TestRequest(OscTestCase):
         self.assertEqual(exp, r.list_view())
 
     def test_request_str1(self):
-        from xml.etree import cElementTree as ET
         """test the __str__ method"""
         xml = open(os.path.join(self._get_fixtures_dir(), 'test_request_str1.xml'), 'r').read().strip()
         r = osc.core.Request()
@@ -496,7 +494,6 @@ History: 2010-12-12T00:00:00 creator      revoked
 
     def test_request_str2(self):
         """test the __str__ method"""
-        from xml.etree import cElementTree as ET
         xml = """\
 <request creator="creator" id="98765">
   <action type="change_devel">
@@ -527,7 +524,6 @@ Comment: <no comment>"""
 
     def test_legacy_request(self):
         """load old-style submitrequest"""
-        from xml.etree import cElementTree as ET
         xml = """\
 <request creator="olduser" id="1234" type="submit">
   <submit>
@@ -563,7 +559,6 @@ Comment: <no comment>"""
 
     def test_get_actions(self):
         """test get_actions method"""
-        from xml.etree import cElementTree as ET
         xml = open(os.path.join(self._get_fixtures_dir(), 'test_request_list_view1.xml'), 'r').read().strip()
         r = osc.core.Request()
         r.read(ET.fromstring(xml))


### PR DESCRIPTION
Importing `cElementTree` has been deprecated since Python 3.3 -
importing `ElementTree` automatically uses the fastest
implementation available - and is finally removed in Python 3.9.
Importing cElementTree directly (not as part of xml) is an even
older relic, it's for Ye Time Before ElementTree Was Added To
Python and it was instead an external module...which was before
Python 2.5. So let's just standardize on importing ElementTree
from xml.etree. Also, let's not repeat this import 12 times in
one file for some reason.

Signed-off-by: Adam Williamson <awilliam@redhat.com>