### PR TITLE
Add req_states parameter to osc.core.get_review_list

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4704,7 +4704,7 @@ def change_request_state_template(req, newstate):
 
 
 def get_review_list(
-    apiurl: str, project="", package="", byuser="", bygroup="", byproject="", bypackage="", states=(), req_type=""
+    apiurl: str, project="", package="", byuser="", bygroup="", byproject="", bypackage="", states=(), req_type="", req_states=("review",)
 ):
     # this is so ugly...
     def build_by(xpath, val):
@@ -4723,8 +4723,11 @@ def get_review_list(
 
     xpath = ''
 
-    # we're interested only in reviews of requests that are still open
-    xpath = xpath_join(xpath, "(state/@name='new' or state/@name='review' or state/@name='declined')", op="and")
+    # By default we're interested only in reviews of requests that are in state review.
+    for req_state in req_states:
+        xpath = xpath_join(xpath, "state/@name='%s'" % req_state, inner=True)
+
+    xpath = "(%s)" % xpath
 
     if states == ():
         xpath = xpath_join(xpath, 'review/@state=\'new\'', op='and')


### PR DESCRIPTION
Keep the original behaviour by default, but allow other callers to also request reviews on e.g. declined SRs.