### PR TITLE
Handle "cd prj; osc ci non_existent_pkg" more gracefully

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -1032,7 +1032,7 @@ class Project:
                         p.commit(msg, verbose=verbose, skip_local_service_run=skip_local_service_run, can_branch=can_branch, force=force)
                     elif pac in self.pacs_unvers and not is_package_dir(os.path.join(self.dir, pac)):
                         print('osc: \'%s\' is not under version control' % pac)
-                    elif pac in self.pacs_broken:
+                    elif pac in self.pacs_broken or not os.path.exists(os.path.join(self.dir, pac)):
                         print('osc: \'%s\' package not found' % pac)
                     elif state == None:
                         self.commitExtPackage(pac, msg, todo, verbose=verbose, skip_local_service_run=skip_local_service_run)


### PR DESCRIPTION
When trying to commit a non-existent package via Project.commit it
is treated as an external package (because a non-existent package
has no "state" inside the project). That is, Project.commitExtPackage
is called, which fails with a FileNotFoundError in case of a
non-existent package (and the traceback is printed to the user).
In order to fix this, treat a non-existent package as broken package.
That is, simply print an info message and do not error out with a
traceback (note: the commit is _not_ aborted).

Fixes: #920 ("osc commit should fail gracefully in case of
nonexistent  filename")