### PR TITLE
connection: Save cookiejar only when there's a Set-Cookie header in the response

### DIFF
--- a/osc/connection.py
+++ b/osc/connection.py
@@ -484,8 +484,9 @@ class CookieJarAuthHandler(AuthHandlerBase):
         return False
 
     def process_response(self, url, request_headers, response):
-        self._cookiejar.extract_cookies(response, MockRequest(url, response.headers))
-        self._cookiejar.save()
+        if response.headers.get_all("set-cookie", None):
+            self._cookiejar.extract_cookies(response, MockRequest(url, response.headers))
+            self._cookiejar.save()
         self._unlock()
 
 

--- a/osc/connection.py
+++ b/osc/connection.py
@@ -451,7 +451,10 @@ class CookieJarAuthHandler(AuthHandlerBase):
                 pass
             jar = http.cookiejar.LWPCookieJar(self.cookiejar_path)
             if os.path.isfile(self.cookiejar_path):
-                jar.load()
+                try:
+                    jar.load()
+                except http.cookiejar.LoadError:
+                    pass
             self.COOKIEJARS[self.cookiejar_path] = jar
         return jar
 


### PR DESCRIPTION
fixes: #1243