### PR TITLE
commandline: handle calls without arguments gracefully

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -134,7 +134,7 @@ class Osc(cmdln.Cmdln):
     def postoptparse(self):
         """merge commandline options into the config"""
 
-        if self._get_canonical_cmd_name(self.args[0]) == "help":
+        if not self.args or self._get_canonical_cmd_name(self.args[0]) == "help":
             # avoid loading config that may trigger prompt for username, password etc.
             return
 


### PR DESCRIPTION
Fixes the following error:

```
%  osc
Traceback (most recent call last):
  File "/usr/bin/osc", line 45, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python3.10/site-packages/osc/babysitter.py", line 67, in run
    return prg.main(argv)
  File "/usr/lib/python3.10/site-packages/osc/cmdln.py", line 341, in main
    self.postoptparse()
  File "/usr/lib/python3.10/site-packages/osc/commandline.py", line 137, in postoptparse
    if self._get_canonical_cmd_name(self.args[0]) == "help":
IndexError: list index out of range
```