### PR TITLE
Add "--extra-pkgs-from" ("-X") option to osc build

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -868,6 +868,12 @@ def main(apiurl, opts, argv):
     elif opts.extra_pkgs != ['']:
         extra_pkgs = opts.extra_pkgs
 
+    if opts.extra_pkgs_from:
+        for filename in opts.extra_pkgs_from:
+            with open(filename, encoding="utf-8") as f:
+                for line in f:
+                    extra_pkgs.append(line.rstrip('\n'))
+
     if xp:
         extra_pkgs += xp
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6290,6 +6290,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help=HELP_MULTIBUILD_ONE)
     @cmdln.option('-x', '--extra-pkgs', metavar='PAC', action='append',
                   help='Add this package when installing the build-root')
+    @cmdln.option('-X', '--extra-pkgs-from', metavar='FILE', action='append',
+                  help='Add packages listed in this file when installing the build-root')
     @cmdln.option('--root', metavar='ROOT',
                   help='Build in specified directory')
     @cmdln.option('-j', '--jobs', metavar='N',


### PR DESCRIPTION
This option adds extra packages listed in the specified file to build.

For now, `osc` does not support automatic buildrequires.

When a package has automatic buildrequires, `osc` just returns error code 9 that is returned by build,
but build leaves a list of missing dependencies in `.build.packages/OTHER/_generated_buildreqs` file inside build root.

These extra packages can be added using `--extra-pkgs` (`-x`) option, but this is very inconvenient if there are many of them.

Allowing to add extra dependencies listed in a file makes building packages with automatic buildrequires much more convenient: just do a first stage build, resulting in a file with list of extra dependencies, and then add extra packages from this file using `--extra-pkgs-from` (`-X`) option that is added by this change.