### PR TITLE
conf: Fix a cut&paste error in setting 'disable_hdrmd5_check' config option

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -890,7 +890,7 @@ def get_config(override_conffile=None,
 
         api_host_options[apiurl]["disable_hdrmd5_check"] = config["disable_hdrmd5_check"]
         if cp.has_option(url, "disable_hdrmd5_check"):
-            api_host_options[apiurl][key] = cp.getboolean(url, "disable_hdrmd5_check")
+            api_host_options[apiurl]["disable_hdrmd5_check"] = cp.getboolean(url, "disable_hdrmd5_check")
 
     # add the auth data we collected to the config dict
     config['api_host_options'] = api_host_options


### PR DESCRIPTION
This set credentials_mgr_class to 'False', which caused TransientCredentialsManager to ask for a password even when doing ssh auth.