### PR TITLE
Change 'review list' command to display open requests (state: new, review, declined)

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -3254,7 +3254,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 if subcmd == 'review':
                     # FIXME: do the review list for the user and for all groups he belong to
                     results = get_review_list(apiurl, project, package, who, opts.group, opts.project, opts.package, state_list,
-                                              opts.type)
+                                              opts.type, req_states=("new", "review", "declined"))
                 else:
                     if opts.involved_projects:
                         who = who or conf.get_apiurl_usr(apiurl)


### PR DESCRIPTION
The original behavior was that only requests in the 'review' state were displayed.

Supplements ##1323 to get the desired `osc review list` behavior back - we want to display open requests, not just those in `review` state.