### PR TITLE
Avoid crash when deleting a password

### DIFF
--- a/osc/credentials.py
+++ b/osc/credentials.py
@@ -246,7 +246,11 @@ class KeyringCredentialsManager(AbstractCredentialsManager):
 
     def delete_password(self, url, user):
         self._load_backend()
-        keyring.delete_password(urlsplit(url)[1], user)
+        service = urlsplit(url)[1]
+        data = keyring.get_password(service, user)
+        if data is None:
+            return
+        keyring.delete_password(service, user)
 
 
 class KeyringCredentialsDescriptor(AbstractCredentialsManagerDescriptor):


### PR DESCRIPTION
When using keyring, osc would crash when called as `osc config ENDPOINT --change-password`
and when the password didn't exist in the backend.

This prevents it by first checking if a password exists.