### PR TITLE
Do not download a bdep with a hdrmd5 from the api by default

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -243,10 +243,6 @@ class Fetcher:
                                             '--offline not possible.' %
                                             i.fullfilename)
                 self.dirSetup(i)
-                if i.hdrmd5 and self.enable_cpio:
-                    self.__add_cpio(i)
-                    done += 1
-                    continue
                 try:
                     # if there isn't a progress bar, there is no output at all
                     prefix = ''


### PR DESCRIPTION
Since a recent backend change, a bdep has a hdrmd5 by default. That
is, osc always downloads these bdeps from the API (unless they are
cached) instead of a mirror. This is not intended.
Using a mirror is no problem because the hdrmd5s are verified in
the build module.
Note: If this causes a problem, one could also use "osc build
--download-api-only" to mimic the old behavior.