### PR TITLE
Add support for sccache.

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -649,6 +649,16 @@ def main(apiurl, opts, argv):
     if opts.pkg_ccache:
         buildargs.append('--pkg-ccache=%s' % opts.pkg_ccache)
         xp.append('ccache')
+    if opts.sccache_uri or config['sccache_uri'] or opts.sccache or config['sccache']:
+        if opts.pkg_ccache or opts.ccache or config['ccache']:
+            raise oscerr.WrongArgs('Error: sccache and ccache can not be enabled at the same time')
+        if opts.sccache_uri:
+            buildargs.append('--sccache-uri=%s' % opts.sccache_uri)
+        elif config['sccache_uri']:
+            buildargs.append('--sccache-uri=%s' % config['sccache_uri'])
+        else:
+            buildargs.append('--sccache')
+        xp.append('sccache')
     if opts.linksources:
         buildargs.append('--linksources')
     if opts.baselibs:

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6463,6 +6463,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='use ccache to speed up rebuilds')
     @cmdln.option('--pkg-ccache', metavar='/path/to/_ccache.tar',
                   help='path to an existing uncompressed archive ccache. Using this option implies --ccache')
+    @cmdln.option('--sccache', action='store_true',
+                  help='use sccache to speed up rebuilds. Conflicts with --cache')
+    @cmdln.option('--sccache-uri', metavar='redis://127.0.0.1:6389',
+                  help='Optional remote URI for sccache storage. Implies --sccache.')
     @cmdln.option('--with', metavar='X', dest='_with', action='append',
                   help='enable feature X for build')
     @cmdln.option('--without', metavar='X', action='append',

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -121,6 +121,8 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'builtin_signature_check': '1',     # by default use builtin check for verify pkgs
             'icecream': '0',
             'ccache': '0',
+            'sccache': '0',
+            'sccache_uri': '',
 
             'buildlog_strip_time': '0',  # strips the build time from the build log
 
@@ -202,7 +204,7 @@ boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'tr
     'checkout_no_colon', 'checkout_rooted', 'check_for_request_on_action', 'linkcontrol', 'show_download_progress', 'request_show_interactive',
     'request_show_source_buildstatus', 'review_inherit_group', 'use_keyring', 'gnome_keyring', 'no_verify', 'builtin_signature_check',
     'http_full_debug', 'include_request_from_project', 'local_service_run', 'buildlog_strip_time', 'no_preinstallimage',
-    'status_mtime_heuristic', 'print_web_links', 'ccache', 'build-shell-after-fail']
+    'status_mtime_heuristic', 'print_web_links', 'ccache', 'sccache', 'build-shell-after-fail']
 integer_opts = ['build-jobs']
 
 api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']
@@ -286,6 +288,12 @@ apiurl = %(apiurl)s
 
 # Enable ccache in build roots.
 # ccache = 1
+
+# Enable sccache in build roots. Conflicts with ccache.
+# sccache = 1
+
+# Optional remote URI for sccache storage.
+# sccache_uri = redis://127.0.0.1:6379
 
 # extra packages to install when building packages locally (osc build)
 # this corresponds to osc build's -x option and can be overridden with that


### PR DESCRIPTION
Sccache is an alternate build caching system to ccache/icecream. It
supports C, C++ and Rust. It can optionally have distributed or remote
caches via redis, s3 object stores, memcached, azure storage or
google cloud storage.

This can help to significantly improve the performance of Rust rebuilds.

For example, Kanidm changes from 400s to 122s on a rebuild, and rust-lang
rebuilds improve from 7200s to 4770s. With some changes to the rust
packages especially this will be possible to speed up over version
changes as well.

See also: obs-build PR https://github.com/openSUSE/obs-build/pull/680