### PR TITLE
Fix getbinaries command to fetch also multibuild packages

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7524,6 +7524,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 for i in binaries:
                     if binary != None and binary != i.name:
                         continue
+                    # skip metadata (unless explicitly specified as the `FILE` (== `binary`) argument)
+                    if not binary and i.name.startswith("_"):
+                        continue
+                    # skip logs (unless explicitly specified as the `FILE` (== `binary`) argument)
+                    if not binary and i.name.endswith(".log"):
+                        continue
                     # skip source rpms
                     if not opts.sources and (i.name.endswith('src.rpm') or i.name.endswith('sdeb')):
                         continue

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7427,8 +7427,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='do not show downloading progress')
     @cmdln.option('-d', '--destdir', default='./binaries', metavar='DIR',
                   help='destination directory')
-    @cmdln.option('-M', '--multibuild-package', action='append',
-                  help='get binaries from specified multibuild package')
+    @cmdln.option('-M', '--multibuild-package', metavar="FLAVOR", action='append',
+                  help='Get binaries from the specified flavor of a multibuild package.'
+                  ' It is meant for use from a package checkout when it is not possible to specify package:flavor.')
     @cmdln.option('--sources', action="store_true",
                   help='also fetch source packages')
     @cmdln.option('--debug', action="store_true",
@@ -7457,6 +7458,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         project = None
         package = None
         binary = None
+
+        if opts.multibuild_package and ((len(args) > 2) or (len(args) <= 2 and is_project_dir(os.getcwd()))):
+            self.optparser.error("The -M/--multibuild-package option can be only used from a package checkout.")
 
         if len(args) < 1 and is_package_dir('.'):
             self.print_repos()

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7496,7 +7496,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
 
         if package is None:
-            package = meta_get_packagelist(apiurl, project)
+            package = meta_get_packagelist(apiurl, project, deleted=0)
         else:
             if opts.multibuild_package:
                 packages = []

--- a/osc/core.py
+++ b/osc/core.py
@@ -3449,6 +3449,11 @@ def meta_get_packagelist(apiurl, prj, deleted=None, expand=False):
     query = {}
     if deleted:
         query['deleted'] = 1
+    elif deleted in (False, 0):
+        # HACK: Omitted 'deleted' and 'deleted=0' produce different results.
+        # By explicit 'deleted=0', we also get multibuild packages listed.
+        # See: https://github.com/openSUSE/open-build-service/issues/9715
+        query['deleted'] = 0
     if expand:
         query['expand'] = 1
 


### PR DESCRIPTION
Fixes: https://github.com/openSUSE/osc/issues/495
Related to: https://github.com/openSUSE/open-build-service/issues/9715