### PR TITLE
Fix a potential TypeError in CpioRead.copyin and CpioRead.copyin_file

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -90,8 +90,8 @@ class Fetcher:
                     try:
                         fd, tmpfile = tempfile.mkstemp(prefix='osc_build_file')
                         archive.copyin_file(hdr.filename,
-                                            os.path.dirname(tmpfile),
-                                            os.path.basename(tmpfile))
+                                            decode_it(os.path.dirname(tmpfile)),
+                                            decode_it(os.path.basename(tmpfile)))
                         self.move_package(tmpfile, pac.localdir, pac)
                     finally:
                         os.close(fd)

--- a/osc/util/cpio.py
+++ b/osc/util/cpio.py
@@ -182,7 +182,7 @@ class CpioRead:
         hdr = self._get_hdr(filename)
         if not hdr:
             raise CpioError(filename, '\'%s\' does not exist in archive' % filename)
-        dest = dest or os.getcwd()
+        dest = dest or os.getcwd().encode()
         fn = new_fn or filename
         self._copyin_file(hdr, dest, fn)
 
@@ -191,7 +191,7 @@ class CpioRead:
         extracts the cpio archive to dest.
         If dest is None $PWD will be used.
         """
-        dest = dest or os.getcwd()
+        dest = dest or os.getcwd().encode()
         for h in self.hdrs:
             self._copyin_file(h, dest, h.filename)
 


### PR DESCRIPTION
If no "dest" argument is specified when calling CpioRead.copyin or
CpioRead.copyin_file, a TypeError occurs in CpioRead._copyin_file
because os.getcwd(), which returns a str, is used as dest and, hence,
the subsequent os.path.join(...) fails (because it tries to join a
str and a bytes).
In order to avoid this, encode the result of os.getcwd().

Note that the existing

archive.copyin_file(hdr.filename,
                    os.path.dirname(tmpfile),
                    os.path.basename(tmpfile))

was OK because CpioRead._copyin_file os.path.join()s "dest" and
"new_fn", which are both str. It is just changed to stress that
CpioRead is a bytes-only API.

Fixes: #865 ("Traceback in osc/util/cpio.py line 128: TypeError:
Can't mix strings and bytes in path components")