### PR TITLE
Do not supersede the same requests several times in osc creq

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1840,14 +1840,14 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         i = 0
         actionsxml = ""
-        supersede = []
+        supersede = set()
         for ai in opts.actions:
             if ai == 'submit':
                 args = opts.actiondata[i]
                 i = i+1
                 actions, to_supersede = self._submit_request(args, opts, options_block)
                 actionsxml += actions
-                supersede.extend(to_supersede)
+                supersede.update(to_supersede)
             elif ai == 'delete':
                 args = opts.actiondata[i]
                 actionsxml += self._delete_request(args, opts)


### PR DESCRIPTION
When calling "osc creq -a prj1 foo prj2 bar -a submit prj1 bar prj2 bar",
the requests that could be superseded are calculated two times for the
prj2/bar package. Hence, they could end up two times in the "supersede"
list (see do_createrequest) In order to avoid duplicates, use a set
instead of a list.

Kudos to darix for pointing this out!

Note: it is a bit questionable if osc's current semantics makes sense
in the above example.