### PR TITLE
fix manual run of source service

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7015,6 +7015,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         log = '\n'.join(get_commitlog(apiurl, project, package, rev, format, opts.meta, opts.deleted, rev_upper))
         run_pager(log)
 
+    @cmdln.option('-v', '--verbose', action='store_true',
+                  help='verbose run of local services for debugging purposes')
     def do_service(self, subcmd, opts, *args):
         """
         Handle source services
@@ -7106,7 +7108,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             elif command in ("runall", "ra"):
                 mode = "all"
 
-        return p.run_source_services(mode, singleservice)
+        return p.run_source_services(mode, singleservice, opts.verbose)
 
     @cmdln.option('-a', '--arch', metavar='ARCH',
                         help='trigger rebuilds for a specific architecture')

--- a/osc/core.py
+++ b/osc/core.py
@@ -464,6 +464,9 @@ class Serviceinfo:
             allservices = [data]
         elif singleservice:
             allservices = [s for s in allservices if s['name'] == singleservice]
+            # set the right called mode or the service would be skipped below
+            for s in allservices:
+                s['mode'] = callmode
 
         if not allservices:
             # short-circuit to avoid a potential http request in vc_export_env


### PR DESCRIPTION
    A service explicit called via singlerun could get skipped otherwise,
    if the service is defined with a different mode.
    
    eg. running
    
      osc service mr download_files
    
    to update and merge files after a version update, but the project has a
    global download_files service configured for validation.
