### PR TITLE
Bring the '--debug' option back to the 'buildinfo' command

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -84,10 +84,14 @@ class Command:
             )
 
         # traverse the parent commands and add their options to the current command
+        commands = []
         cmd = self
         while cmd:
-            cmd.init_arguments()
+            commands.append(cmd)
             cmd = cmd.parent
+        # iterating backwards to give the command's options a priority over parent/global options
+        for cmd in reversed(commands):
+            cmd.init_arguments()
 
     def __repr__(self):
         return f"<osc plugin {self.full_name} at {self.__hash__():#x}>"


### PR DESCRIPTION
It was automatically removed by the argument parser when resolving a conflict between buildinfo's --debug and the global --debug option. Now we're iterating backwards to give the command's options a priority over parent/global options.