### PR TITLE
Improve error message in case of an URLError

### DIFF
--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -139,7 +139,11 @@ def run(prg, argv=None):
     except HTTPException as e:
         print(e, file=sys.stderr)
     except URLError as e:
-        print('Failed to reach a server:\n', e.reason, file=sys.stderr)
+        msg = 'Failed to reach a server'
+        if hasattr(e, '_osc_host_port'):
+            msg += ' (%s)' % e._osc_host_port
+        msg += ':\n'
+        print(msg, e.reason, file=sys.stderr)
     except IOError as e:
         # ignore broken pipe
         if e.errno != errno.EPIPE:

--- a/osc/core.py
+++ b/osc/core.py
@@ -33,7 +33,7 @@ except ImportError:
 
 try:
     from urllib.parse import urlsplit, urlunsplit, urlparse, quote_plus, urlencode, unquote
-    from urllib.error import HTTPError
+    from urllib.error import HTTPError, URLError
     from urllib.request import pathname2url, install_opener, urlopen
     from urllib.request import Request as URLRequest
     from io import StringIO
@@ -42,7 +42,7 @@ except ImportError:
     #python 2.x
     from urlparse import urlsplit, urlunsplit, urlparse
     from urllib import pathname2url, quote_plus, urlencode, unquote
-    from urllib2 import HTTPError, install_opener, urlopen
+    from urllib2 import HTTPError, URLError, install_opener, urlopen
     from urllib2 import Request as URLRequest
     from cStringIO import StringIO
     from httplib import IncompleteRead
@@ -3402,6 +3402,9 @@ def http_request(method, url, headers={}, data=None, file=None):
             req.add_header('Content-Length', str(content_length))
         try:
             return urlopen(req)
+        except URLError as e:
+            e._osc_host_port = req.host
+            raise
         finally:
             if hasattr(conf.cookiejar, 'save'):
                 conf.cookiejar.save(ignore_discard=True)


### PR DESCRIPTION
The old code does not print any information about the host, for
which the access failed, in case of an URLError. In order to fix
this, add information about the host (and port) to the URLError
instance in core.http_request and use this information in the
babysitter to print out a more detailed error message (which includes
the host (and port)).
For now, we simply add a "private" "_osc_host_port" attribute to
the URLError instance (this way we avoid potential name clashes (due
to the "_osc" prefix) and could come up with a different/more clever
way in the future (due to its privateness)).

Fixes: #954 ("Better diagnostic for domain name issues")