### PR TITLE
Retry on receiving the following HTTP status codes: 400, 500, 502, 503, 504

### DIFF
--- a/osc/connection.py
+++ b/osc/connection.py
@@ -230,6 +230,15 @@ def http_request(method: str, url: str, headers=None, data=None, file=None):
         pool_kwargs["retries"] = urllib3.Retry(
             total=int(conf.config["http_retries"]),
             backoff_factor=2,
+            status_forcelist=(
+                400,  # Bad Request; retry on 400: service in progress
+                500,  # Internal Server Error
+                502,  # Bad Gateway
+                503,  # Service Unavailable
+                504,  # Gateway Timeout
+            ),
+            # don't raise because we want an actual response rather than a MaxRetryError with "too many <status_code> error responses" message
+            raise_on_status=False,
             **retries_kwargs,
         )
 


### PR DESCRIPTION
Retrying 400 mitigates a problem with retrieving data from OBS API while the server runs a service.

Fixes: #722