### PR TITLE
DebQuery: Handle uncompressed Debian packages

### DIFF
--- a/osc/util/debquery.py
+++ b/osc/util/debquery.py
@@ -75,6 +75,11 @@ class DebQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
                         decompressed = reader.read()
                     tar = tarfile.open(name="control.tar.zst",
                                        fileobj=BytesIO(decompressed))
+                else:
+                    control = arfile.get_file(b'control.tar')
+                    if control:
+                        tar = tarfile.open(name="control.tar",
+                                           fileobj=control)
             if control is None:
                 raise DebError(self.__path, 'missing control.tar')
         try:

--- a/osc/util/debquery.py
+++ b/osc/util/debquery.py
@@ -69,34 +69,38 @@ class DebQuery(packagequery.PackageQuery, packagequery.PackageQueryResult):
 
     def _open_tar(self, arfile):
         control = arfile.get_file(b'control.tar')
-        if control:
-            return tarfile.open(fileobj=control)
-        return None
+        if not control:
+            return None
+
+        return tarfile.open(fileobj=control)
 
     def _open_tar_gz(self, arfile):
         control = arfile.get_file(b'control.tar.gz')
-        if control:
-            return tarfile.open(fileobj=control)
-        return None
+        if not control:
+            return None
+
+        return tarfile.open(fileobj=control)
 
     def _open_tar_xz(self, arfile):
         control = arfile.get_file(b'control.tar.xz')
-        if control:
-            if not HAVE_LZMA:
-                raise DebError(self._path, 'can\'t open control.tar.xz without python-lzma')
-            decompressed = lzma.decompress(control.read())
-            return tarfile.open(fileobj=BytesIO(decompressed))
-        return None
+        if not control:
+            return None
+
+        if not HAVE_LZMA:
+            raise DebError(self._path, 'can\'t open control.tar.xz without python-lzma')
+        decompressed = lzma.decompress(control.read())
+        return tarfile.open(fileobj=BytesIO(decompressed))
 
     def _open_tar_zst(self, arfile):
         control = arfile.get_file(b'control.tar.zst')
-        if control:
-            if not HAVE_ZSTD:
-                raise DebError(self._path, 'can\'t open control.tar.zst without python-zstandard')
-            with zstandard.ZstdDecompressor().stream_reader(BytesIO(control.read())) as reader:
-                decompressed = reader.read()
-            return tarfile.open(fileobj=BytesIO(decompressed))
-        return None
+        if not control:
+            return None
+
+        if not HAVE_ZSTD:
+            raise DebError(self._path, 'can\'t open control.tar.zst without python-zstandard')
+        with zstandard.ZstdDecompressor().stream_reader(BytesIO(control.read())) as reader:
+            decompressed = reader.read()
+        return tarfile.open(fileobj=BytesIO(decompressed))
 
     def _parse_control(self, control, all_tags=False, self_provides=True, *extra_tags):
         data = control.readline().strip()


### PR DESCRIPTION
Debian packages can also be uncompressed in which case the archive contains a control.tar file. Such a package can be created with `dpkg-deb -Znone`.

As an example for reproduction, the [linux-image-unsigned-*.deb](http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-image-unsigned-5.15.0-46-generic_5.15.0-46.49_amd64.deb) from Ubuntu 22.04 is not compressed.

With master:
```
$ python3 -m osc.util.debquery linux-image-unsigned-5.15.0-46-generic_5.15.0-46.49_amd64.deb 
missing control.tar
```
With this PR branch:
```
$ python3 -m osc.util.debquery linux-image-unsigned-5.15.0-46-generic_5.15.0-46.49_amd64.deb 
b'linux-image-unsigned-5.15.0-46-generic' b'5.15.0' b'46.49' b'amd64'
[...]
```

The first commit adds support for this uncompressed Debian package format. The second commit refactors the control.tar extraction in DebQuery to avoid the conditional cascade.