### PR TITLE
Another take to use arch when selecting repo for build target

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6396,16 +6396,23 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 # only persist our own repos
                 Repo.tofile(repolistfile, repositories)
 
+        if not repositories:
+            raise oscerr.WrongArgs('no configured repos to build against')
+
+        arch_repos = sorted({r.name for r in repositories if r.arch == arg_arch})
+        if arg_repository not in arch_repos:
+            raise oscerr.WrongArgs('no configured repos for arch %s' % (arg_arch))
+
         no_repo = False
         repo_names = sorted({r.name for r in repositories})
-        if not arg_repository and repositories:
+        if not arg_repository:
             # XXX: we should avoid hardcoding repository names
             # Use a default value from config, but just even if it's available
             # unless try standard, or openSUSE_Factory, or openSUSE_Tumbleweed
             no_repo = True
-            arg_repository = repositories[-1].name
+            arg_repository = arch_repos[-1]
             for repository in (conf.config['build_repository'], 'standard', 'openSUSE_Factory', 'openSUSE_Tumbleweed'):
-                if repository in repo_names:
+                if repository in arch_repos:
                     arg_repository = repository
                     no_repo = False
                     break

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6400,7 +6400,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             raise oscerr.WrongArgs('no configured repos to build against')
 
         arch_repos = sorted({r.name for r in repositories if r.arch == arg_arch})
-        if arg_repository not in arch_repos:
+        if not arch_repos:
             raise oscerr.WrongArgs('no configured repos for arch %s' % (arg_arch))
 
         no_repo = False


### PR DESCRIPTION
This is another attempt to solve problem that `osc build` selects `OpenSuse_Tumbleweed` even if this selection doesn't fit the required architecture.

https://github.com/openSUSE/osc/pull/241#issuecomment-1203673363

* [ ] trace the role of `no_repo`
* [ ] trace the role of `repo_names`
* [ ] check offline logic is not broken (check that offline still
      needed a non-empty repo list before this change)