### PR TITLE
fix product build rpm caching

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -293,7 +293,7 @@ class Pac:
 
 
     def makeurls(self, cachedir, urllist):
-        self.localdir = '%s/%s/%s/%s' % (cachedir, self.project, self.repository, self.arch)
+        self.localdir = '%s/%s/%s/%s' % (cachedir, self.project, self.repository, self.repoarch)
         self.fullfilename = os.path.join(self.localdir, self.canonname)
         self.urllist = [url % self.mp for url in urllist]
 

--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -265,8 +265,8 @@ class Fetcher:
                         if not hdrmd5 or hdrmd5 != i.hdrmd5:
                             print('%s/%s: attempting download from api, since the hdrmd5 did not match - %s != %s'
                                 % (i.project, i.name, hdrmd5, i.hdrmd5))
-                        os.unlink(i.fullfilename)
-                        self.__add_cpio(i)
+                            os.unlink(i.fullfilename)
+                            self.__add_cpio(i)
 
                 except KeyboardInterrupt:
                     print('Cancelled by user (ctrl-c)')


### PR DESCRIPTION
* src/noarch rpm packaages needs to be stored in scheduler architecture to avoid
  conflicts of the multiple versions
* avoid removal of every downloaded file