### PR TITLE
Use verifymd5 to determine freshness

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -1244,6 +1244,13 @@ class Package:
                 self.in_conflict.remove(fname)
                 self.write_conflictlist()
 
+    def _compute_verifymd5(self):
+        md5str = ''
+        for f in self.filelist:
+            if f.name != '_link':
+                md5str += f.md5+'  '+f.name+"\n"
+        return hashlib.md5(md5str.encode('utf-8')).hexdigest()
+
     def info(self):
         source_url = makeurl(self.apiurl, ['source', self.prjname, self.name])
         r = info_templ % (self.prjname, self.name, self.absdir, self.apiurl, source_url, self.srcmd5, self.rev, self.linkinfo)
@@ -2254,6 +2261,8 @@ rev: %s
     def update_needed(self, sinfo):
         # this method might return a false-positive (that is a True is returned,
         # even though no update is needed) (for details, see comments below)
+        if sinfo.get('verifymd5') == self._compute_verifymd5():
+            return False
         if self.islink():
             if self.isexpanded():
                 # check if both revs point to the same expanded sources


### PR DESCRIPTION
Use `verifymd5` to determine freshness
to speed up `osc up` for large repo checkouts by a factor of 10 or more

The verifymd5 value is not (yet) stored
so we quickly compute it as needed

Fixes https://github.com/openSUSE/open-build-service/issues/10250

In my test, it is now possible to finish `osc up` of `openSUSE:Factory` across the Atlantic (165ms RTT) in just 93 seconds.

Note: Needs testing with OBS services

could also profit from a review by @mlschroe or @adrianschroeter