### PR TITLE
Ensure creation of `~/.osc_cookiejar` adheres to XDG Base Directory Specification

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -94,6 +94,19 @@ def _get_processors():
     except ValueError as e:
         return 1
 
+
+def _identify_osccookiejar():
+    if os.path.isfile(os.path.join(os.path.expanduser("~"), '.osc_cookiejar')):
+        # For backwards compatibility, use the old location if it exists
+        return '~/.osc_cookiejar'
+
+    if os.getenv('XDG_STATE_HOME', '') != '':
+        osc_state_dir = os.path.join(os.getenv('XDG_STATE_HOME'), 'osc')
+    else:
+        osc_state_dir = os.path.join(os.path.expanduser("~"), '.local', 'state', 'osc')
+
+    return os.path.join(osc_state_dir, 'cookiejar')
+
 DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'user': None,
             'pass': None,
@@ -136,7 +149,7 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'post_mortem': '0',
             'use_keyring': '0',
             'gnome_keyring': '0',
-            'cookiejar': '~/.osc_cookiejar',
+            'cookiejar': _identify_osccookiejar(),
             # fallback for osc build option --no-verify
             'no_verify': '0',
             # enable project tracking by default
@@ -638,6 +651,8 @@ def init_basicauth(config, config_mtime):
         AbstractHTTPHandler.__init__ = urllib2_debug_init
 
     cookie_file = os.path.expanduser(config['cookiejar'])
+    if not os.path.exists(os.path.dirname(cookie_file)):
+        os.makedirs(os.path.dirname(cookie_file), mode=0o700)
     global cookiejar
     cookiejar = LWPCookieJar(cookie_file)
     try:


### PR DESCRIPTION
In a similar theme to #349, this ensures the file is created according to the XDG Base Directory specification. Just like that change, it uses the XDG Base Directly specification on windows (usually I prefer to use the spec only on Unix-like platlforms). In this case, `XDG_CACHE_HOME` seemed to be a better fit compared to `XDG_STATE_HOME`

A subtle difference compared to #349 is that `XDG_STATE_HOME` is not used if it is defined, but empty (in the other change, the variable is used if it is empty). This is more correct, according to the spec. 


<details>
<summary>Test suite results (passes)</summary>

```txt
➤ python suite.py
..................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 194 tests in 1.253s

OK
```

</details>
