### PR TITLE
Add support to manually override download url locations.

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -221,7 +221,8 @@ boolean_opts = ['debug', 'do_package_tracking', 'http_debug', 'post_mortem', 'tr
     'status_mtime_heuristic', 'print_web_links', 'ccache', 'sccache', 'build-shell-after-fail']
 integer_opts = ['build-jobs']
 
-api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj']
+api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj',
+    'downloadurl']
 
 new_conf_template = """
 [general]
@@ -1023,6 +1024,16 @@ def get_config(override_conffile=None,
             api_host_options[apiurl]['trusted_prj'] = cp.get(url, 'trusted_prj').split(' ')
         else:
             api_host_options[apiurl]['trusted_prj'] = []
+
+        # ⚠️  This option is experimental and may be removed at any time in the future!
+        # This allows overriding the download url for an OBS instance to specify a closer mirror
+        # or proxy system, which can greatly improve download performance, latency and more.
+        # For example, this can use https://github.com/Firstyear/opensuse-proxy-cache in a local
+        # geo to improve performance.
+        if cp.has_option(url, 'downloadurl'):
+            api_host_options[apiurl]['downloadurl'] = cp.get(url, 'downloadurl')
+        else:
+            api_host_options[apiurl]['downloadurl'] = None
 
     # add the auth data we collected to the config dict
     config['api_host_options'] = api_host_options

--- a/osc/core.py
+++ b/osc/core.py
@@ -5788,7 +5788,7 @@ def result_xml_to_dicts(xml):
         rmap['repostate'] = node.get('code')
         rmap['pkg'] = rmap['package'] = rmap['pac'] = ''
         rmap['code'] = node.get('code')
-        rmap['details'] = ''
+        rmap['details'] = node.get('details')
         # the way we currently use this function, there should be
         # always a status element
         snodes = node.findall('status')
@@ -5809,6 +5809,10 @@ def result_xml_to_dicts(xml):
             details = statusnode.find('details')
             if details is not None:
                 smap['details'] = details.text
+            if rmap['code'] == 'broken':
+                # real error just becomes visible in details/verbose
+                smap['code'] = rmap['code']
+                smap['details'] = "repository: " + rmap['details']
             yield smap, is_multi
 
 
@@ -5951,6 +5955,8 @@ def get_prj_results(apiurl, prj, hide_legend=False, csv=False, status_filter=Non
             state = "outdated"
         else:
             state = node.get('state')
+        if node.get('details'):
+            state += ' details: ' + node.get('details')
         tg = (node.get('repository'), node.get('arch'), state)
         targets.append(tg)
         for pacnode in node.findall('status'):


### PR DESCRIPTION
This adds support base on each apiurl to customise the download location. This can be combined with a local proxy cache or other to allow caching of packages outside of osc's environment. 