### PR TITLE
[build] Do not try to run source services if --local-package is set

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -790,6 +790,9 @@ def main(apiurl, opts, argv):
     if opts.noinit:
         buildargs.append('--noinit')
 
+    if not is_package_dir('.'):
+        opts.noservice = True
+
     # check for source services
     if not opts.offline and not opts.noservice:
         p = osc.core.Package(os.curdir)


### PR DESCRIPTION
When using the option --local-package to build a package that doesn't
exist on the on the server, yet, the error message:
 "Error: "<directory>" is not an osc package working copy."
is generated.
This occurs when build.main() attempts to run source services which
is probably not a good idea as these are part of the core.Package
infrastructure which cannot be initialized for such packages.

It is probably best to skip the source services. See Issue#936.

Signed-off-by: Egbert Eich <eich@suse.com>