### PR TITLE
Revert "Do not list declined requests by default"

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2487,7 +2487,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('-f', '--force', action='store_true',
                         help='enforce state change, can be used to ignore open reviews')
     @cmdln.option('-s', '--state',
-                        help='only list requests in one of the comma separated given states (new/review/accepted/revoked/declined) or "all" [default="new,review"]')
+                        help='only list requests in one of the comma separated given states (new/review/accepted/revoked/declined) or "all" [default="new,review,declined"]')
     @cmdln.option('-D', '--days', metavar='DAYS',
                         help='only list requests in state "new" or changed in the last DAYS.')
     @cmdln.option('-U', '--user', metavar='USER',
@@ -2621,7 +2621,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             state_list = ["all"]
         else:
             if not opts.state:
-                opts.state = "new,review"
+                opts.state = "new,review,declined"
             state_list = opts.state.split(",")
             state_list = [i for i in state_list if i.strip()]
 

--- a/osc/core.py
+++ b/osc/core.py
@@ -4657,7 +4657,7 @@ def get_request_collection(
             raise ValueError("Project must be set to query a package; see https://github.com/openSUSE/open-build-service/issues/13075")
         query["package"] = package
 
-    states = states or ("new", "review")
+    states = states or ("new", "review", "declined")
     if states:
         if "all" not in states:
             query["states"] = ",".join(states)
@@ -4772,6 +4772,7 @@ def get_user_projpkgs_request_list(
     req_state=(
         "new",
         "review",
+        "declined",
     ),
     req_type=None,
     exclude_projects=None,
@@ -8033,7 +8034,7 @@ def get_commit_msg(wc_dir, pacs):
     return msg
 
 
-def print_request_list(apiurl, project, package=None, states=('new', 'review'), force=False):
+def print_request_list(apiurl, project, package=None, states=("new", "review"), force=False):
     """
     prints list of pending requests for the specified project/package if "check_for_request_on_action"
     is enabled in the config or if "force" is set to True


### PR DESCRIPTION
This reverts commit 2892f1bb1121e70b00e0102e391d79c4daa7cf30.
This reverts commit 9073b1a1d275827c57dd8cebb0250a231ba3fd9a.

The declined requests are still on maintainer's TODO list, they should be either superseded with another request or revoked.

Reverts: #1107 
