### PR TITLE
Add support for project separator

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4704,6 +4704,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             prj_dir = opts.output_dir if opts.output_dir else project
             if not opts.output_dir and conf.config['checkout_no_colon']:
                 prj_dir = prj_dir.replace(':', '/')
+            else:
+                prj_dir = prj_dir.replace(':', conf.config['project_separator'])
             if os.path.exists(prj_dir):
                 sys.exit('osc: project directory \'%s\' already exists' % prj_dir)
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -98,6 +98,11 @@ class Osc(cmdln.Cmdln):
     def get_version(self):
         return get_osc_version()
 
+    def _process_project_name(self, project):
+        if isinstance(project, str):
+            return project.replace(conf.config['project_separator'], ':')
+        return project
+
     def get_optparser(self):
         """this is the parser for "global" options (not specific to subcommand)"""
 
@@ -349,6 +354,7 @@ class Osc(cmdln.Cmdln):
                 elif is_package_dir(cwd):
                     project = store_read_project(cwd)
                     package = store_read_package(cwd)
+            project = self._process_project_name(project)
         if len(args) > 1:
             package = args[1]
         if len(args) > 2:
@@ -510,7 +516,7 @@ class Osc(cmdln.Cmdln):
                 project = store_read_project(localdir)
                 package = store_read_package(localdir)
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
 
         if project == None or package == None:
@@ -555,7 +561,7 @@ class Osc(cmdln.Cmdln):
             else:
                 raise oscerr.WrongArgs('Either specify project [package] or call it from a project/package working copy')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
 
         query = {'cmd': 'addchannels'}
 
@@ -598,7 +604,7 @@ class Osc(cmdln.Cmdln):
             else:
                 raise oscerr.WrongArgs('Either specify project [package] or call it from a project/package working copy')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             if len(args) > 1:
                 channel = args[1]
 
@@ -651,7 +657,7 @@ class Osc(cmdln.Cmdln):
                 else:
                     sys.exit('This command must be called in a checked out project or patchinfo package.')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             if len(args) > 1:
                 patchinfo = args[1]
 
@@ -709,7 +715,7 @@ class Osc(cmdln.Cmdln):
             project = store_read_project(os.curdir)
             package = store_read_package(os.curdir)
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         else:
             raise oscerr.WrongArgs('need Project and Package')
@@ -751,13 +757,13 @@ class Osc(cmdln.Cmdln):
 
         devprj, devpkg = None, None
         if len(args) == 3 or len(args) == 4:
-            project, package = args[0], args[1]
-            devprj = args[2]
+            project, package = self._process_project_name(args[0]), args[1]
+            devprj = self._process_project_name(args[2])
             if len(args) == 4:
                 devpkg = args[3]
         elif len(args) >= 1 and len(args) <= 2:
             project, package = store_read_project(os.curdir), store_read_package(os.curdir)
-            devprj = args[0]
+            devprj = self._process_project_name(args[0])
             if len(args) == 2:
                 devpkg = args[1]
         else:
@@ -782,7 +788,7 @@ class Osc(cmdln.Cmdln):
         localdir = os.getcwd()
         project = package = None
         if len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         elif is_package_dir(localdir):
             project = store_read_project(localdir)
@@ -992,7 +998,7 @@ class Osc(cmdln.Cmdln):
                 apiurl = store_read_apiurl(os.curdir)
                 project = store_read_project(os.curdir)
             else:
-                project = args[0]
+                project = self._process_project_name(args[0])
 
         elif cmd == 'pkg':
             if len(args) < 2:
@@ -1003,11 +1009,11 @@ class Osc(cmdln.Cmdln):
                 else:
                     package = args[0]
             else:
-                project = args[0]
+                project = self._process_project_name(args[0])
                 package = args[1]
 
         elif cmd == 'attribute':
-            project = args[0]
+            project = self._process_project_name(args[0])
             if len(args) > 1:
                 package = args[1]
             else:
@@ -1030,7 +1036,7 @@ class Osc(cmdln.Cmdln):
         elif cmd == 'group':
             group = args[0]
         elif cmd == 'pattern':
-            project = args[0]
+            project = self._process_project_name(args[0])
             if len(args) > 1:
                 pattern = args[1]
             else:
