### PR TITLE
maintainer search: lookup via package name by default and binary as fallback

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.171
+  - maintainer search: lookup via package name by default and binary as fallback
+
 0.170
   - fix code for python3.8 and python3.9
   - remove dead code

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8183,7 +8183,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         """${cmd_name}: Show maintainers according to server side configuration
 
             # Search for official maintained sources in OBS instance
-            osc maintainer BINARY <options>
+            osc maintainer BINARY_OR_PACKAGE_NAME <options>
             osc maintainer -U <user> <options>
             osc maintainer -G <group> <options>
 
@@ -8231,7 +8231,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     opts.set_bugowner_request = bugowner
                     opts.set_bugowner = None
 
-        binary = None
+        search_term = None
         prj = None
         pac = None
         metaroot = None
@@ -8253,8 +8253,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 pass
             prj = store_read_project('.')
         elif len(args) == 1:
-            # it is unclear if one argument is a binary or a project, try binary first for new OBS 2.4
-            binary = prj = args[0]
+            # it is unclear if one argument is a search_term or a project, try search_term first for new OBS 2.4
+            search_term = prj = args[0]
         elif len(args) == 2:
             prj = args[0]
             pac = args[1]
@@ -8264,7 +8264,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
 
         # Try the OBS 2.4 way first.
-        if binary or opts.user or opts.group:
+        if search_term or opts.user or opts.group:
             limit = None
             if opts.all:
                 limit = 0
@@ -8272,13 +8272,17 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             if filterroles == [ 'bugowner', 'maintainer' ]:
                 # use server side configured default
                 filterroles = None
-            if binary:
-                searchresult = owner(apiurl, binary, "binary", usefilter=filterroles, devel=None, limit=limit)
+            if search_term:
+                # try the package name first, it is faster and may catch cases where no
+                # binary with that name exists for the given package name
+                searchresult = owner(apiurl, search_term, "package", usefilter=filterroles, devel=None, limit=limit)
+                if searchresult == None or len(searchresult) == 0:
+                    searchresult = owner(apiurl, search_term, "binary", usefilter=filterroles, devel=None, limit=limit)
                 if searchresult != None and len(searchresult) == 0:
                     # We talk to an OBS 2.4 or later understanding the call
                     if opts.set_bugowner or opts.set_bugowner_request:
                         # filtered search did not succeed, but maybe we want to set an owner initially?
-                        searchresult = owner(apiurl, binary, "binary", usefilter="", devel=None, limit=-1)
+                        searchresult = owner(apiurl, search_term, "binary", usefilter="", devel=None, limit=-1)
                         if searchresult:
                             print("WARNING: the binary exists, but has no matching maintainership roles defined.")
                             print("Do you want to set it in the container where the binary appeared first?")

--- a/osc/core.py
+++ b/osc/core.py
@@ -6809,12 +6809,21 @@ def search(apiurl, queries=None, **kwargs):
         res[urlpath] = ET.parse(f).getroot()
     return res
 
-def owner(apiurl, binary, mode="binary", attribute=None, project=None, usefilter=None, devel=None, limit=None):
+def owner(apiurl, search_term=None, mode="binary", attribute=None,
+          project=None, usefilter=None, devel=None, limit=None, binary=None):
     """
     Perform a binary package owner search. This is supported since OBS 2.4.
     """
+
+    # binary is just for API backward compatibility
+    if not ((search_term is None) ^ (binary is None)):
+        raise ValueError('Either specify search_term or binary')
+    elif binary is not None:
+        search_term = binary
+ 
     # find default project, if not specified
-    query = { mode: binary }
+    # mode can be "binary" or "package" atm
+    query = { mode: search_term }
     if attribute:
         query['attribute'] = attribute
     if project:


### PR DESCRIPTION

This is faster in best case since the binary search does not need
to be executed on the server.

It also finds package names where no binary with that name exists.
(as for some multibuild cases)