### PR TITLE
Osc.postoptparse only returns if the get_config call succeeds

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -131,7 +131,7 @@ class Osc(cmdln.Cmdln):
         return optparser
 
 
-    def postoptparse(self, try_again = True):
+    def postoptparse(self):
         """merge commandline options into the config"""
         try:
             conf.get_config(override_conffile = self.options.conffile,
@@ -152,19 +152,16 @@ class Osc(cmdln.Cmdln):
                 apiurl = self.options.apiurl
             conf.interactive_config_setup(e.file, apiurl)
             print('done', file=sys.stderr)
-            if try_again:
-                self.postoptparse(try_again = False)
+            self.postoptparse()
         except oscerr.ConfigMissingApiurl as e:
             print(e.msg, file=sys.stderr)
             conf.interactive_config_setup(e.file, e.url, initial=False)
-            if try_again:
-                self.postoptparse(try_again = False)
+            self.postoptparse()
         except oscerr.ConfigMissingCredentialsError as e:
             print(e.msg)
             print('Please enter new credentials.')
             conf.interactive_config_setup(e.file, e.url, initial=False)
-            if try_again:
-                self.postoptparse(try_again = False)
+            self.postoptparse()
 
         self.options.verbose = conf.config['verbose']
         self.download_progress = None


### PR DESCRIPTION
The old code passes try_again=False to the recursive postoptparse
call when calling it from one of the exception handlers. This is
wrong because it can result in an incomplete conf.config dict (for
instance, if two apiurl sections have no user and no password and
no credentials_mgr_class option - see #761 ("Traceback config with
two backends and no username")).
Hence, Osc.postoptparse should only return if the conf.get_config
call succeeds. For this, unconditionally call Osc.postoptparse from
within the exception handlers. Note: this could potentially (although
quite unlikely) result in an endless recursion but in each recursive
call "user" interaction is required (that is, the user could simply
press CTRL+c) - so this should not be a problem.

Implementation note: this change breaks the API. Rationale: the
semantics of Osc.postoptparse changed. Hence, "pretending" to
honor the try_again parameter could result in unexpected behavior
(from the API consumer's POV). Hence, a traceback might be more
sensible.

Fixes: #761 ("Traceback config with two backends and no username")