### PR TITLE
mv: Fix regression

### DIFF
--- a/behave/features/mv.feature
+++ b/behave/features/mv.feature
@@ -1,0 +1,21 @@
+Feature: `osc mv` command
+
+
+# common steps for all scenarios
+Background:
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory/test-pkgA"
+     And I set working directory to "{context.osc.temp}/test:factory/test-pkgA"
+
+
+Scenario: Run `osc mv <file> <new-name>` in a package checkout
+    When I execute osc with args "mv test-pkgA.changes new-name.changes"
+    Then the exit code is 0
+     And I execute osc with args "status"
+     And stdout is
+     """
+     A    new-name.changes
+     D    test-pkgA.changes
+     """
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
+     And file "{context.osc.temp}/test:factory/test-pkgA/new-name.changes" exists

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -9159,11 +9159,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         os.rename(source, dest)
         try:
-            tgt_pkg[0].addfile(os.path.basename(dest))
+            tgt_pkg.addfile(os.path.basename(dest))
         except oscerr.PackageFileConflict:
             # file is already tracked
             pass
-        src_pkg[0].delete_file(os.path.basename(source), force=opts.force)
+        src_pkg.delete_file(os.path.basename(source), force=opts.force)
 
     @cmdln.option('-d', '--delete', action='store_true',
                         help='delete option from config or reset option to the default)')

--- a/tests/test_core_package.py
+++ b/tests/test_core_package.py
@@ -69,6 +69,36 @@ class TestPackageFromPaths(OscTestCase):
     def _get_fixtures_dir(self):
         return FIXTURES_DIR
 
+    def test_package_object_dir(self):
+        path = "projectA/pkgA"
+        path = os.path.join(self.tmpdir, 'osctest', path)
+        pac = osc.core.Package(path)
+
+        self.assertEqual(pac.name, "pkgA")
+        self.assertEqual(pac.prjname, "projectA")
+        self.assertEqual(pac.apiurl, "http://localhost")
+        self.assertEqual(pac.todo, [])
+
+    def test_package_object_file(self):
+        path = "projectA/pkgA/pkgA.spec"
+        path = os.path.join(self.tmpdir, 'osctest', path)
+        pac = osc.core.Package(path)
+
+        self.assertEqual(pac.name, "pkgA")
+        self.assertEqual(pac.prjname, "projectA")
+        self.assertEqual(pac.apiurl, "http://localhost")
+        self.assertEqual(pac.todo, ["pkgA.spec"])
+
+    def test_package_object_file_missing(self):
+        path = "projectA/pkgA/missing-file"
+        path = os.path.join(self.tmpdir, 'osctest', path)
+        pac = osc.core.Package(path)
+
+        self.assertEqual(pac.name, "pkgA")
+        self.assertEqual(pac.prjname, "projectA")
+        self.assertEqual(pac.apiurl, "http://localhost")
+        self.assertEqual(pac.todo, ["missing-file"])
+
     def test_single_package(self):
         paths = ["projectA/pkgA"]
         paths = [os.path.join(self.tmpdir, 'osctest', i) for i in paths]


### PR DESCRIPTION
Moved Package.todo handling in one place.
Fixed a situation when path to a file that doesn't exist is passed to Package

fixes: #1221