### PR TITLE
Make stderr line buffered if it does not refer to a tty

### DIFF
--- a/osc-wrapper.py
+++ b/osc-wrapper.py
@@ -23,6 +23,7 @@ except NameError:
     pass
 
 # avoid buffering output on pipes (bnc#930137)
+# Note: the following only applies to python2
 # Basically, a "print('foo')" call is translated to a corresponding
 # fwrite call that writes to the stdout stream (cf. string_print
 # (Objects/stringobject.c) and builtin_print (Python/bltinmodule.c));
@@ -35,6 +36,9 @@ except NameError:
 # remains fully buffered (see PyFile_SetBufSize (Objects/fileobject.c))).
 if not os.isatty(sys.stdout.fileno()):
     sys.stdout = os.fdopen(sys.stdout.fileno(), sys.stdout.mode, 1)
+
+if not os.isatty(sys.stderr.fileno()):
+    sys.stderr = os.fdopen(sys.stderr.fileno(), sys.stderr.mode, 1)
 
 osccli = commandline.Osc()
 


### PR DESCRIPTION
If osc is invoked, for instance, via "osc -d rbl ... > log.txt 2>&1",
writes to stderr and stdout do not necessarily appear in program order
in the log.txt file. More precisely, it is possible that the buildlog
comes first and the http debug output is at the end of the
file.
During osc/python3 startup (with the redirection from above), the
following is done:
- make stdout line buffered (due to the code in osc-wrapper.py)
- make stderr buffered (but not line buffered) because stderr does
  not refer to a tty (python3 startup)

Consequently, if osc has code like

print("foo")
print("bar", file=sys.stderr)
print("baz")

it is possible that the contents of the log.txt is

foo
baz
bar

because stderr is buffered (but not line buffered). In order to fix
this, make stderr line buffered, too.