### PR TITLE
Move test runner from pytest back to standard unittest

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -50,7 +50,7 @@ jobs:
             zypper --non-interactive --gpg-auto-import-keys refresh
             zypper --non-interactive dist-upgrade
             zypper --non-interactive install git-lfs
-            zypper --non-interactive install diffstat diffutils python3 python3-chardet python3-M2Crypto python3-pip python3-pytest python3-rpm python3-setuptools
+            zypper --non-interactive install diffstat diffutils python3 python3-chardet python3-M2Crypto python3-pip python3-rpm python3-setuptools
 
       - name: 'Install packages (Fedora/CentOS)'
         if: ${{ startsWith(matrix.container, 'fedora:') || contains(matrix.container, 'centos:')  }}
@@ -58,7 +58,7 @@ jobs:
             dnf -y makecache
             dnf -y distro-sync
             dnf -y install git-lfs
-            dnf -y install diffstat diffutils python3 python3-chardet python3-m2crypto python3-pip python3-pytest python3-rpm python3-setuptools
+            dnf -y install diffstat diffutils python3 python3-chardet python3-m2crypto python3-pip python3-rpm python3-setuptools
 
       - name: 'Install packages (Debian/Ubuntu)'
         if: ${{ startsWith(matrix.container, 'debian:') || startsWith(matrix.container, 'ubuntu:')  }}
@@ -66,7 +66,7 @@ jobs:
             apt-get -y update
             apt-get -y upgrade
             apt-get -y --no-install-recommends install git-lfs
-            apt-get -y --no-install-recommends install diffstat diffutils python3 python3-chardet python3-m2crypto python3-pip python3-pytest python3-rpm python3-setuptools
+            apt-get -y --no-install-recommends install diffstat diffutils python3 python3-chardet python3-m2crypto python3-pip python3-rpm python3-setuptools
 
       - uses: actions/checkout@v3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[options]
-setup_requires =
-    pytest-runner
-tests_require =
-    pytest
-
-[aliases]
-test=pytest
-
 [flake8]
 exclude = .git,__pycache__
 max-line-length = 120


### PR DESCRIPTION
One dependency less.
It would also become a problem on CentOS Stream 9 where pytest is not available.