### PR TITLE
Fix show_upstream_rev call in checkRevision

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -6689,7 +6689,7 @@ def checkRevision(prj, pac, revision, apiurl=None, meta=False):
     if not apiurl:
         apiurl = conf.config['apiurl']
     try:
-        if int(revision) > int(show_upstream_rev(apiurl, prj, pac, meta)) \
+        if int(revision) > int(show_upstream_rev(apiurl, prj, pac, meta=meta)) \
            or int(revision) <= 0:
             return False
         else:


### PR DESCRIPTION
If meta=True is passed to checkRevision, the meta parameter is used
as a revision in the show_upstream_rev call. Instead, it should be
bound to show_upstream_rev's meta parameter.