### PR TITLE
conf: Preserve oscrc symlink

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -695,8 +695,20 @@ def write_config(fname, cp):
     if os.path.exists(fname) and not os.path.isfile(fname):
         # only write to a regular file
         return
+
+    # config file is behind a symlink
+    # resolve the symlink and continue writing the config as usual
+    if os.path.islink(fname):
+        fname = os.readlink(fname)
+
+    # create directories to the config file (if they don't exist already)
     if not os.path.exists(os.path.dirname(fname)):
-        os.makedirs(os.path.dirname(fname), mode=0o700)
+        try:
+            os.makedirs(os.path.dirname(fname), mode=0o700)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
     with open(fname + '.new', 'w') as f:
         cp.write(f, comments=True)
     try:


### PR DESCRIPTION
When a user creates a symlink pointing from ~/.config/osc/oscrc to a different location,
don't overwrite the symlink but follow it when writing configuration on disk.

Fixes https://github.com/openSUSE/osc/issues/390

Could someone review this from security perspective?
I don't think that this could cause any harm (e.g. a user setting the path so root overwrites system files etc.), but I may have missed something.
