### PR TITLE
extract config section from _buildenv if -r is set

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -20,7 +20,7 @@ except ImportError:
 
 from tempfile import NamedTemporaryFile, mkdtemp
 from osc.fetch import *
-from osc.core import get_buildinfo, store_read_apiurl, store_read_project, store_read_package, meta_exists, quote_plus, get_buildconfig, is_package_dir, dgst
+from osc.core import get_buildinfo, store_read_apiurl, store_read_project, store_read_package, meta_exists, quote_plus, get_buildconfig, is_package_dir, dgst, get_repr_buildconfig
 from osc.core import get_binarylist, get_binary_file, run_external, return_external, raw_input
 from osc.util import rpmquery, debquery, archquery
 from osc.util.helper import decode_it
@@ -907,8 +907,12 @@ def main(apiurl, opts, argv):
             if not os.path.isfile(bc_filename):
                 raise oscerr.WrongOptions('--offline is not possible, no local buildconfig file')
         else:
-            print('Getting buildconfig from server and store to %s' % bc_filename)
-            bc = get_buildconfig(apiurl, prj, repo)
+            if opts.reproduce:
+                print('Getting buildconfig from buildenv for original package and store to %s' % bc_filename)
+                bc = get_repr_buildconfig(apiurl, prj, pac, repo, arch)
+            else:
+                print('Getting buildconfig from server and store to %s' % bc_filename)
+                bc = get_buildconfig(apiurl, prj, repo)
             if not bc_file:
                 bc_file = open(bc_filename, 'w')
             bc_file.write(decode_it(bc))

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6450,6 +6450,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='Start with cached prjconf and packages without contacting the api server')
     @cmdln.option('-l', '--preload', action='store_true',
                   help='Preload all files into the cache for offline operation')
+    @cmdln.option('-r', '--reproduce', action='store_true',
+                  help='Use buildconfig from buildenv of package to reproduce the original build')
     @cmdln.option('--no-changelog', action='store_true',
                   help='don\'t update the package changelog from a changes file')
     @cmdln.option('--rsync-src', metavar='RSYNCSRCPATH', dest='rsyncsrc',

--- a/osc/core.py
+++ b/osc/core.py
@@ -6259,6 +6259,15 @@ def get_buildinfo(apiurl, prj, package, repository, arch, specfile=None, addlist
     return f.read()
 
 
+def get_repr_buildconfig(apiurl, prj, pkg, repository, arch):
+    u = makeurl(apiurl, ['build', prj, repository, arch, pkg, '_buildenv'])
+    f = http_GET(u)
+
+    root = ET.parse(f).getroot()
+    for config in root.findall('config'):
+       return config.text
+
+
 def get_buildconfig(apiurl, prj, repository, path=None):
     query = []
     if path:


### PR DESCRIPTION
use buildconfig stored in _buildenv to be sure the same config is used to build the package locally as it was used to build on the server when the original package was created.