### PR TITLE
Do not return Request instances in Osc._submit_request

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1623,10 +1623,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         reqs = get_request_list(apiurl, dst_project, dst_package, req_type='submit', req_state=['new', 'review'])
         user = conf.get_apiurl_usr(apiurl)
         myreqs = [ i for i in reqs if i.state.who == user and i.reqid != opts.supersede ]
+        myreq_ids = [r.reqid for r in myreqs]
         repl = 'y'
         if len(myreqs) > 0 and not opts.yes:
             print('You already created the following submit request: %s.' % \
-                  ', '.join([i.reqid for i in myreqs ]))
+                  ', '.join(myreq_ids))
             repl = raw_input('Supersede the old requests? (y/n/c) ')
             if repl.lower() == 'c':
                 print('Aborting', file=sys.stderr)
@@ -1637,10 +1638,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         actionxml = """<action type="submit"> <source project="%s" package="%s"  rev="%s"/> <target project="%s" package="%s"/> %s </action>"""  % \
                 (src_project, src_package, opts.revision or show_upstream_rev(apiurl, src_project, src_package), dst_project, dst_package, options_block)
         if opts.supersede:
-            myreqs.append(opts.supersede)
+            myreq_ids.append(opts.supersede)
 
         #print 'created request id', result
-        return actionxml, myreqs
+        return actionxml, myreq_ids
 
     def _delete_request(self, args, opts):
         if len(args) < 1:


### PR DESCRIPTION
If there are existing requests that should be superseded, the old
code stores the Request instances in the myreqs list, which is
returned to the caller. However, the caller expects only request
ids instead of instances of class Request. Eventually, this results
in a type error - excerpt:

...
  File "/usr/lib/python3.8/site-packages/osc/commandline.py", line 1892, in do_createrequest
    change_request_state(apiurl, srid, 'superseded',
  File "/usr/lib/python3.8/site-packages/osc/core.py", line 4322, in change_request_state
    u = makeurl(apiurl,
  File "/usr/lib/python3.8/site-packages/osc/core.py", line 3326, in makeurl
    return urlunsplit((scheme, netloc, '/'.join([path] + list(l)), query, ''))
TypeError: sequence item 2: expected str instance, Request found

Hence, simply return the request ids instead of the Request instances.

Note: this changes the API of the Osc._submit_request method but
this is OK because it is not part of the public API.