### PR TITLE
Fix the commit of a frozen package wc

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -1533,8 +1533,8 @@ class Package:
                         'error: file \'%s\' with state \'%s\' is not known by meta' \
                         % (filename, st))
                 todo_send[filename] = f.md5
-            if ((self.ispulled() or self.islinkrepair()) and st != 'A'
-                and filename not in sha256sums):
+            if ((self.ispulled() or self.islinkrepair() or self.isfrozen())
+                and st != 'A' and filename not in sha256sums):
                 # Ignore files with state 'A': if we should consider it,
                 # it would have been in pac.todo, which implies that it is
                 # in sha256sums.


### PR DESCRIPTION
Always send the sha256sums of all tracked files in case of a
frozen package wc. For instance, this is needed if the package is
a plain link (no branch) because in this case the backend might
request a sha256sum for a tracked but unmodified file (this can
happen because the backend cannot expand the link).
The new behavior is in line with a pulled/linkrepair package wc.

Fixes: #924 ("Transmitting file data There is no sha256 sum for
file")