### PR TITLE
openSUSE is the only correct way to spell openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # openSUSE Commander
 
-OpenSUSE Commander (osc) is a command-line interface to the
+openSUSE Commander (osc) is a command-line interface to the
 [Open Build Service (OBS)](https://github.com/openSUSE/open-build-service/).
 
 

--- a/contrib/osc.spec
+++ b/contrib/osc.spec
@@ -101,7 +101,7 @@ Recommends:     xdg-utils
 Provides:       %{use_python_pkg}-osc
 
 %description
-OpenSUSE Commander is a command-line client for the Open Build Service.
+openSUSE Commander is a command-line client for the Open Build Service.
 
 See http://en.opensuse.org/openSUSE:OSC, as well as
 http://en.opensuse.org/openSUSE:Build_Service_Tutorial
@@ -127,7 +127,7 @@ PYTHONPATH=. argparse-manpage \
     --function=get_parser \
     --project-name=osc \
     --prog=osc \
-    --description="OpenSUSE Commander" \
+    --description="openSUSE Commander" \
     --author="Contributors to the osc project. See the project's GIT history for the complete list." \
     --url="https://github.com/openSUSE/osc/"
 %endif


### PR DESCRIPTION
According to https://en.opensuse.org/Help:Style#openSUSE_spelling
