### PR TITLE
Support slash notation in "osc creq -a <action type> args"

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -1506,7 +1506,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         parser.values.actions.append(value[0])
         del value[0]
-        parser.values.actiondata.append(value)
+        parser.values.actiondata.append(slash_split(value))
 
     def _submit_request(self, args, opts, options_block):
         actionxml = ""


### PR DESCRIPTION
Most osc commands support slash notation for the specification of
a project package pair. That is, "osc <cmd> prj/pkg" has the same
semantics as "osc <cmd> prj pkg" (in most cases).
For consistency reasons, "osc creq" should also support the slash
notation for the action type's arguments. That is, for instance,
"osc creq -a submit src_prj/src_pkg dst_prj/dst_pkg" should have the
same effect as "osc creq -a submit src_prj src_pkg dst_prj dst_pkg".

Proposed-by: darix