### PR TITLE
Fix python2 regression in util.helper.decode_it

### DIFF
--- a/osc/util/helper.py
+++ b/osc/util/helper.py
@@ -56,14 +56,14 @@ def decode_list(ilist):
 
 
 def decode_it(obj):
-    """Decode the given object.
+    """Decode the given object unless it is a str.
 
-    If the given object has no decode method, the object itself is
+    If the given object is a str or has no decode method, the object itself is
     returned. Otherwise, try to decode the object using utf-8. If this
     fails due to a UnicodeDecodeError, try to decode the object using
     latin-1.
     """
-    if not hasattr(obj, 'decode'):
+    if isinstance(obj, str) or not hasattr(obj, 'decode'):
         return obj
     try:
         return obj.decode('utf-8')


### PR DESCRIPTION
In commit 276d6e2439c8c53c182dbe785b038919e64da9f3 ("Do not use the
chardet module in util.helper.decode_it") util.helper.decode_it was
changed to always decode the passed object if it has a decode method.
Since a python2 str has a decode method, the new code tries to utf-8
decode the passed str. As a result, a unicode object is returned (if
the decoding worked). Since a unicode object is not an instance of
type str, all subsequent isinstance(decoded_obj, str) checks evaluate
to False, which break some codepaths.
In order to fix this, restore the old python2 behavior (that is, if
the passed object is a str, it is not decode it). This change does not
affect the python3 codepaths.

Fixes: #814 ("osc log | fails")