### PR TITLE
Handle missing os.sysconf more gracefully

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -87,11 +87,11 @@ except:
 def _get_processors():
     """
     get number of processors (online) based on
-    SC_NPROCESSORS_ONLN (returns 1 if config name does not exist).
+    SC_NPROCESSORS_ONLN (returns 1 if config name/os.sysconf does not exist).
     """
     try:
         return os.sysconf('SC_NPROCESSORS_ONLN')
-    except ValueError as e:
+    except (AttributeError, ValueError):
         return 1
 
 


### PR DESCRIPTION
os.sysconf is not available on all platforms (like Windows) but it
is used to retrieve the number of online processors. If missing,
assume one processor (building on such a platform will most likely
not work, though).

Fixes: #948 ("Windows compatibility") (at least it improves the
Windows support a bit)