### PR TITLE
Escape % character in binary download URLs

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -180,7 +180,8 @@ class Buildinfo:
             self.pathes.append(node.get('project')+"/"+node.get('repository'))
             # a hash providing the matching URL for specific repos for newer OBS instances
             if node.get('url'):
-                self.urls[node.get('project')+"/"+node.get('repository')] = node.get('url') + '/%(arch)s/%(filename)s'
+                url = node.get('url').replace('%', '%%')
+                self.urls[node.get('project')+"/"+node.get('repository')] = url + '/%(arch)s/%(filename)s'
 
         self.vminstall_list = [ dep.name for dep in self.deps if dep.vminstall ]
         self.preinstall_list = [ dep.name for dep in self.deps if dep.preinstall ]
@@ -1044,7 +1045,7 @@ def main(apiurl, opts, argv):
         # we have now specific download repositories per repository. Could be removed IMHO, since the api fallback
         # is there. In worst case it could fetch the wrong rpm...
         if bi.downloadurl:
-            urllist.append(bi.downloadurl + '/%(extproject)s/%(extrepository)s/%(arch)s/%(filename)s')
+            urllist.append(bi.downloadurl.replace('%', '%%') + '/%(extproject)s/%(extrepository)s/%(arch)s/%(filename)s')
     if opts.disable_cpio_bulk_download:
         urllist.append( '%(apiurl)s/build/%(project)s/%(repository)s/%(repoarch)s/%(repopackage)s/%(repofilename)s' )
 


### PR DESCRIPTION
Without escaping the % character, the download URL could be subject
to string formatting (depending on the subsequent characters). For
instance, if the url attribute's value of a buildinfo's path element
contains the substring "c_c%2B%2B", the "%2B" is interpreted as a
format string (see issue #965), which is wrong ("B" is not a valid
format character at all). In order to avoid this, escape all
% characters in the download urls.
Note: escaping the % characters in the download url itself is OK
because we only intend to "format" the path.

Note: we do not escape the % characters for urls from the config
file (implicit assumption: the user already correctly escaped the
urls (whether this assumption is sensible or not is debatable, of
course)).

Fixes: #965 ("unsupported format character 'B' (0x42) at index 66")