### PR TITLE
Improve credentials manager selection

### DIFF
--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -151,7 +151,7 @@ def run(prg, argv=None):
             raise
         print(e, file=sys.stderr)
     except (oscerr.ConfigError, oscerr.NoConfigfile) as e:
-        print(e.msg, file=sys.stderr)
+        print(e, file=sys.stderr)
     except configparser.Error as e:
         print(e.message, file=sys.stderr)
     except oscerr.OscIOError as e:

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -1121,7 +1121,9 @@ def select_credentials_manager_descr():
     for row in table:
         print(row)
 
-    i = raw_input('Select credentials manager: ')
+    i = raw_input('Select credentials manager [default=1]: ')
+    if not i:
+        i = "1"
     if not i.isdigit():
         sys.exit('Invalid selection')
     i = int(i) - 1

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -1109,8 +1109,18 @@ def select_credentials_manager_descr():
     if not credentials.has_keyring_support():
         print('To use keyrings please install python%d-keyring.' % sys.version_info.major)
     creds_mgr_descriptors = credentials.get_credentials_manager_descriptors()
+
+    rows = []
     for i, creds_mgr_descr in enumerate(creds_mgr_descriptors, 1):
-        print('%d) %s (%s)' % (i, creds_mgr_descr.name(), creds_mgr_descr.description()))#
+        rows += [str(i), creds_mgr_descr.name(), creds_mgr_descr.description()]
+
+    from .core import build_table
+    headline = ('NUM', 'NAME', 'DESCRIPTION')
+    table = build_table(len(headline), rows, headline)
+    print()
+    for row in table:
+        print(row)
+
     i = raw_input('Select credentials manager: ')
     if not i.isdigit():
         sys.exit('Invalid selection')

--- a/osc/credentials.py
+++ b/osc/credentials.py
@@ -15,6 +15,9 @@ try:
 except ImportError:
     gnomekeyring = None
 
+from . import conf
+from . import oscerr
+
 
 class AbstractCredentialsManagerDescriptor(object):
     def name(self):
@@ -184,7 +187,11 @@ class KeyringCredentialsManager(AbstractCredentialsManager):
         self._backend_cls_name = options
 
     def _load_backend(self):
-        keyring_backend = keyring.core.load_keyring(self._backend_cls_name)
+        try:
+            keyring_backend = keyring.core.load_keyring(self._backend_cls_name)
+        except ModuleNotFoundError:
+            msg = "Invalid credentials_mgr_class: {}".format(self._backend_cls_name)
+            raise oscerr.ConfigError(msg, conf.config['conffile'])
         keyring.set_keyring(keyring_backend)
 
     @classmethod

--- a/osc/credentials.py
+++ b/osc/credentials.py
@@ -81,10 +81,10 @@ class PlaintextConfigFileCredentialsManager(AbstractCredentialsManager):
 
 class PlaintextConfigFileDescriptor(AbstractCredentialsManagerDescriptor):
     def name(self):
-        return 'Config file credentials manager'
+        return 'Config'
 
     def description(self):
-        return 'Store the credentials in the config file (plain text)'
+        return 'Store the password in plain text in the osc config file [insecure, persistent]'
 
     def create(self, cp):
         return PlaintextConfigFileCredentialsManager(cp, None)
@@ -116,10 +116,10 @@ class ObfuscatedConfigFileCredentialsManager(
 
 class ObfuscatedConfigFileDescriptor(AbstractCredentialsManagerDescriptor):
     def name(self):
-        return 'Obfuscated Config file credentials manager'
+        return 'Obfuscated config'
 
     def description(self):
-        return 'Store the credentials in the config file (obfuscated)'
+        return 'Store the password in obfuscated form in the osc config file [insecure, persistent]'
 
     def create(self, cp):
         return ObfuscatedConfigFileCredentialsManager(cp, None)
@@ -154,10 +154,10 @@ class TransientCredentialsManager(AbstractCredentialsManager):
 
 class TransientDescriptor(AbstractCredentialsManagerDescriptor):
     def name(self):
-        return 'Transient password store'
+        return 'Transient'
 
     def description(self):
-        return 'Do not store the password and always ask for the password'
+        return 'Do not store the password and always ask for it [secure, in-memory]'
 
     def create(self, cp):
         return TransientCredentialsManager(cp, None)

--- a/osc/oscerr.py
+++ b/osc/oscerr.py
@@ -22,6 +22,9 @@ class ConfigError(OscBaseError):
         self.msg = msg
         self.file = fname
 
+    def __str__(self):
+        return "Error in config file {}\n   {}".format(self.file, self.msg)
+
 class ConfigMissingApiurl(ConfigError):
     """Exception raised when a apiurl does not exist in the config file"""
     def __init__(self, msg, fname, url):
@@ -45,6 +48,9 @@ class NoConfigfile(OscBaseError):
         OscBaseError.__init__(self)
         self.file = fname
         self.msg = msg
+
+    def __str__(self):
+        return "Config file cannot be found: {}\n   {}".format(self.file, self.msg)
 
 class ExtRuntimeError(OscBaseError):
     """Exception raised when there is a runtime error of an external tool"""


### PR DESCRIPTION
Implemented new keyctl credentials manager.
Order credential managers by priority and name.
Credential manager with the highest prio is a default now.
Remove unwanted python-keyrings backends.
Made clear which credentials managers are (in)secure.
Briefly tested the code on python2.
