### PR TITLE
Use python3 in osc-wrapper

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # this wrapper exists so it can be put into /usr/bin, but still allows the
 # python module to be called within the source directory during development


### PR DESCRIPTION
Use `python3` in `osc-wrapper.py`
because python2 is obsolete
and we dont want to install `python2-m2crypto` and other deps
just for development