### PR TITLE
Fix local service execution of scmsync packages

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -2630,14 +2630,13 @@ rev: %s
         os.chdir(self.absdir)  # e.g. /usr/lib/obs/service/verify_file fails if not inside the project dir.
         si = Serviceinfo()
         if os.path.exists('_service'):
-            if self.filenamelist.count('_service') or self.filenamelist_unvers.count('_service'):
-                try:
-                    service = ET.parse(os.path.join(self.absdir, '_service')).getroot()
-                except ET.ParseError as v:
-                    line, column = v.position
-                    print('XML error in _service file on line %s, column %s' % (line, column))
-                    sys.exit(1)
-                si.read(service)
+            try:
+                service = ET.parse(os.path.join(self.absdir, '_service')).getroot()
+            except ET.ParseError as v:
+                line, column = v.position
+                print('XML error in _service file on line %s, column %s' % (line, column))
+                sys.exit(1)
+            si.read(service)
         si.getProjectGlobalServices(self.apiurl, self.prjname, self.name)
         r = si.execute(self.absdir, mode, singleservice, verbose)
         os.chdir(curdir)


### PR DESCRIPTION
read _service file even when it is not tracked. This is the case in scmsync case.

I am not aware of a situation where it would break, when the local _service file exists but is not tracked yet.

osc#1350