### PR TITLE
flake8: Initial configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git,__pycache__
+max-line-length = 120


### PR DESCRIPTION
Set max line length to 120.
Keep the all the other settings on their default values.

If `max-line-length = 120` is too much, let me know which value you prefer.
