### PR TITLE
cmdln: Fix hide() decorator to take an optional argument with a boolean value

### DIFF
--- a/osc/cmdln.py
+++ b/osc/cmdln.py
@@ -61,7 +61,7 @@ def name(name):
     return decorate
 
 
-def hide():
+def hide(value=True):
     """
     For obsolete calls, hide them in help listings.
 
@@ -72,7 +72,7 @@ def hide():
                 #...implement 'shell' command
     """
     def decorate(f):
-        f.hidden = True
+        f.hidden = bool(value)
         return f
     return decorate
 


### PR DESCRIPTION
To restore compatibility with the install plugin.