### PR TITLE
allow to run build script as user

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@
   - add build --stage flag. Useful for example for fixing file lists and just
     running the install section to see the result of it (use --stage=i=).
     Check the help for more details.
+  - allow to run build script as non-root, by setting su-wrapper empty
 
 0.172.0
   - support --lastsucceeded/--last-succeeded in "osc buildlog", "osc

--- a/osc/build.py
+++ b/osc/build.py
@@ -552,12 +552,13 @@ def run_build(opts, *args):
     cmd += args
 
     sucmd = os.environ.get('OSC_SU_WRAPPER', config['su-wrapper']).split()
-    if sucmd[0] == 'su':
-        if sucmd[-1] == '-c':
-            sucmd.pop()
-        cmd = sucmd + ['-s', cmd[0], 'root', '--'] + cmd[1:]
-    else:
-        cmd = sucmd + cmd
+    if sucmd:
+        if sucmd[0] == 'su':
+            if sucmd[-1] == '-c':
+                sucmd.pop()
+            cmd = sucmd + ['-s', cmd[0], 'root', '--'] + cmd[1:]
+        else:
+            cmd = sucmd + cmd
     if not opts.userootforbuild:
         cmd.append('--norootforbuild')
     return run_external(cmd[0], *cmd[1:])
@@ -1341,12 +1342,13 @@ def main(apiurl, opts, argv):
 
     if need_root:
         sucmd = config['su-wrapper'].split()
-        if sucmd[0] == 'su':
-            if sucmd[-1] == '-c':
-                sucmd.pop()
-            cmd = sucmd + ['-s', cmd[0], 'root', '--' ] + cmd[1:]
-        else:
-            cmd = sucmd + cmd
+        if sucmd:
+            if sucmd[0] == 'su':
+                if sucmd[-1] == '-c':
+                    sucmd.pop()
+                cmd = sucmd + ['-s', cmd[0], 'root', '--' ] + cmd[1:]
+            else:
+                cmd = sucmd + cmd
 
     # change personality, if needed
     if hostarch != bi.buildarch and bi.buildarch in change_personality:

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -219,6 +219,8 @@ apiurl = %(apiurl)s
 
 # Wrapper to call build as root (sudo, su -, ...)
 #su-wrapper = %(su-wrapper)s
+# set it empty to run build script as user (works only with KVM atm):
+#su-wrapper =
 
 # rootdir to setup the chroot environment
 # can contain %%(repo)s, %%(arch)s, %%(project)s, %%(package)s and %%(apihost)s (apihost is the hostname


### PR DESCRIPTION
works only with kvm atm, we should maybe point the user to it in that
case?

Requires: https://github.com/openSUSE/obs-build/pull/678/files