### PR TITLE
No need to install Python 3 explicitly

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -58,7 +58,7 @@ jobs:
             dnf -y makecache
             dnf -y distro-sync
             dnf -y install git-lfs
-            dnf -y install diffstat diffutils python3 python3-chardet python3-m2crypto python3-pip python3-rpm python3-setuptools
+            dnf -y install diffstat diffutils python3-chardet python3-m2crypto python3-pip python3-rpm python3-setuptools
 
       - name: 'Install packages (Debian/Ubuntu)'
         if: ${{ startsWith(matrix.container, 'debian:') || startsWith(matrix.container, 'ubuntu:')  }}
@@ -66,7 +66,7 @@ jobs:
             apt-get -y update
             apt-get -y upgrade
             apt-get -y --no-install-recommends install git-lfs
-            apt-get -y --no-install-recommends install diffstat diffutils python3 python3-chardet python3-m2crypto python3-pip python3-rpm python3-setuptools
+            apt-get -y --no-install-recommends install diffstat diffutils python3-chardet python3-m2crypto python3-pip python3-rpm python3-setuptools
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -50,7 +50,7 @@ jobs:
             zypper --non-interactive --gpg-auto-import-keys refresh
             zypper --non-interactive dist-upgrade
             zypper --non-interactive install git-lfs
-            zypper --non-interactive install diffstat diffutils python3 python3-chardet python3-M2Crypto python3-pip python3-rpm python3-setuptools
+            zypper --non-interactive install diffstat diffutils python3-chardet python3-M2Crypto python3-pip python3-rpm python3-setuptools
 
       - name: 'Install packages (Fedora/CentOS)'
         if: ${{ startsWith(matrix.container, 'fedora:') || contains(matrix.container, 'centos:')  }}


### PR DESCRIPTION
It's pulled as a dependency to python3-* packages.
This should fix test failures on `fedora:rawhide`.

Fedora install step fails right now, because `dnf` outputs this to `stderr`.
```
Complete!
Last metadata expiration check: 0:00:53 ago on Sun Jul 24 17:32:14 2022.
Package python3-3.11.0~b4-1.fc37.x86_64 is already installed.
Package python3-rpm-4.18.0-0.beta1.2.fc37.x86_64 is already installed.
Error: 
(try to add '--skip-broken' to skip uninstallable packages)
 Problem: conflicting requests
  - nothing provides python(abi) = 3.10 needed by python3-m2crypto-0.38.0-2.fc35.x86_64
Error: Process completed with exit code 1.
```
And GitHub Actions treat non-empty `stderr` as error.