### PR TITLE
RFC: Support a regex based name filtering in core.get_prj_results

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5891,6 +5891,9 @@ def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=Non
     f = show_prj_results_meta(apiurl, prj)
     root = ET.fromstring(b''.join(f))
 
+    if name_filter is not None:
+        name_filter = re.compile(name_filter)
+
     pacs = []
     # sequence of (repo,arch) tuples
     targets = []
@@ -5945,12 +5948,12 @@ def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=Non
                             if not name_filter:
                                 pacs_to_show.append(pkg)
                                 targets_to_show.append(repo)
-                            elif name_filter in pkg:
+                            elif name_filter.search(pkg) is not None:
                                 pacs_to_show.append(pkg)
         #filtering for Package Name
         elif name_filter:
             for pkg in pacs:
-                if name_filter in pkg:
+                if name_filter.search(pkg) is not None:
                     pacs_to_show.append(pkg)
 
         #filter non building states


### PR DESCRIPTION
This breaks the existing API (see below). Hence, feedback is welcome:)

So far, core.get_prj_results only supports a substring based name
filtering mechanism. Now, a regex based name filtering mechanism
is used. That is, if the regex matches a package name, the package
is not filtered out.

This is an API incompatible change:
- 3rd party code which looks like this is going to break:
  class Foo(str):
      ...
      def __eq__(self, other):
          return ...

  ... = core.get_prj_results(..., name_filter=Foo())

  (My gut feeling says there are no such callers. However, if this
  really breaks any serious code, we can fix it in a follow-up commit)

- "osc prjresults openSUSE:Leap:15.2:Update --name-filter zypper." will
  now also show "zypper-docker" etc. because the dot (".") matches any
  character (except a newline). Previously, only packages that contained
  the str "zypper" followed by a dot (".") were shown. The old behavior
  can be restored, if the dot is escaped: "osc prjresults
  openSUSE:Leap:15.2:Update --name-filter 'zypper\.'".
  Of course, this affects all other special characters, too.
  Additionally, if an illegal regex is passed to the --name-filter option,
  an exception is raised. The previous code did not fail.

  This can break existing workflows and scripts. We could avoid this by
  introducing a --name-filter-regex option but this would clutter the
  UI (IMHO).

A regex based name filtering feature was requested by @darix .