### PR TITLE
Add python-rpmextras_require for rpm signature verification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ setuptools.setup(
     packages=['osc', 'osc.util'],
     data_files=data_files,
     install_requires=['cryptography', 'urllib3'],
+    extras_require={
+       'RPM signature verification': ['rpm'],
+    },
     entry_points={
       'console_scripts': [
           'osc=osc.babysitter:main'


### PR DESCRIPTION
The dependency was added in 8fb9669ae414f06e61dbe112704540e6b8ce55ca but not specified.