### PR TITLE
fix content of osc workerinfo --help

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6079,9 +6079,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         """${cmd_name}: gets the information to a worker from the server
 
         Examples:
-            osc workerinfo <workername>
+            osc workerinfo x86_64:goat:1
 
-        ${cmd_usage}
+        Usage:
+            osc workerinfo <hostarch>:<workerid>
+
         ${cmd_option_list}
         """
         apiurl = self.get_api_url()


### PR DESCRIPTION
Replace usage with better explanation. It was missing that it requires a
prefixed hostarch. Also workername is instead called workerid in the
API.

Usage help was before: osc workerinfo WORKER

Add actual example.

See also the fix for this in OBS API docs:
openSUSE/open-build-service#10024