### PR TITLE
Do not retrieve the package list when initializing a project via osc …

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -242,7 +242,8 @@ class Osc(cmdln.Cmdln):
         apiurl = self.get_api_url()
 
         if not package:
-            Project.init_project(apiurl, os.curdir, project, conf.config['do_package_tracking'])
+            Project.init_project(apiurl, os.curdir, project, conf.config['do_package_tracking'],
+                                 getPackageList=False)
             print('Initializing %s (Project: %s)' % (os.curdir, project))
         else:
             Package.init_package(apiurl, project, package, os.curdir)


### PR DESCRIPTION
…init

Currently, when trying to initialize a non existent (server-side)
project via "osc init <prj>", osc errors out (after creating the wc)
because it fails to retrieve the package list. However, there is no
need to retrieve the package list in the "osc init <prj>" case. Hence,
skip the package list retrieval. As a result, osc does not error out.

For the background, see the discussion in #858 ("osc fails to check
out an empty project as project") [1].

[1] https://github.com/openSUSE/osc/issues/858#issuecomment-722330024