### PR TITLE
`XDG_CONFIG_HOME` for calculating oscrc is no longer used if it is empty

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -1043,9 +1043,12 @@ def identify_conf():
     if 'OSC_CONFIG' in os.environ:
         return os.environ.get('OSC_CONFIG')
     if os.path.exists(os.path.expanduser('~/.oscrc')):
-        conffile = '~/.oscrc'
+        return '~/.oscrc'
+
+    if os.environ.get('XDG_CONFIG_HOME', '') != '':
+        conffile = os.environ.get('XDG_CONFIG_HOME') + '/osc/oscrc'
     else:
-        conffile = os.environ.get('XDG_CONFIG_HOME', '~/.config') + '/osc/oscrc'
+        conffile = '~/.config/osc/oscrc'
 
     return conffile
 


### PR DESCRIPTION
Hai,

As requested in #940, this fixes the use of `$XDG_CONFIG_HOME` to be more spec compliant 

Previously, if XDG_CONFIG_HOME was defined as an empty string, it was used when calculating the value of the oscrc config file. Now, if XDG_CONFIG_HOME is an empty string, `~/.config` is used instead. According to the [spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), this is more compliant

<details>
<summary>Test suite result (passes)</summary>

```txt
➤ python suite.py
..................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 194 tests in 1.217s

OK
```

</details>