### PR TITLE
Add "--force" option to the "osc add" command

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4759,6 +4759,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print('\n'.join(lines))
 
 
+    @cmdln.option('-f', '--force', action='store_true',
+                  help='add files even if they are excluded by the exclude_glob config option')
     def do_add(self, subcmd, opts, *args):
         """${cmd_name}: Mark files to be added upon the next commit
 
@@ -4784,7 +4786,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             elif arg.startswith('http://') or arg.startswith('https://') or arg.startswith('ftp://'):
                 addDownloadUrlService(arg)
             else:
-                addFiles([arg])
+                addFiles([arg], force=opts.force)
 
 
     def do_mkpac(self, subcmd, opts, *args):

--- a/osc/core.py
+++ b/osc/core.py
@@ -7208,7 +7208,7 @@ def addDownloadUrlService(url):
     f.close()
 
 
-def addFiles(filenames, prj_obj = None):
+def addFiles(filenames, prj_obj = None, force=False):
     for filename in filenames:
         if not os.path.exists(filename):
             raise oscerr.OscIOError(None, 'file \'%s\' does not exist' % filename)
@@ -7267,7 +7267,7 @@ def addFiles(filenames, prj_obj = None):
         for filename in pac.todo:
             if filename in pac.skipped:
                 continue
-            if filename in pac.excluded:
+            if filename in pac.excluded and not force:
                 print('osc: warning: \'%s\' is excluded from a working copy' % filename, file=sys.stderr)
                 continue
             try:


### PR DESCRIPTION
"osc add --force <filename>" adds the filename to the working copy
even if it is excluded by the exclude_glob config option.