### PR TITLE
WIP: Add withhistory, withbinaries and makeoriginolder to copypac

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2980,8 +2980,14 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='URL of destination api server. Default is the source api server.')
     @cmdln.option('-m', '--message', metavar='TEXT',
                   help='specify message TEXT')
+    @cmdln.option('-M', '--make-origin-older', action='store_true',
+                  help='Make origin older, the source vrev is extended and target is guaranteed to be newer')
     @cmdln.option('-e', '--expand', action='store_true',
                         help='if the source package is a link then copy the expanded version of the link')
+    @cmdln.option('-w', '--with-history', action='store_true',
+                  help='copies sources with history on copy command')
+    @cmdln.option('-W', '--with-binaries', action='store_true',
+                  help='copies also binaries on copy command')
     def do_copypac(self, subcmd, opts, *args):
         """
         Copy a package
@@ -3038,6 +3044,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 comment += ", using expand"
             if opts.client_side_copy:
                 comment += ", using client side copy"
+            if opts.make_origin_older:
+                comment += ", making the origin older"
+            if opts.with_history:
+                comment += ", including history"
+            if opts.with_binaries:
+                comment += ", including binaries"
 
         if src_project == dst_project and \
            src_package == dst_package and \
@@ -3053,7 +3065,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                      expand=opts.expand,
                      revision=rev,
                      comment=comment,
-                     keep_link=opts.keep_link)
+                     keep_link=opts.keep_link,
+                     make_origin_older=opts.make_origin_older,
+                     with_history=opts.with_history,
+                     with_binaries=opts.with_binaries)
         print(decode_it(r))
 
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -5463,7 +5463,10 @@ def copy_pac(src_apiurl, src_project, src_package,
              revision = None,
              comment = None,
              force_meta_update = None,
-             keep_link = None):
+             keep_link = None,
+             make_origin_older=False,
+             with_history=False,
+             with_binaries=False):
     """
     Create a copy of a package.
 
@@ -5501,6 +5504,12 @@ def copy_pac(src_apiurl, src_project, src_package,
             query['orev'] = revision
         if comment:
             query['comment'] = comment
+        if make_origin_older:
+            query['makeoriginolder'] = '1'
+        if with_history:
+            query['withhistory'] = '1'
+        if with_binaries:
+            query['withbinaries'] = '1'
         u = makeurl(dst_apiurl, ['source', dst_project, dst_package], query=query)
         f = http_POST(u)
         return f.read()


### PR DESCRIPTION
Apparently the code is OK, but OBS does not like `witthistory`.

```
$ ./osc-wrapper.py -v copypac -W -w systemsmanagement:Uyuni:Master spacewalk home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master
makeurl: https://api.opensuse.org ['source', 'systemsmanagement:Uyuni:Master', 'spacewalk'] {'rev': 'latest'}
makeurl: https://api.opensuse.org ['source', 'systemsmanagement:Uyuni:Master', 'spacewalk', '_meta'] {}
makeurl: https://api.opensuse.org ['source/home%3Ajuliogonzalezgil%3Abranches%3Asystemsmanagement%3AUyuni%3AMaster/spacewalk/_meta'] {}
Copying files...
makeurl: https://api.opensuse.org ['source', 'home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master', 'spacewalk'] {'cmd': 'copy', 'oproject': 'systemsmanagement:Uyuni:Master', 'opackage': 'spacewalk', 'orev': '76', 'comment': 'osc copypac from project:systemsmanagement:Uyuni:Master package:spacewalk revision:76, including history, including binaries', 'withhistory': '1', 'withbinaries': '1'}
Server returned an error: HTTP Error 400: Bad Request
unknown parameter 'withhistory'
```

I still need to figure out what's wrong.

According to @hennevogel:

> POST /source/<project>/<package>?cmd=copy&withhistory=1&oproject=source_project&opackage=source_package

Should work. So I am not sure what I am missing here.