### PR TITLE
Add type annotations

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -13,6 +13,29 @@ on:
       - '**.py'
 
 jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install mypy
+      - run: pip install types-cryptography types-urllib3
+      - run: pip install distro keyring progressbar zstandard
+      - run: mypy osc
+
+  darker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+      - uses: akaihola/darker@1.5.1
+        with:
+          options: "--check --diff --color --line-length=120"
+          src: "."
+          version: "1.5.1"
+
   pylint_plugins:
     name: 'Diff pylint runs on osc plugin'
     runs-on: 'ubuntu-latest'

--- a/osc/build.py
+++ b/osc/build.py
@@ -1376,12 +1376,12 @@ def main(apiurl, opts, argv):
         for dep in bi.deps:
             if dep.sysroot:
                 # packages installed in sysroot subdirectory need to get a prefix for init_buildsystem
-                rpmlist.append('sysroot: %s %s\n' % (dep.name, dep.fullfilename))
+                rpmlist.append("sysroot: %s %s\n" % (dep.name, dep.fullfilename))
             else:
-                rpmlist.append('%s %s\n' % (dep.name, dep.fullfilename))
+                rpmlist.append("%s %s\n" % (dep.name, dep.fullfilename))
     for i in imagebins:
-        rpmlist.append('%s preinstallimage\n' % i)
-    rpmlist += ['%s %s\n' % (i[0], i[1]) for i in rpmlist_prefers]
+        rpmlist.append("%s preinstallimage\n" % i)
+    rpmlist += ["%s %s\n" % (i[0], i[1]) for i in rpmlist_prefers]
 
     if imagefile:
         rpmlist.append('preinstallimage: %s\n' % imagefile)
@@ -1474,11 +1474,11 @@ def main(apiurl, opts, argv):
             print()
             print('The buildroot was:', build_root)
             sys.exit(rc)
-    except KeyboardInterrupt as i:
+    except KeyboardInterrupt as keyboard_interrupt_exception:
         print("keyboard interrupt, killing build ...")
         cmd.append('--kill')
         run_external(cmd[0], *cmd[1:])
-        raise i
+        raise keyboard_interrupt_exception
 
     pacdir = os.path.join(build_root, '.build.packages')
     if os.path.islink(pacdir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,10 @@ lint =
     darker==1.5.1
     mypy
 
+[options.package_data]
+osc =
+    py.typed
+
 [options.entry_points]
 console_scripts =
     osc = osc.babysitter:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,11 @@ install_requires =
     rpm
     urllib3
 
+[options.extras_require]
+lint =
+    darker==1.5.1
+    mypy
+
 [options.entry_points]
 console_scripts =
     osc = osc.babysitter:main


### PR DESCRIPTION
This PR should achieve two things:

- Add a reasonable amount of type annotations for `core.py` to enable external consumers of `osc` as a library to better know what should be passed to methods.
- Automatically check in the CI that the code quality according to [mypy](http://mypy-lang.org/) and [pylint](https://pylint.pycqa.org/en/latest/) is not getting worse.

@dmach The new CI will obviously go nuts on the current code. I hope to collaboratively work out the details of a configuration that is useful for the current state of the project that is ultimately getting stricter the more the project improves over time.