### PR TITLE
Avoid superfluous/excessive usage of _html_escape

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1976,7 +1976,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         else:
             r.add_action('add_role', tgt_project=project, tgt_package=package,
               person_name=user, person_role=role)
-        r.description = _html_escape(opts.message or '')
+        r.description = opts.message
         r.create(apiurl)
         print(r.reqid)
 
@@ -2043,7 +2043,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         r = Request()
         r.add_action('delete', tgt_project=project, tgt_package=package, tgt_repository=repository)
-        r.description = _html_escape(opts.message)
+        r.description = opts.message
         if opts.accept_in_hours:
           r.accept_at_in_hours(int(opts.accept_in_hours))
         r.create(self.get_api_url())
@@ -2093,7 +2093,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         r = Request()
         r.add_action('change_devel', src_project=devel_project, src_package=devel_package,
             tgt_project=project, tgt_package=package)
-        r.description = _html_escape(opts.message)
+        r.description = opts.message
         r.create(self.get_api_url())
         print(r.reqid)
 
@@ -2661,7 +2661,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                                                                                 project, package)
                                     msg = "%s (forwarded request %s from %s)" % (rq.description, reqid, rq.creator)
                                     rid = create_submit_request(apiurl, action.tgt_project, action.tgt_package,
-                                                                project, package, _html_escape(msg))
+                                                                project, package, msg)
                                     print(msg)
                                     print("New request #", rid)
                                     for req in reqs:
@@ -3169,7 +3169,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     r.add_action('release', src_project=source_project, src_package=pac)
             else:
                 r.add_action('release', src_project=source_project)
-            r.description = _html_escape(opts.message)
+            r.description = opts.message
             r.create(apiurl)
         print(r.reqid)
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -4191,7 +4191,7 @@ def create_release_request(apiurl, src_project, message=''):
     # api will complete the request
     r.add_action('maintenance_release', src_project=src_project)
     # XXX: clarify why we need the unicode(...) stuff
-    r.description = _html_escape(unicode(message, 'utf8'))
+    r.description = unicode(message, 'utf8')
     r.create(apiurl)
     return r
 
@@ -4204,7 +4204,7 @@ def create_maintenance_request(apiurl, src_project, src_packages, tgt_project, t
     else:
         r.add_action('maintenance_incident', src_project=src_project, tgt_project=tgt_project, tgt_releaseproject=tgt_releaseproject, opt_sourceupdate = opt_sourceupdate)
     # XXX: clarify why we need the unicode(...) stuff
-    r.description = _html_escape(unicode(message, 'utf8'))
+    r.description = unicode(message, 'utf8')
     r.create(apiurl, addrevision=True, enforce_branching=enforce_branching)
     return r
 


### PR DESCRIPTION
When creating a new request via the core.Request.create method, there is
no need to escape the data that is assigned to the "description" attribute
of a core.Request instance. Internally, core.Request.create ensures that
the data, which is POSTed to the api, is correctly escaped (the escaping
is implicitly done by ET (see core.Request.to_str)). Manually escaping the
description results in a double escaping (the escaped description is
escaped by ET again) - this is not the desired behavior.
Analogously, there is no need to escape the data that is passed to the
message parameter of the core.create_submit_request function because
core.create_submit_request takes care of escaping it.

Fixes: #869 ("Silly encoding of htmlencodable entities")