### PR TITLE
use sr_ids[0] for superseding

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1329,7 +1329,7 @@ class Osc(cmdln.Cmdln):
             if len(myreqs) > 0:
                 for req in myreqs:
                     change_request_state(apiurl, str(req), 'superseded',
-                                             'superseded by %s' % result, result)
+                                             'superseded by %s' % sr_ids[0], sr_ids[0])
 
             sys.exit('Successfully finished')
 


### PR DESCRIPTION
result is not assigned in the case of many packages per request

fixes https://github.com/openSUSE/osc/issues/849