### PR TITLE
Do not traceback on conflicting argparse arguments

### DIFF
--- a/osc/cmdln.py
+++ b/osc/cmdln.py
@@ -174,7 +174,10 @@ class Cmdln:
             # add hidden copy of global options so they can be used in any place
             self.add_global_options(subparser, suppress=True)
             for option_args, option_kwargs in options:
-                subparser.add_argument(*option_args, **option_kwargs)
+                try:
+                    subparser.add_argument(*option_args, **option_kwargs)
+                except argparse.ArgumentError as e:
+                    print(f"WARNING: Could not add argument '{e.argument_name}' to the '{cmd_name}' sub-command: {e}", file=sys.stderr)
 
     def argparse_error(self, *args, **kwargs):
         """


### PR DESCRIPTION
If a plugin uses an argument that conflicts with osc's global args, osc fails with argparse.ArgumentError.
The exception is now caught and reported as a warning, while the conflicting argument is skipped.