### PR TITLE
Some os.getcwd() fixes in osc.util

### DIFF
--- a/osc/util/ar.py
+++ b/osc/util/ar.py
@@ -72,7 +72,7 @@ class ArFile(BytesIO):
         and permissions.
         """
         if not dir:
-            dir = os.getcwd()
+            dir = os.getcwdb()
         fn = os.path.join(dir, self.name)
         with open(fn, 'wb') as f:
             f.write(self.getvalue())

--- a/osc/util/cpio.py
+++ b/osc/util/cpio.py
@@ -182,7 +182,7 @@ class CpioRead:
         hdr = self._get_hdr(filename)
         if not hdr:
             raise CpioError(filename, '\'%s\' does not exist in archive' % filename)
-        dest = dest or os.getcwd().encode()
+        dest = dest or os.getcwdb()
         fn = new_fn or filename
         self._copyin_file(hdr, dest, fn)
 
@@ -191,7 +191,7 @@ class CpioRead:
         extracts the cpio archive to dest.
         If dest is None $PWD will be used.
         """
-        dest = dest or os.getcwd().encode()
+        dest = dest or os.getcwdb()
         for h in self.hdrs:
             self._copyin_file(h, dest, h.filename)
 


### PR DESCRIPTION
- Avoid a potential TypeError in util.ArFile.saveTo
- Use os.getcwdb() instead of os.getcwd().encode() in util.cpio.CpioRead

(For the details, see the commit descriptions.)