@@ -1338,7 +1344,7 @@ class Osc(cmdln.Cmdln):
 
             target_project = None
             if len(args) == 1:
-                target_project = args[0]
+                target_project = self._process_project_name(args[0])
             if opts.separate_requests or opts.seperate_requests:
                 for p in meta_get_packagelist(apiurl, project):
                     # get _link info from server, that knows about the local state ...
@@ -1430,7 +1436,7 @@ class Osc(cmdln.Cmdln):
                 dst_project = p.linkinfo.project
                 dst_package = p.linkinfo.package
             elif len(args) > 0:
-                dst_project = args[0]
+                dst_project = self._process_project_name(args[0])
                 if len(args) == 2:
                     dst_package = args[1]
                 else:
@@ -1455,6 +1461,7 @@ class Osc(cmdln.Cmdln):
                 dst_package = args[3]
             else:
                 dst_package = src_package
+            dst_project = self._process_project_name(dst_project)
         else:
             raise oscerr.WrongArgs('Incorrect number of arguments.\n\n' \
                   + self.get_cmd_help('request'))
@@ -1657,7 +1664,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 dst_project = p.linkinfo.project
                 dst_package = p.linkinfo.package
             elif len(args) > 0:
-                dst_project = args[0]
+                dst_project = self._process_project_name(args[0])
                 if len(args) == 2:
                     dst_package = args[1]
                 else:
@@ -1679,6 +1686,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 dst_package = args[3]
             else:
                 dst_package = src_package
+            dst_project = self._process_project_name(dst_project)
         else:
             raise oscerr.WrongArgs('Incorrect number of arguments.\n\n' \
                   + self.get_cmd_help('request'))
@@ -1750,12 +1758,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             if len(args) < 3:
                 raise oscerr.WrongArgs('Too few arguments.')
 
-            devel_project = args[2]
-            project = args[0]
+            devel_project = self._process_project_name(args[2])
+            project = self._process_project_name(args[0])
             package = args[1]
             devel_package = package
             if len(args) > 3:
-                devel_package = args[3]
+                devel_package = self._process_project_name(args[3])
 
         actionxml = """ <action type="change_devel"> <source project="%s" package="%s" /> <target project="%s" package="%s" /> </action> """ % \
                 (devel_project, devel_package, project, package)
@@ -1772,7 +1780,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         user = conf.get_apiurl_usr(apiurl)
         role = args[0]
-        project = args[1]
+        project = self._process_project_name(args[1])
         actionxml = """ <action type="add_role"> <target project="%s" /> <person name="%s" role="%s" /> </action> """ % \
                 (project, user, role)
 
@@ -1796,7 +1804,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         user = args[0]
         role = args[1]
-        project = args[2]
+        project = self._process_project_name(args[2])
         actionxml = """ <action type="add_role"> <target project="%s" /> <person name="%s" role="%s" /> </action> """ % \
                 (project, user, role)
 
@@ -1820,7 +1828,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         group = args[0]
         role = args[1]
-        project = args[2]
+        project = self._process_project_name(args[2])
         actionxml = """ <action type="add_role"> <target project="%s" /> <group name="%s" role="%s" /> </action> """ % \
                 (project, group, role)
 
@@ -1843,7 +1851,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
 
         user = args[0]
-        project = args[1]
+        project = self._process_project_name(args[1])
         package = ""
         if len(args) > 2:
             package = """package="%s" """ % (args[2])
@@ -2007,7 +2015,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
 
         if len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             if package.startswith('group:'):
                 user = package
@@ -2015,7 +2023,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 user = conf.get_apiurl_usr(apiurl)
         elif len(args) == 3:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             user = args[2]
         elif len(args) < 2 and is_package_dir(os.curdir):
@@ -2027,7 +2035,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 user = args[0]
         elif len(args) == 1:
             user = conf.get_apiurl_usr(apiurl)
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = None
         else:
             raise oscerr.WrongArgs('Wrong number of arguments.')
@@ -2093,9 +2101,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if len(args) > 2:
             raise oscerr.WrongArgs('Too many arguments.')
         elif len(args) == 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         elif is_project_dir(os.getcwd()):
             project = store_read_project(os.curdir)
