### PR TITLE
Handle a callable in credentials._LazyPassword.__str__

### DIFF
--- a/osc/credentials.py
+++ b/osc/credentials.py
@@ -40,9 +40,14 @@ class _LazyPassword(object):
 
     def __str__(self):
         if self._password is None:
-            self._password = self._pwfunc()
-            if self._password is None:
+            password = self._pwfunc()
+            if callable(password):
+                print('Warning: use of a deprecated credentials manager API.',
+                      file=sys.stderr)
+                password = password()
+            if password is None:
                 raise oscerr.OscIOError(None, 'Unable to retrieve password')
+            self._password = password
         return self._password
 
     def __len__(self):


### PR DESCRIPTION
It is possible that the self._pwfunc() call returns a callable. For
instance, if the keyutils.osc.OscKernelKeyringBackend is configured
in the oscrc. Hence, check in credentials._LazyPassword.__str__
if the returned password is a callable and, if so, call it. Moreover,
a deprecation warning is printed. Eventually, this compat code will
be removed again.

This is a follow-up commit for commit
784d330f202c6e53d5adaeb1b48f93ef1a2e0ad6 ("Only prompt for a password
if the server asks for it") (actually, it is a regression that was
not caught during the review...).