### PR TITLE
Config select password store

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -9206,6 +9206,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             if len(args) != 1:
                 raise oscerr.WrongArgs('--change-password only needs the apiurl')
             args = [args[0], 'pass']
+        elif opts.select_password_store:
+            if len(args) != 1:
+                raise oscerr.WrongArgs('--select-password-store only needs the apiurl')
+            args = [args[0], 'pass']
+
         if len(args) < 2 and not (opts.dump or opts.dump_full):
             raise oscerr.WrongArgs('Too few arguments')
         elif opts.dump or opts.dump_full:

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -726,6 +726,13 @@ def config_set_option(section, opt, val=None, delete=False, update=True, creds_m
     if section == 'general' and not opt in general_opts or \
        section != 'general' and not opt in api_host_options:
         raise oscerr.ConfigError('unknown config option \'%s\'' % opt, config['conffile'])
+
+    if not val and not delete and opt == 'pass' and creds_mgr_descr is not None:
+        # change password store
+        creds_mgr = _get_credentials_manager(section, cp)
+        user = _extract_user_compat(cp, section, creds_mgr)
+        val = creds_mgr.get_password(section, user)
+
     run = False
     if val:
         if opt == 'pass':

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -762,7 +762,7 @@ def config_set_option(section, opt, val=None, delete=False, update=True, creds_m
     elif delete and (cp.has_option(section, opt) or opt == 'pass'):
         if opt == 'pass':
             creds_mgr = _get_credentials_manager(section, cp)
-            user = _extract_user_compar(cp, section, creds_mgr)
+            user = _extract_user_compat(cp, section, creds_mgr)
             creds_mgr.delete_password(section, user)
         else:
             cp.remove_option(section, opt)


### PR DESCRIPTION
```
    Add support for changing the password store via osc config
    
    The password store can be changed (without entering the password
    again) via "osc config <apiurl> --select-password-store". This
    command deletes the password from the current password store and
    stores it in the selected password store.
    
    Previously, the --select-password-store option had no meaningful
    semantics. In order to use it, one always had to provide a password
    and explicitly pass "pass" as the config option (the same could be
    achieved by using --change-password). Hence, in a strict sense,
    this change breaks the UI.
```