### PR TITLE
Do not use the deprecated Element.getchildren anymore

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -7139,7 +7139,7 @@ def stripETxml(node):
     node.tail = None
     if node.text != None:
         node.text = node.text.replace(" ", "").replace("\n", "")
-    for child in node.getchildren():
+    for child in node:
         stripETxml(child)
 
 def addGitSource(url):


### PR DESCRIPTION
Element.getchildren is deprecated and not available on python39
anymore. Instead, iterate over the element itself (which iterates
over the element's children).

Fixes: #903 ("AttributeError: 'xml.etree.ElementTree.Element' object
has no attribute 'getchildren'")