### PR TITLE
Drop Windows from supported operating systems

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4653,8 +4653,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             prj_dir = opts.output_dir if opts.output_dir else project
             if not opts.output_dir and conf.config['checkout_no_colon']:
                 prj_dir = prj_dir.replace(':', '/')
-            if sys.platform[:3] == 'win':
-                prj_dir = prj_dir.replace(':', ';')
             if os.path.exists(prj_dir):
                 sys.exit('osc: project directory \'%s\' already exists' % prj_dir)
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -4082,8 +4082,6 @@ def _get_linux_distro():
 
 def get_default_editor():
     system = platform.system()
-    if system == 'Windows':
-        return 'notepad'
     if system == 'Linux':
         dist = _get_linux_distro()
         if dist == 'debian':
@@ -4095,8 +4093,6 @@ def get_default_editor():
 
 def get_default_pager():
     system = platform.system()
-    if system == 'Windows':
-        return 'less'
     if system == 'Linux':
         dist = _get_linux_distro()
         if dist == 'debian':
@@ -5061,12 +5057,8 @@ def checkout_package(apiurl, project, package,
 
     if not prj_dir:
         prj_dir = olddir
-    else:
-        if sys.platform[:3] == 'win':
-            prj_dir = prj_dir[:2] + prj_dir[2:].replace(':', ';')
-        else:
-            if conf.config['checkout_no_colon']:
-                prj_dir = prj_dir.replace(':', '/')
+    elif conf.config['checkout_no_colon']:
+        prj_dir = prj_dir.replace(':', '/')
 
     root_dots = '.'
     if conf.config['checkout_rooted']:

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setuptools.setup(
     long_description_content_type="text/plain",
     author='openSUSE project',
     author_email='opensuse-buildservice@opensuse.org',
-    license='GPL',
+    license='GPLv2+',
     platforms=['Linux', 'Mac OSX', 'Windows XP/2000/NT', 'Windows 95/98/ME', 'FreeBSD'],
     keywords=['openSUSE', 'SUSE', 'RPM', 'build', 'buildservice'],
     url='http://en.opensuse.org/openSUSE:OSC',

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Build Tools",
         "Topic :: System :: Archiving :: Packaging",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,11 @@ import distutils.core
 from distutils.command import build, install_data
 import gzip
 import os.path
-import sys
 
 import setuptools
 
 import osc.core
 from osc import commandline
-
-# optional support for py2exe
-try:
-    import py2exe
-
-    HAVE_PY2EXE = True
-except:
-    HAVE_PY2EXE = False
 
 
 class build_osc(build.build, object):
@@ -90,17 +81,8 @@ class install_data(install_data.install_data, object):
         self.data_files = data_files
 
 
-addparams = {}
-if HAVE_PY2EXE:
-    addparams['console'] = [
-        {'script': 'osc-wrapper.py', 'dest_base': 'osc', 'icon_resources': [(1, 'osc.ico')]}]
-    addparams['zipfile'] = 'shared.lib'
-    addparams['options'] = {'py2exe': {'optimize': 0, 'compressed': True,
-                                       'packages': ['xml.etree', 'StringIO', 'gzip']}}
-
 data_files = []
-if sys.platform[:3] != 'win':
-    data_files.append((os.path.join('share', 'man', 'man1'), ['osc.1.gz']))
+data_files.append((os.path.join('share', 'man', 'man1'), ['osc.1.gz']))
 
 with open("README") as fh:
     long_description = fh.read()
@@ -114,7 +96,7 @@ setuptools.setup(
     author='openSUSE project',
     author_email='opensuse-buildservice@opensuse.org',
     license='GPLv2+',
-    platforms=['Linux', 'Mac OSX', 'Windows XP/2000/NT', 'Windows 95/98/ME', 'FreeBSD'],
+    platforms=['Linux', 'MacOS X', 'FreeBSD'],
     keywords=['openSUSE', 'SUSE', 'RPM', 'build', 'buildservice'],
     url='http://en.opensuse.org/openSUSE:OSC',
     download_url='https://github.com/openSUSE/osc',
@@ -129,7 +111,9 @@ setuptools.setup(
         "Intended Audience :: Information Technology",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
-        "Operating System :: OS Independent",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: BSD :: FreeBSD",
+        "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
@@ -151,5 +135,4 @@ setuptools.setup(
         'build_docs': build_docs,
         'install_data': install_data
     },
-    **addparams
 )


### PR DESCRIPTION
The ':' character is used as a separator in Open Build Service
and constantly appears in directory names after running osc commands.
Windows do not support ':' as a valid character on file system.
This breaks not only osc but also basic commands such
as 'git clone' on a project that contains colons in paths.
    
That's why we decided to make osc unsupported on Windows.

After merging this, I'd close the following issues and PRs:
https://github.com/openSUSE/osc/issues/960
https://github.com/openSUSE/osc/issues/963
https://github.com/openSUSE/osc/issues/964
https://github.com/openSUSE/osc/pull/961
https://github.com/openSUSE/osc/pull/962