### PR TITLE
Move out table formatting in `osc dist` into helper function

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5358,7 +5358,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         """
         apiurl = self.get_api_url()
 
-        print('\n'.join(get_distibutions(apiurl)))  # FIXME:, opts.discontinued))
+        print('\n'.join(get_distributions(apiurl)))  # FIXME:, opts.discontinued))
 
     @cmdln.hide(1)
     def do_results_meta(self, subcmd, opts, *args):

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -19,7 +19,7 @@ from . import conf
 from . import oscerr
 from .core import *
 from .util import safewriter
-from .util.helper import _html_escape
+from .util.helper import _html_escape, format_table
 
 
 MAN_HEADER = r""".TH %(ucname)s "1" "%(date)s" "%(name)s %(version)s" "User Commands"
@@ -5358,7 +5358,14 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         """
         apiurl = self.get_api_url()
 
-        print('\n'.join(get_distributions(apiurl)))  # FIXME:, opts.discontinued))
+        dists = get_distributions(apiurl)
+        if dists:
+            headers = dists[0].keys()
+            rows = []
+            for dist in dists:
+                rows.append([dist[h] for h in headers])
+            print(format_table(rows, headers))
+
 
     @cmdln.hide(1)
     def do_results_meta(self, subcmd, opts, *args):

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5364,7 +5364,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             rows = []
             for dist in dists:
                 rows.append([dist[h] for h in headers])
-            print(format_table(rows, headers))
+            print(format_table(rows, headers).rstrip())
 
 
     @cmdln.hide(1)

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5341,10 +5341,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
 
     @cmdln.alias('dists')
-# FIXME: using just ^DISCONTINUED as match is not a general approach and only valid for one instance
-#        we need to discuss an api call for that, if we need this
-#    @cmdln.option('-d', '--discontinued', action='store_true',
-#                        help='show discontinued distributions')
     def do_distributions(self, subcmd, opts, *args):
         """${cmd_name}: Shows all available distributions
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -5603,7 +5603,7 @@ def get_repositories(apiurl):
     return r
 
 
-def get_distibutions(apiurl, discon=False):
+def get_distributions(apiurl, discon=False):
     r = []
 
     # FIXME: this is just a naming convention on api.opensuse.org, but not a general valid apparoach

--- a/osc/core.py
+++ b/osc/core.py
@@ -40,7 +40,7 @@ except ImportError:
 from . import conf
 from . import oscerr
 from .connection import http_request, http_GET, http_POST, http_PUT, http_DELETE
-from .util.helper import decode_list, decode_it, raw_input, _html_escape
+from .util.helper import decode_list, decode_it, raw_input, _html_escape, format_table
 
 
 ET_ENCODING = "unicode"
@@ -5625,25 +5625,6 @@ def get_distributions(apiurl, discon=False):
     else:
         f = http_GET(makeurl(apiurl, ['distributions']))
         root = ET.fromstring(b''.join(f))
-
-        def format_table(rows, headers):
-            """Format list of tuples into equal width table with headers"""
-            maxlens = [len(h) for h in headers]
-            for r in rows:
-                for i, c in enumerate(r):
-                    maxlens[i] = max(maxlens[i], len(c))
-            tpltpl = []
-            for i, m in enumerate(maxlens):
-                tpltpl.append('{%s:<%s}' % (i, m))
-            # {0:12}  {1:7}  {2:10}  {3:8}
-            templ = '  '.join(tpltpl) + '\n'
-
-            out = ''
-            out += templ.format(*headers)
-            out += templ.format(*['-'*m for m in maxlens])
-            for r in rows:
-                out += templ.format(*r)
-            return out
 
         headers = ('distribution', 'project', 'repository', 'reponame')
         distlist = []

--- a/osc/core.py
+++ b/osc/core.py
@@ -5603,27 +5603,9 @@ def get_repositories(apiurl):
     return r
 
 
-def get_distributions(apiurl, discon=False):
+def get_distributions(apiurl):
     """Returns list of dicts with headers
       'distribution', 'project', 'repository', 'reponame'"""
-
-    # FIXME: this is just a naming convention on api.opensuse.org, but not a general valid apparoach
-    if discon:
-        r = []
-        result_line_templ = '%(name)-25s %(project)s'
-        f = http_GET(makeurl(apiurl, ['build']))
-        root = ET.fromstring(''.join(f))
-
-        for node in root.findall('entry'):
-            if node.get('name').startswith('DISCONTINUED:'):
-                rmap = {}
-                rmap['name'] = node.get('name').replace('DISCONTINUED:', '').replace(':', ' ')
-                rmap['project'] = node.get('name')
-                r.append(result_line_templ % rmap)
-
-        r.insert(0, 'distribution              project')
-        r.insert(1, '------------              -------')
-        return r
 
     f = http_GET(makeurl(apiurl, ['distributions']))
     root = ET.fromstring(b''.join(f))

