### PR TITLE
Add '--buildtool-opt' option passing options to underlying rpmbuild to the 'build' command

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -1057,6 +1057,9 @@ def main(apiurl, opts, argv):
     if opts.build_opt:
         buildargs += opts.build_opt
 
+    if opts.buildtool_opt:
+        buildargs += [f"--buildtool-opt={opt}" for opt in opts.buildtool_opt]
+
     # real arch of this machine
     # vs.
     # arch we are supposed to build for

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7012,6 +7012,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='define macro X with value Y')
     @cmdln.option('--build-opt', metavar='OPT', action='append',
                   help='pass option OPT to the build command')
+    @cmdln.option('--buildtool-opt', metavar='OPT', action='append',
+                  help='pass option OPT to the build tool command (rpmbuild)')
     @cmdln.option('--userootforbuild', '--login-as-root', action='store_true',
                   help='Run build or shell as root. The default is to build as '
                   'unprivileged user. Note that a line "# norootforbuild" '


### PR DESCRIPTION
Fixes: #1280 