### PR TITLE
core.get_request_list: Remove deprecation warning

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4834,14 +4834,6 @@ def get_request_list(
     withfullhistory=False,
     roles=None,
 ):
-
-    import warnings
-    warnings.warn(
-        "osc.core.get_request_list() is deprecated. "
-        "Use osc.core.get_request_collection() instead.",
-        DeprecationWarning
-    )
-
     kwargs = {
         "apiurl": apiurl,
         "user": req_who,


### PR DESCRIPTION
It turned out that get_request_list() and get_request_collection() are not interchangeable and we need both for different use cases.

get_request_collection() was designed mainly for the 'osc my' command, while get_request_list() should be used in a generic use case