### PR TITLE
Show the md5s that are failing to validate

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -263,8 +263,8 @@ class Fetcher:
                         # delete it and mark it for downloading from the API
                         hdrmd5 = packagequery.PackageQuery.queryhdrmd5(i.fullfilename)
                         if not hdrmd5 or hdrmd5 != i.hdrmd5:
-                            print('%s/%s: attempting download from api, since the hdrmd5 did not match'
-                                % (i.project, i.name))
+                            print('%s/%s: attempting download from api, since the hdrmd5 did not match - %s != %s'
+                                % (i.project, i.name, hdrmd5, i.hdrmd5))
                         os.unlink(i.fullfilename)
                         self.__add_cpio(i)
 


### PR DESCRIPTION
Rather than just saying an md5 mismatch occured, show the exact values of the md5s that are failing. This generally indicates a mirror-synchronisation issue or something else that has gone wrong