### PR TITLE
Add 'stage' options to 'osc build'

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -687,6 +687,18 @@ def main(apiurl, opts, argv):
         pac = pac + ":" + opts.multibuild_package
     if opts.wipe:
         buildargs.append("--wipe")
+    if (opts.stage_single and (opts.stage_pre or opts.stage_post)) \
+       or (opts.stage_pre and opts.stage_post):
+        raise oscerr.WrongOptions('Options --stage-single, --stage-pre and --stage-post cannot be combined')
+    if (opts.stage_single):
+        buildargs.append("--stage=%s" % opts.stage_single)
+        buildargs.append("--mode=single")
+    if (opts.stage_pre):
+        buildargs.append("--stage=%s" % opts.stage_pre)
+        buildargs.append("--mode=pre")
+    if (opts.stage_post):
+        buildargs.append("--stage=%s" % opts.stage_post)
+        buildargs.append("--mode=post")
 
     orig_build_root = config['build-root']
     # make it possible to override configuration of the rc file

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6489,6 +6489,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='trust packages from all projects')
     @cmdln.option('--nopreinstallimage', '--no-preinstallimage', action='store_true',
                   help='Do not use preinstall images for creating the build root.')
+    @cmdln.option('--ssingle', '--stage-single', dest='stage_single',
+                  help='Only perform specified build stage.')
+    @cmdln.option('--spre', '--stage-pre', dest='stage_pre',
+                  help='Only perform build stages up to and including specified stage.')
+    @cmdln.option('--spost', '--stage-post', dest='stage_post',
+                  help='Only perform build stages starting from and including specified stage.')
     @cmdln.alias('chroot')
     @cmdln.alias('shell')
     @cmdln.alias('wipe')


### PR DESCRIPTION
The stage options can be used to start or stop the build with
a specific stage or build only a single stage.
For example for RPM builds this is useful to avoid a potentially
lengthy %build stage to test changes in the %install or %files
stage only.
Of course this works only if the previous stages have been built
during a prior call and have not been deleted, yet.
The stages are named according to the stage names of the underlying
packaging system (for rpm these are -bp, -bc, -bi, -bb, -bs and
-bl).
To build all stages up to the specified stage: --stage-pre=<stage>,
to build only the specified stage: --stage-single=<stage>,
to build all stages starting from the specified stage:
--stage-pre=<stage>.
Whether this option is supported depends on the underlying build
and packaging system. Presently, it is only supported for RPM
builds.
Additional changes to 'obs-build' are required as well.

Signed-off-by: Egbert Eich <eich@suse.com>