@@ -2157,8 +2165,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         elif len(args) > 4:
             raise oscerr.WrongArgs('Too many arguments.')
         else:
-            devel_project = args[2]
-            project = args[0]
+            devel_project = self._process_project_name(args[2])
+            project = self._process_project_name(args[0])
             package = args[1]
             devel_package = package
             if len(args) == 4:
@@ -2385,7 +2393,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             package = None
             project = None
             if len(args) > 0:
-                project = args[0]
+                project = self._process_project_name(args[0])
             elif opts.project:
                 project = opts.project
                 if opts.package:
@@ -2814,10 +2822,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             if not p.islink():
                 sys.exit('Local directory is no checked out source link package, aborting')
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         elif len(args) == 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
         else:
             raise oscerr.WrongArgs('Incorrect number of arguments.\n\n' \
                   + self.get_cmd_help('setlinkrev'))
@@ -2860,7 +2868,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         elif len(args) > 2:
             raise oscerr.WrongArgs('Too many arguments (required none or two)')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             update_local_dir = False
 
@@ -2890,7 +2898,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = store_read_project(os.curdir)
             package = store_read_package(os.curdir)
         elif len(args) == 2:
-            project, package = args
+            project = self._process_project_name(args[0])
+            package = args[1]
         elif len(args) > 2:
             raise oscerr.WrongArgs('Too many arguments (required none or two)')
         else:
@@ -2965,9 +2974,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         rev, dummy = parseRevisionOption(opts.revision)
         vrev = None
 
-        src_project = args[0]
+        src_project = self._process_project_name(args[0])
         src_package = args[1]
-        dst_project = args[2]
+        dst_project = self._process_project_name(args[2])
         if len(args) > 3:
             dst_package = args[3]
         else:
@@ -3024,9 +3033,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('Incorrect number of arguments.\n\n' \
                   + self.get_cmd_help('aggregatepac'))
 
-        src_project = args[0]
+        src_project = self._process_project_name(args[0])
         src_package = args[1]
-        dst_project = args[2]
+        dst_project = self._process_project_name(args[2])
         if len(args) > 3:
             dst_package = args[3]
         else:
@@ -3087,9 +3096,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('Incorrect number of arguments.\n\n' \
                   + self.get_cmd_help('copypac'))
 
-        src_project = args[0]
+        src_project = self._process_project_name(args[0])
         src_package = args[1]
-        dst_project = args[2]
+        dst_project = self._process_project_name(args[2])
         if len(args) > 3:
             dst_package = args[3]
         else:
@@ -3177,7 +3186,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 raise oscerr.WrongArgs('Too few arguments.')
         if len(args) > 0:
-            source_project = args[0]
+            source_project = self._process_project_name(args[0])
         if len(args) > 1:
             source_package = args[1]
 
@@ -3248,7 +3257,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         elif len(args) == 0:
             raise oscerr.WrongArgs('Too few arguments.')
         if len(args) > 0:
-            source_project = args[0]
+            source_project = self._process_project_name(args[0])
 
         f = show_project_meta(apiurl, source_project)
         root = ET.fromstring(b''.join(f))
@@ -3309,7 +3318,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('Too many arguments.')
 
         if len(args) == 1:
-            target_project = args[0]
+            target_project = self._process_project_name(args[0])
         else:
             xpath = 'attribute/@name = \'%s\'' % maintenance_attribute
             res = search(apiurl, project_id=xpath)
@@ -3404,12 +3413,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 else:
                     raise oscerr.WrongArgs('No package directory')
             else:
-                source_project = args[0]
+                source_project = self._process_project_name(args[0])
         if len(args) > 1:
             if len(args) == 2:
                 sys.exit('Source package defined, but no release project.')
             source_packages = args[1:]
-            release_project = args[-1]
+            release_project = self._process_project_name(args[-1])
             source_packages.remove(release_project)
         if opts.cleanup:
             opt_sourceupdate = 'cleanup'
@@ -3530,7 +3539,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if len(args) >= 1:
             package = args[0]
         if len(args) >= 2:
-            tproject = args[1]
+            tproject = self._process_project_name(args[1])
 
         if subcmd == 'sm' or subcmd == 'maintained':
             opts.dryrun = 1
