### PR TITLE
Add XDG compatible location for osc plugins.

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -9570,6 +9570,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             '/usr/lib/osc-plugins',
             '/usr/local/lib/osc-plugins',
             '/var/lib/osc-plugins',  # Kept for backward compatibility
+            os.path.expanduser('~/.local/lib/osc-plugins'),
             os.path.expanduser('~/.osc-plugins')]
         for plugin_dir in plugin_dirs:
             if not os.path.isdir(plugin_dir):


### PR DESCRIPTION
I believe it is generally a good idea to move stuff from $HOME to XDG-compatible directories.