### PR TITLE
Do not determine queried package by the source package origin

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -1367,7 +1367,7 @@ def main(apiurl, opts, argv):
 
     for i in bi.deps:
         if i.hdrmd5:
-            if not i.name.startswith('container:') and i.pacsuffix != 'rpm':
+            if not i.name.startswith('container:') and not i.fullfilename.endswith(".rpm"):
                 continue
             if i.name.startswith('container:'):
                 hdrmd5 = dgst(i.fullfilename)


### PR DESCRIPTION
The bug report is here: #1355 

It would be better to look at queried package origin directly, instead of assuming its type by the source package. Otherwise, in case we are building `.spec` via `debbuild`, RPM tools will start querying a Debian package and this will fail on Debian platform.