@@ -3661,7 +3670,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         expected = 'home:%s:branches:%s' % (conf.get_apiurl_usr(apiurl), args[0])
         if len(args) >= 3:
-            expected = tproject = args[2]
+            expected = tproject = self._process_project_name(args[2])
         if len(args) >= 4:
             tpackage = args[3]
 
@@ -3670,7 +3679,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         try:
             exists, targetprj, targetpkg, srcprj, srcpkg = \
-                branch_pkg(apiurl, args[0], args[1],
+                branch_pkg(apiurl, self._process_project_name(args[0]), args[1],
                            nodevelproject=opts.nodevelproject, rev=opts.revision,
                            linkrev=opts.linkrev,
                            target_project=tproject, target_package=tpackage,
@@ -3686,7 +3695,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print('NOTE: Package target exists already via project links, link will point to given project.')
             print('      A submission will initialize a new instance.')
             exists, targetprj, targetpkg, srcprj, srcpkg = \
-                branch_pkg(apiurl, args[0], args[1],
+                branch_pkg(apiurl, self._process_project_name(args[0]), args[1],
                            nodevelproject=opts.nodevelproject, rev=opts.revision,
                            linkrev=opts.linkrev,
                            target_project=tproject, target_package=tpackage,
@@ -3704,7 +3713,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print('Using existing branch project: %s' % targetprj, file=sys.stderr)
 
         devloc = None
-        if not exists and (srcprj != args[0] or srcpkg != args[1]):
+        if not exists and (srcprj != self._process_project_name(args[0]) or srcpkg != args[1]):
             try:
                 root = ET.fromstring(b''.join(show_attribute_meta(apiurl, args[0], None, None,
                     conf.config['maintained_update_project_attribute'], False, False)))
@@ -3766,7 +3775,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             msg = edit_message()
 
         apiurl = self.get_api_url()
-        prj = args[0]
+        prj = self._process_project_name(args[0])
         pkgs = args[1:]
 
         if pkgs:
@@ -3804,7 +3813,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('Wrong number of arguments')
 
         apiurl = self.get_api_url()
-        prj = args[0]
+        prj = self._process_project_name(args[0])
 
         msg = ''
         if opts.message:
@@ -3892,7 +3901,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('Wrong number of arguments')
 
         apiurl = self.get_api_url()
-        prj = args[0]
+        prj = self._process_project_name(args[0])
 
         msg = ''
         if opts.message:
@@ -4123,7 +4132,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         new_package = None
 
         if len(args) == 2:
-            new_project = args[0]
+            new_project = self._process_project_name(args[0])
             new_package = args[1]
             if opts.oldprj:
                 old_project = opts.oldprj
@@ -4132,13 +4141,13 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         elif len(args) == 3 or len(args) == 4:
             if opts.oldprj or opts.oldpkg:
                 raise oscerr.WrongArgs('--oldpkg and --oldprj are only valid with two arguments')
-            old_project = args[0]
+            old_project = self._process_project_name(args[0])
             new_package = old_package = args[1]
-            new_project = args[2]
+            new_project = self._process_project_name(args[2])
             if len(args) == 4:
                 new_package = args[3]
         elif len(args) == 1 and opts.meta:
-            new_project = args[0]
+            new_project = self._process_project_name(args[0])
             new_package = '_project'
         else:
             raise oscerr.WrongArgs('Wrong number of arguments')
@@ -4287,7 +4296,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = store_read_project(os.curdir)
             package = args[0]
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         else:
             raise RuntimeError('Internal error: bad check for arguments.')
@@ -4424,12 +4433,13 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 raise oscerr.WrongArgs('Current directory is not a project.')
         elif len(args) == 1:
-            newprj = args[0]
+            newprj = self._process_project_name(args[0])
             oldprj = self._get_branch_parent(newprj)
             if oldprj is None:
                 raise oscerr.WrongArgs('Single-argument form must be for a home branch.')
         elif len(args) == 2:
-            oldprj, newprj = args
+            oldprj = self._process_project_name(args[0])
+            newprj = self._process_project_name(args[1])
         else:
             raise RuntimeError('BUG in argument parsing, please report.\n'
                                'args: ' + repr(args))
@@ -4510,7 +4520,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
 
         if len(args) == 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
         elif len(args) == 0:
             project = store_read_project('.')
         else:
@@ -4550,9 +4560,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         package = None
         if len(args) == 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         elif len(args) == 0:
             project = store_read_project('.')
@@ -4656,7 +4666,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = package = filename = None
             apiurl = self.get_api_url()
             try:
-                project = project_dir = args[0]
+                project = project_dir = self._process_project_name(args[0])
                 package = args[1]
                 filename = args[2]
             except:
@@ -5519,7 +5529,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = store_read_project(wd)
             package = store_read_package(wd)
         if len(args) > 0:
-            project = args[0]
+            project = self._process_project_name(args[0])
         if len(args) > 1:
             package = args[1]
 
@@ -5608,7 +5618,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if args:
             if len(args) == 1:
-                project = args[0]
+                project = self._process_project_name(args[0])
             else:
                 raise oscerr.WrongArgs('Wrong number of arguments.')
         else:
@@ -5829,6 +5839,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 raise oscerr.WrongArgs('Too many arguments.')
             else:
                 project, package, repository, arch = args
+                project = self._process_project_name(project)
 
         if opts.multibuild_package:
             package = package + ":" + opts.multibuild_package
@@ -5973,7 +5984,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             repository = args[0]
             arch = args[1]
         elif len(args) == 4:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repository = args[2]
             arch = args[3]
@@ -6074,12 +6085,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             arch = args[1]
 
         if len(args) == 3:
-            project = args[0]
+            project = self._process_project_name(args[0])
             repository = args[1]
             arch = args[2]
 
         if len(args) == 4:
-            project = args[0]
+            project = self._process_project_name(args[0])
             packages = [args[1]]
             repository = args[2]
             arch = args[3]
@@ -6152,7 +6163,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 package = store_read_package('.')
             repository, arch, build_descr = self.parse_repoarchdescr(args, alternative_project=opts.alternative_project, ignore_descr=True, multibuild_package=opts.multibuild_package)
         elif len(args) == 4 or len(args) == 5:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repository = args[2]
             arch = args[3]
@@ -6224,7 +6235,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             project = store_read_project(wd)
             repository = args[0]
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             repository = args[1]
         else:
             raise oscerr.WrongArgs('Wrong number of arguments.')
@@ -6269,7 +6280,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         args = slash_split(args)
 
         if len(args) == 4:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repository = args[2]
             arch = args[3]
@@ -6334,9 +6345,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         disabled = None
 
         if len(args) == 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
         elif len(args) == 2:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
         elif len(args) == 0:
             if is_package_dir('.'):
@@ -6985,7 +6996,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
 
         if len(args) == 4:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repository = args[2]
             arch = args[3]
@@ -7034,12 +7045,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
 
         if len(args) == 4:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repository = args[2]
             arch = args[3]
         elif len(args) == 3:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = None        # skipped = prj
             repository = args[1]
             arch = args[2]
@@ -7116,10 +7127,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         elif len(args) > 2:
             raise oscerr.WrongArgs('Too many arguments (required none or two)')
         elif len(args) == 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = "_project"
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
 
         rev, rev_upper = parseRevisionOption(opts.revision, allow_md5=False)
@@ -7193,7 +7204,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             if len(args) == 2:
                 singleservice = args[1]
         elif len(args) == 3 and args[0] in remote_commands:
-            project = args[1]
+            project = self._process_project_name(args[1])
             package = args[2]
         else:
             raise oscerr.WrongArgs('Too many arguments.')
@@ -7279,7 +7290,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 raise oscerr.WrongArgs('Too few arguments.')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             if len(args) > 1:
                 package = args[1]
 
@@ -7354,7 +7365,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         elif len(args) != 5:
             raise oscerr.WrongArgs('Wrong number of arguments.')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repo = args[2]
             arch = args[3]
@@ -7404,7 +7415,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 raise oscerr.WrongArgs('Too few arguments.')
         else:
-            project = args[0]
+            project = self._process_project_name(args[0])
             if len(args) > 1:
                 package = args[1]
 
@@ -7477,7 +7488,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         # respect given project and package
         if len(args) >= 1:
-            project = args[0]
+            project = self._process_project_name(args[0])
 
         if len(args) == 2:
             package = args[1]
@@ -7559,7 +7570,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         architecture = None
         if len(args) == 4 or len(args) == 5:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             repository = args[2]
             architecture = args[3]
@@ -8461,9 +8472,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             prj = store_read_project('.')
         elif len(args) == 1:
             # it is unclear if one argument is a search_term or a project, try search_term first for new OBS 2.4
-            search_term = prj = args[0]
+            search_term = prj = self._process_project_name(args[0])
         elif len(args) == 2:
-            prj = args[0]
+            prj = self._process_project_name(args[0])
             pac = args[1]
         else:
             raise oscerr.WrongArgs('Wrong number of arguments.')
@@ -8719,7 +8730,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         args = slash_split(args)
         project = package = filename = None
         if len(args) == 3:
-            project = args[0]
+            project = self._process_project_name(args[0])
             package = args[1]
             filename = args[2]
         elif len(args) == 1 and is_package_dir(os.getcwd()):
@@ -8793,13 +8804,13 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         apiurl = self.get_api_url()
         args = slash_split(args)
         if len(args) >= 3 and len(args) <= 4:
-            prj = args[0]
+            prj = self._process_project_name(args[0])
             package = target_package = args[1]
-            target_prj = args[2]
+            target_prj = self._process_project_name(args[2])
             if len(args) == 4:
                 target_package = args[3]
         elif len(args) == 2:
-            target_prj = prj = args[0]
+            target_prj = prj = self._process_project_name(args[0])
             target_package = package = args[1]
         elif is_package_dir(os.getcwd()):
             target_prj = prj = store_read_project(os.getcwd())
@@ -9140,7 +9151,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             if is_project_dir(cwd) or is_package_dir(cwd):
                 prj = store_read_project(cwd)
         if len(args) == 1:
-            prj = args[0]
+            prj = self._process_project_name(args[0])
 
         if not prj:
             raise oscerr.WrongArgs('Please specify just the project')

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -168,6 +168,8 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'getpac_default_project': 'openSUSE:Factory',
             # alternate filesystem layout: have multiple subdirs, where colons were.
             'checkout_no_colon': '0',
+            # project separator
+            'project_separator': ':',
             # change filesystem layout: avoid checkout from within a proj or package dir.
             'checkout_rooted': '0',
             # local files to ignore with status, addremove, ....
@@ -337,6 +339,9 @@ apiurl = %(apiurl)s
 
 # alternate filesystem layout: have multiple subdirs, where colons were.
 #checkout_no_colon = %(checkout_no_colon)s
+
+# instead of colons, use the specified as separator
+#project_separator = %(project_separator)s
 
 # change filesystem layout: avoid checkout within a project or package dir.
 #checkout_rooted = %(checkout_rooted)s

--- a/osc/core.py
+++ b/osc/core.py
@@ -5136,6 +5136,8 @@ def checkout_package(apiurl, project, package,
         prj_dir = olddir
     elif conf.config['checkout_no_colon']:
         prj_dir = prj_dir.replace(':', '/')
+    else:
+        prj_dir = prj_dir.replace(':', conf.config['project_separator'])
 
     root_dots = '.'
     if conf.config['checkout_rooted']:


### PR DESCRIPTION
The motivation is to have a configurable project separator and not just use hardcoded colon. The main obstacle in using colons as project separator is the inability of including colon in environment variables like PATH or LD_LIBRARY_PATH. This then breaks in not so subtle and yet wonderfully mysterious ways.

An example is to do `npm install` and then doing `npm run` and getting "command not found" because the cwd cannot be added to PATH. Another is trying to run a unit test that fixes a segfault in a program, yet the ctest keeps failing because the patch contains : and thus is unusable in the LD_LIBRARY_PATH that you expect to run...

As a workaround, I've now taken advantage of UTF-8 and can have checkouts like,

     home🚀adamm🚀valgrind/valgrind

by ading this to the config file (.oscrc),

    project_separator = 🚀

(FYI: I'm using a rocket emoji to lift my productivity in this Web 3.0 world)

Regarding patches, the small one allows for checkouts. The big one is to make things work the other way, allowing you to copy paste the altered checkout.

I've marked this as WIP because I haven't yet checked if I've managed to find all the places where project is parsed as osc argument in the big patch.

Opinions and feedback is welcome.
