### PR TITLE
maintenance_request: verify right target for superseding

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4438,7 +4438,8 @@ def get_exact_request_list(apiurl, src_project, dst_project, src_package=None, d
     xpath += " and action[source/@project='%s'" % src_project
     if src_package:
         xpath += " and source/@package='%s'" % src_package
-    xpath += " and target/@project='%s'" % dst_project
+    xpath += " and ((target/@project='%s' and action/@type='submit')"  % dst_project
+    xpath += "      or (target/@releaseproject='%s' and action/@type='maintenance_incident'))" % dst_project
     if dst_package:
         xpath += " and target/@package='%s'" % dst_package
     xpath += "]"


### PR DESCRIPTION
NOTE: this is more a bugreport then a pull request atm...

We need to check against releaseproject instead of targetproject for
maintenance_incident. Since target_project is almost always the one
maintenance project (eg. openSUSE:Maintenance).

WARNING: this relies on a new xpath query support which is not available
         yet! Also no compat code implemented yet.