### PR TITLE
Add alias "manualrun" for deprecated "disabledrun"

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6949,12 +6949,14 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                            specified source service. In case parameters exist for this one in _service file
                            they are used.
             runall      ra run all services independent of the used mode
-            localrun    lr run all services except the ones with mode "buildtime", "disabled", or
-                           "serveronly" (deprecated)
-            disabledrun dr run all services with mode "disabled" or "serveronly" (deprecated)
+            manualrun   mr run all services with mode "manual"
             remoterun   rr trigger a re-run on the server side
             merge          commits all server side generated files and drops the _service definition
             wait           waits until the service finishes and returns with an error if it failed
+
+            Not for common usage anymore:
+            localrun    lr the same as "run" but services with mode "serveronly" are also executed
+            disabledrun dr run all services with mode "disabled"
 
         ${cmd_option_list}
         """
@@ -6988,7 +6990,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         command = args[0]
 
-        if not (command in ( 'runall', 'ra', 'run', 'localrun', 'disabledrun', 'remoterun', 'lr', 'dr', 'r', 'rr', 'merge', 'wait' )):
+        if not (command in ( 'runall', 'ra', 'run', 'localrun', 'manualrun', 'disabledrun', 'remoterun', 'lr', 'dr', 'mr', 'rr', 'merge', 'wait' )):
             raise oscerr.WrongArgs('Wrong command given.')
 
         if command == "remoterun" or command == "rr":
@@ -7003,12 +7005,14 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print(mergeservice(apiurl, project, package))
             return
 
-        if command in ('runall', 'ra', 'run', 'localrun', 'disabledrun', 'lr', 'dr', 'r'):
+        if command in ('runall', 'ra', 'run', 'localrun', 'manualrun', 'disabledrun', 'lr', 'mr', 'dr', 'r'):
             if not is_package_dir(os.curdir):
                 raise oscerr.WrongArgs('Local directory is no package')
             p = Package(".")
             if command == "localrun" or command == "lr":
                 mode = "local"
+            elif command == "manualrun" or command == "mr":
+                mode = "manual"
             elif command == "disabledrun" or command == "dr":
                 mode = "disabled"
             elif command == "runall" or command == "ra":

--- a/osc/core.py
+++ b/osc/core.py
@@ -453,7 +453,11 @@ class Serviceinfo:
                     continue
                 if service['mode'] == "buildtime":
                     continue
-                if service['mode'] == "serveronly" and callmode != "disabled":
+                if service['mode'] == "serveronly" and callmode != "local":
+                    continue
+                if service['mode'] == "manual" and callmode != "manual":
+                    continue
+                if service['mode'] != "manual" and callmode == "manual":
                     continue
                 if service['mode'] == "disabled" and callmode != "disabled":
                     continue
@@ -479,7 +483,7 @@ class Serviceinfo:
                     #        updating _services.
                     return r
 
-                if service['mode'] == "disabled" or service['mode'] == "trylocal" or service['mode'] == "localonly" or callmode == "local" or callmode == "trylocal" or callmode == "all":
+                if service['mode'] == "manual" or service['mode'] == "disabled" or service['mode'] == "trylocal" or service['mode'] == "localonly" or callmode == "local" or callmode == "trylocal" or callmode == "all":
                     for filename in os.listdir(temp_dir):
                         os.rename(os.path.join(temp_dir, filename), os.path.join(dir, filename))
                 else:


### PR DESCRIPTION
The "disabledrun" service commands is marked as deprecated but has no
explicit replacement. It is still a useful command for updating packages
manually or through a CI system without being forced to run all defined
services with the "runall" command. This change adds an alias
"manualrun" and a new mode "manual" which behave the same as the
deprecated "disabledrun" command and "disabled" mode but have clearer
meaning.

Followup from discussion on https://github.com/openSUSE/osc/pull/769