### PR TITLE
Slash split arguments in do_browse

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4474,6 +4474,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         """
 
         apiurl = self.get_api_url()
+        args = slash_split(args)
 
         package = None
         if len(args) == 1:


### PR DESCRIPTION
Without the slash splitting, "osc browse prj/pkg" interprets the
argument as a project, which is wrong. Hence, perform the slash
splitting (as most commands do).