### PR TITLE
Fix grabber to work with old urllib3 versions that do not contain URLSchemeUnknown exception

### DIFF
--- a/osc/grabber.py
+++ b/osc/grabber.py
@@ -10,7 +10,11 @@ from urllib.parse import urlparse
 from urllib.parse import unquote
 from urllib.error import URLError
 
-import urllib3.exceptions
+try:
+    from urllib3.exceptions import URLSchemeUnknown
+except ImportError:
+    class URLSchemeUnknown(Exception):
+        pass
 
 from .core import streamfile
 
@@ -39,7 +43,8 @@ class OscMirrorGroup:
             try:
                 self._grabber.urlgrab(mirror, filename, text)
                 return True
-            except (HTTPError, URLError, urllib3.exceptions.URLSchemeUnknown) as e:
+            except (HTTPError, URLError, URLSchemeUnknown, KeyError) as e:
+                # urllib3 1.25.10 throws a KeyError: pool_key_constructor = self.key_fn_by_scheme[scheme]
                 # try next mirror
                 pass
 

--- a/tests/test_grabber.py
+++ b/tests/test_grabber.py
@@ -1,0 +1,32 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+import osc.conf
+import osc.grabber as osc_grabber
+
+
+class TestMirrorGroup(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='osc_test')
+        # reset the global `config` in preparation for running the tests
+        importlib.reload(osc.conf)
+        osc.conf.get_config()
+
+    def tearDown(self):
+        # reset the global `config` to avoid impacting tests from other classes
+        importlib.reload(osc.conf)
+        try:
+            shutil.rmtree(self.tmpdir)
+        except:
+            pass
+
+    def test_invalid_scheme(self):
+        gr = osc_grabber.OscFileGrabber()
+        mg = osc_grabber.OscMirrorGroup(gr, ["container://example.com"])
+        mg.urlgrab(None, os.path.join(self.tmpdir, "file"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes: #1322