--- a/osc/core.py
+++ b/osc/core.py
@@ -5625,20 +5625,19 @@ def get_distributions(apiurl, discon=False):
         r.insert(1, '------------              -------')
         return r
 
-    else:
-        f = http_GET(makeurl(apiurl, ['distributions']))
-        root = ET.fromstring(b''.join(f))
+    f = http_GET(makeurl(apiurl, ['distributions']))
+    root = ET.fromstring(b''.join(f))
 
-        distlist = []
-        for node in root.findall('distribution'):
-            dmap = {}
-            for child in node:
-                if child.tag == 'name':
-                    dmap['distribution'] = child.text
-                elif child.tag in ('project', 'repository', 'reponame'):
-                    dmap[child.tag] = child.text
-            distlist.append(dmap)
-        return distlist
+    distlist = []
+    for node in root.findall('distribution'):
+        dmap = {}
+        for child in node:
+            if child.tag == 'name':
+                dmap['distribution'] = child.text
+            elif child.tag in ('project', 'repository', 'reponame'):
+                dmap[child.tag] = child.text
+        distlist.append(dmap)
+    return distlist
 
 
 # old compat lib call

--- a/osc/core.py
+++ b/osc/core.py
@@ -40,7 +40,7 @@ except ImportError:
 from . import conf
 from . import oscerr
 from .connection import http_request, http_GET, http_POST, http_PUT, http_DELETE
-from .util.helper import decode_list, decode_it, raw_input, _html_escape, format_table
+from .util.helper import decode_list, decode_it, raw_input, _html_escape
 
 
 ET_ENCODING = "unicode"
@@ -5604,10 +5604,12 @@ def get_repositories(apiurl):
 
 
 def get_distributions(apiurl, discon=False):
-    r = []
+    """Returns list of dicts with headers
+      'distribution', 'project', 'repository', 'reponame'"""
 
     # FIXME: this is just a naming convention on api.opensuse.org, but not a general valid apparoach
     if discon:
+        r = []
         result_line_templ = '%(name)-25s %(project)s'
         f = http_GET(makeurl(apiurl, ['build']))
         root = ET.fromstring(''.join(f))
@@ -5621,14 +5623,13 @@ def get_distributions(apiurl, discon=False):
 
         r.insert(0, 'distribution              project')
         r.insert(1, '------------              -------')
+        return r
 
     else:
         f = http_GET(makeurl(apiurl, ['distributions']))
         root = ET.fromstring(b''.join(f))
 
-        headers = ('distribution', 'project', 'repository', 'reponame')
         distlist = []
-        rows = []
         for node in root.findall('distribution'):
             dmap = {}
             for child in node:
@@ -5637,12 +5638,7 @@ def get_distributions(apiurl, discon=False):
                 elif child.tag in ('project', 'repository', 'reponame'):
                     dmap[child.tag] = child.text
             distlist.append(dmap)
-            # append row sorted by headers
-            rows.append([dmap[h] for h in headers])
-
-        return format_table(rows, headers).splitlines()
-
-    return r
+        return distlist
 
 
 # old compat lib call

--- a/osc/util/helper.py
+++ b/osc/util/helper.py
@@ -51,3 +51,22 @@ def raw_input(*args):
 
 def _html_escape(data):
     return html.escape(data, quote=False)
+
+
+def format_table(rows, headers):
+    """Format list of tuples into equal width table with headers"""
+    maxlens = [len(h) for h in headers]
+    for r in rows:
+        for i, c in enumerate(r):
+            maxlens[i] = max(maxlens[i], len(c))
+    tpltpl = []
+    for i, m in enumerate(maxlens):
+        tpltpl.append('{%s:<%s}' % (i, m))
+    # {0:12}  {1:7}  {2:10}  {3:8}
+    templ = '  '.join(tpltpl) + '\n'
+
+    out = templ.format(*headers)
+    out += templ.format(*['-'*m for m in maxlens])
+    for r in rows:
+        out += templ.format(*r)
+    return out


### PR DESCRIPTION
This is a cleanup of #863 and refactoring of internals.

* fixed typo in core `get_distributions` method name
* moved out formatting code into `util.helper.format_table` function
* made `core` method return list of dicts instead of list of strings