### PR TITLE
Do not crash when running "osc search --binary --verbose foo"

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7960,10 +7960,16 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     result.append(s)
 
                 if opts.verbose:
-                    title = node.findtext('title').strip()
-                    if len(title) > 60:
-                        title = title[:61] + '...'
-                    result.append(title)
+                    if opts.binary:
+                        result.append(node.get('repository') or '-')
+                        result.append(node.get('arch') or '-')
+                        result.append(node.get('version') or '-')
+                        result.append(node.get('release') or '-')
+                    else:
+                        title = node.findtext('title').strip()
+                        if len(title) > 60:
+                            title = title[:61] + '...'
+                        result.append(title)
 
                 if opts.repos_baseurl:
                     # FIXME: no hardcoded URL of instance
@@ -7995,7 +8001,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 headline.append('Rev')
                 headline.append('Srcmd5')
             if opts.verbose:
-                headline.append('# Title')
+                if opts.binary:
+                    headline.extend(['# Repository', '# Arch', '# Version',
+                                     '# Release'])
+                else:
+                    headline.append('# Title')
             if opts.repos_baseurl:
                 headline.append('# URL')
             if opts.binary:


### PR DESCRIPTION
The old code does not support the --binary option in combination
with the --verbose option. Specifying --binary and --verbose at
the same time results in a crash (because the binary listing
contains no <title>...</title> element).
In order to fix this, do not try to access a <title>...</title>
element when --binary and --verbose are both specified. Instead,
in this case, include information about the repo, arch, version,
and release of the corresponding binary element.

Fixes: #933 ("osc se -v -B crash")