### PR TITLE
Disable configparser interpolation to allow unescaped '%' in values

### DIFF
--- a/osc/OscConfigParser.py
+++ b/osc/OscConfigParser.py
@@ -211,7 +211,7 @@ class OscConfigParser(configparser.ConfigParser):
     """
 
     def __init__(self, defaults=None):
-        super().__init__(defaults or {})
+        super().__init__(defaults or {}, interpolation=None)
         self._sections = ConfigLineOrder()
 
     # XXX: unfortunately we have to override the _read() method from the ConfigParser()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,26 @@
+import unittest
+
+from osc.OscConfigParser import OscConfigParser
+
+
+class TestOscConfigParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = OscConfigParser()
+        self.parser.read_string("""
+[general]
+apiurl = http://localhost
+
+[http://localhost]
+credentials_mgr_class=
+user=
+pass=
+""")
+
+    def test_disabled_interpolation(self):
+        # with interpolation on, this would raise
+        # ValueError: invalid interpolation syntax in '%' at position 0
+        self.parser.set("http://localhost", "pass", "%")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fixes: #1155