### PR TITLE
Fix osc add for github /archive/ URLs

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4712,7 +4712,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         # Do some magic here, when adding a url. We want that the server to download the tar ball and to verify it
         for arg in parseargs(args):
             if arg.endswith('.git') or arg.startswith('git://') or \
-               arg.startswith('git@') or (arg.startswith('https://github.com') and '/releases/' not in arg) or \
+               arg.startswith('git@') or (arg.startswith('https://github.com') and '/releases/' not in arg and '/archive/' not in arg) or \
                arg.startswith('https://gitlab.com'):
                 addGitSource(arg)
             elif arg.startswith('http://') or arg.startswith('https://') or arg.startswith('ftp://'):


### PR DESCRIPTION
"osc add https://github.com/foo/bar/archive/12345.tar.gz" should treat the URL as archive and not as git source.

---

Similar to #1027