### PR TITLE
fix hdmrd5 check of local cached files

### DIFF
--- a/osc/util/packagequery.py
+++ b/osc/util/packagequery.py
@@ -87,7 +87,7 @@ class PackageQuery:
         f = open(filename, 'rb')
         magic = f.read(7)
         f.seek(0)
-        if magic[:4] == '\xed\xab\xee\xdb':
+        if magic[:4] == b'\xed\xab\xee\xdb':
             from . import rpmquery
             f.close()
             return rpmquery.RpmQuery.queryhdrmd5(filename)


### PR DESCRIPTION
Current OBS is delivering hdrmd5 in buildinfo. It turns out
that osc has already code for validating cached files, but it
invalidates all local files atm with python 3.x