### PR TITLE
interpretation of string literals in messages

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -911,6 +911,10 @@ class Osc(cmdln.Cmdln):
         # If project or package arguments missing, assume to work
         # with project and/or package in current local directory.
         attributepath = []
+
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
+
         if cmd in ['prj', 'prjconf']:
             if len(args) < 1:
                 apiurl = store_read_apiurl(os.curdir)
@@ -1211,6 +1215,9 @@ class Osc(cmdln.Cmdln):
             src_update = "update"
         elif opts.no_update:
             src_update = "noupdate"
+
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         myreqs = []
         if opts.supersede:
@@ -1872,6 +1879,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if not opts.message:
             opts.message = edit_message()
+        else:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         xml = """<request> %s <state name="new"/> <description>%s</description> </request> """ % \
               (actionsxml, _html_escape(opts.message or ""))
@@ -1949,6 +1958,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongOptions('invalid \'--role\': either specify \'maintainer\' or \'bugowner\'')
         if not opts.message:
             opts.message = edit_message()
+        else:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         r = Request()
         if user.startswith('group:'):
@@ -2027,6 +2038,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 footer = textwrap.TextWrapper(width = 66).fill(
                          'please explain why you like to delete project %s' % project)
             opts.message = edit_message(footer)
+        else:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         r = Request()
         r.add_action('delete', tgt_project=project, tgt_package=package, tgt_repository=repository)
@@ -2074,6 +2087,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                      'please explain why you like to change the devel project of %s/%s to %s/%s'
                      % (project, package, devel_project, devel_package))
             opts.message = edit_message(footer)
+        else:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         r = Request()
         r.add_action('change_devel', src_project=devel_project, src_package=devel_package,
@@ -2240,6 +2255,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if opts.incoming:
             conf.config['include_request_from_project'] = False
+
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         if args[0] == 'help':
             return self.do_help(['help', 'request'])
@@ -2785,7 +2803,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('Too many arguments (required none or two)')
         else:
             raise oscerr.WrongArgs('Too few arguments (required none or two)')
-
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
         try:
             copy_pac(apiurl, project, package, apiurl, project, package, expand=True, comment=opts.message)
         except HTTPError as e:
@@ -2990,7 +3009,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         rev, dummy = parseRevisionOption(opts.revision)
 
         if opts.message:
-            comment = opts.message
+            comment = str(opts.message.encode().decode('unicode_escape'))
         else:
             if not rev:
                 rev = show_upstream_rev(src_apiurl, src_project, src_package)
@@ -3123,6 +3142,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if not opts.message:
             opts.message = edit_message()
+        else:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         r = create_release_request(apiurl, source_project, opts.message)
         print(r.reqid)
@@ -3156,6 +3177,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         maintenance_attribute = conf.config['maintenance_attribute']
         if opts.attribute:
             maintenance_attribute = opts.attribute
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         source_project = target_project = None
 
@@ -3292,6 +3315,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if not opts.message:
             opts.message = edit_message()
+        else:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
 
         supersede_existing = False
         reqs = []
@@ -3508,6 +3533,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if len(args) >= 4:
             tpackage = args[3]
 
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
+
         try:
           exists, targetprj, targetpkg, srcprj, srcpkg = \
                 branch_pkg(apiurl, args[0], args[1],
@@ -3601,7 +3629,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         msg = ''
         if opts.message:
-            msg = opts.message
+            msg = str(opts.message.encode().decode('unicode_escape'))
         else:
             msg = edit_message()
 
@@ -3648,7 +3676,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         msg = ''
         if opts.message:
-            msg = opts.message
+            msg = str(opts.message.encode().decode('unicode_escape'))
         else:
             msg = edit_message()
 
@@ -3694,6 +3722,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         ${cmd_option_list}
         """
         apiurl = self.get_api_url()
+        if opts.message:
+            opts.message = str(opts.message.encode().decode('unicode_escape'))
         kind = 'prj'
         path_args = (project,)
         if package is not None:
@@ -3734,7 +3764,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         msg = ''
         if opts.message:
-            msg = opts.message
+            msg = str(opts.message.encode().decode('unicode_escape'))
         else:
             msg = edit_message()
 
@@ -4810,7 +4840,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         msg = ''
         if opts.message:
-            msg = opts.message
+            msg = str(opts.message.encode().decode('unicode_escape'))
         elif opts.file:
             if opts.file == '-':
                 msg = sys.stdin.read()
@@ -8240,7 +8270,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
             if requestactionsxml != "":
                 if opts.message:
-                    message = opts.message
+                    message = str(opts.message.encode().decode('unicode_escape'))
                 else:
                     message = edit_message()
 


### PR DESCRIPTION
string literals are not interpreted correctly when using `-m "my\ntwo line message"`

fixes https://github.com/openSUSE/osc/issues/801