### PR TITLE
Use a fixed suffix for the upfilename in Package.mergefile

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -1300,7 +1300,7 @@ class Package:
             self.to_be_added.remove(n)
             self.write_addlist()
         elif state == 'C':
-            # don't remove "merge files" (*.r, *.mine...)
+            # don't remove "merge files" (*.mine, *.new...)
             # that's why we don't use clear_from_conflictlist
             self.in_conflict.remove(n)
             self.write_conflictlist()
@@ -1336,15 +1336,10 @@ class Package:
             filename = os.path.join(self.dir, n)
             storefilename = os.path.join(self.storedir, n)
             myfilename = os.path.join(self.dir, n + '.mine')
-            if self.islinkrepair() or self.ispulled():
-                upfilename = os.path.join(self.dir, n + '.new')
-            else:
-                upfilename = os.path.join(self.dir, n + '.r' + self.rev)
+            upfilename = os.path.join(self.dir, n + '.new')
 
             try:
                 os.unlink(myfilename)
-                # the working copy may be updated, so the .r* ending may be obsolete...
-                # then we don't care
                 os.unlink(upfilename)
                 if self.islinkrepair() or self.ispulled():
                     os.unlink(os.path.join(self.dir, n + '.old'))
@@ -1683,7 +1678,7 @@ class Package:
         filename = os.path.join(self.dir, n)
         storefilename = os.path.join(self.storedir, n)
         myfilename = os.path.join(self.dir, n + '.mine')
-        upfilename = os.path.join(self.dir, n + '.r' + self.rev)
+        upfilename = os.path.join(self.dir, n + '.new')
         origfile_tmp = os.path.join(self.storedir, '_in_update', '%s.copy' % n)
         origfile = os.path.join(self.storedir, '_in_update', n)
         shutil.copyfile(filename, origfile_tmp)


### PR DESCRIPTION
```
The old code uses a variable .rXYZ suffix (where XYZ is the revision
of the package wc during the merge operation). Now, if Package.mergefile
is invoked during an update, XYZ represents the "old" revision. That
is, if a merge conflict happens, then a subsequent "osc resolved <file>"
will not unlink the <file>.rXYZ file (because
Package.clear_from_conflictlist only takes the current rev into account).

In order to fix this, use a fixed ".new" suffix. This way,
Package.clear_from_conflictlist can properly unlink the corresponding
*.new file. This naming scheme for the "upfilename" is in line with
"osc pull" and "osc repairlink".

Note: if a working copy was updated with an "old" osc version (without
this commit) and a "new" osc version (with this commit) is used to run
"osc resolved <file>", then the <file>.rXYZ file is _NOT_ removed (it
is not worth the effort to add compat code for this).
```