### PR TITLE
Add zsh completition made by Holger Macht and improve

### DIFF
--- a/contrib/osc.spec
+++ b/contrib/osc.spec
@@ -10,6 +10,7 @@
 %define completion_dir_bash %{_datadir}/bash-completion/completions
 %define completion_dir_csh %{_sysconfdir}/profile.d
 %define completion_dir_fish %{_datadir}/fish/vendor_completions.d
+%define completion_dir_zsh %{_datadir}/zsh/functions/Completion
 %define osc_plugin_dir %{_prefix}/lib/osc-plugins
 # need to override python_sitelib because it is not set as we would expect on many distros
 %define python_sitelib %(RPM_BUILD_ROOT= %{use_python} -Ic "import sysconfig; print(sysconfig.get_path('purelib'))")
@@ -150,6 +151,7 @@ install -Dm0755 contrib/osc.complete %{buildroot}%{_datadir}/osc/complete
 install -Dm0644 contrib/complete.csh %{buildroot}%{completion_dir_csh}/osc.csh
 install -Dm0644 contrib/complete.sh %{buildroot}%{completion_dir_bash}/osc.sh
 install -Dm0644 contrib/osc.fish %{buildroot}%{completion_dir_fish}/osc.fish
+install -Dm0644 contrib/osc.zsh %{buildroot}%{completion_dir_zsh}/osc.zsh
 
 # install rpm macros
 install -Dm0644 macros.osc %{buildroot}%{_rpmmacrodir}/macros.osc
@@ -191,6 +193,7 @@ install -Dm0644 osc.1 %{buildroot}%{_mandir}/man1/osc.1
 %{completion_dir_bash}/*
 %{completion_dir_csh}/*
 %{completion_dir_fish}/*
+%{completion_dir_zsh}/*
 
 # osc owns the dirs to avoid the "directories not owned by a package" build error
 %dir %{_datadir}/fish

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -1,0 +1,149 @@
+#compdef osc
+#
+# Copyright (C) 2009,2010 Holger Macht <holger@homac.de>
+#
+# This file is released under the GPLv2.
+#
+# Based on the zsh guide from http://zsh.dotsrc.org/Guide/zshguide06.html
+#
+# Toggle verbose completions: zstyle ':completion:*:osc:*' verbose no
+#                             zstyle ':completion:*:osc-subcommand:*' verbose no
+# 
+# Use the variables $ZSH_OSC_BUILD_TARGETS_EXTRA and $ZSH_OSC_PROJECTS_EXTRA to
+# extend the list of possible completions in your ~/.zshrc like that:
+#  export OSC_PROJECTS_EXTRA="Base:System Base:shells"
+#
+# version 0.2
+#
+
+OSC_BUILD_TARGETS="openSUSE_13.1 openSUSE_13.2 openSUSE_Tumbleweed openSUSE_Factory SLE_11_SP3 SLE_12"
+OSC_PROJECTS="openSUSE:Factory openSUSE:Tumbleweed openSUSE:13.2 openSUSE:13.1"
+
+# user defined variables $OSC_BUILD_TARGETS_EXTRA and
+# $OSC_PROJECTS_EXTRA can add to the project/build target list
+OSC_BUILD_TARGETS="$OSC_BUILD_TARGETS $ZSH_OSC_BUILD_TARGETS_EXTRA"
+OSC_PROJECTS="$OSC_PROJECTS $ZSH_OSC_PROJECTS_EXTRA"
+
+# Main dispatcher
+
+_osc() {
+    if (( CURRENT > 2 )) && [[ ${words[2]} != "help" ]]; then
+        # Remember the subcommand name
+	local cmd=${words[2]}
+        # Set the context for the subcommand.
+	curcontext="${curcontext%:*:*}:osc-subcommand"
+        # Narrow the range of words we are looking at to exclude `osc'
+	(( CURRENT-- ))
+	shift words
+        # Run the completion for the subcommand
+	if [ "$cmd" = "submitreq" -o "$cmd" = "sr" ]; then
+	    _osc_cmd_submitreq
+	elif [ "$cmd" = "getbinaries" ]; then
+	    _osc_cmd_getbinaries
+	elif [ "$cmd" = "checkout" -o "$cmd" = "co" -o "$cmd" = "branch" ]; then
+	    _osc_cmd_checkout
+	elif [ "$cmd" = "buildlog" -o "$cmd" = "buildinfo" -o "$cmd" = "bl" ]; then
+	    _osc_cmd_buildlog
+	else
+	    _osc_cmd_do $cmd
+	fi
+    else
+	local hline
+	local -a cmdlist
+	local tag=0
+	_call_program help-commands osc help | while read -A hline; do
+	    # start parsing with "commands:"
+	    [[ $hline[1] = "commands:" ]] && tag=1
+	    # stop parsing at the line starting with "For"
+	    [[ $hline[1] = "For" ]] && tag=0
+	    [[ $tag = 0 ]] && continue
+	    # all commands have to start with lower case letters
+	    [[ $hline[1] =~ ^[A-Z] ]] && continue
+	    (( ${#hline} < 2 )) && continue
+
+    	    # ${hline[1]%,} truncates the last ','
+	    cmdlist=($cmdlist "${hline[1]%,}:${hline[2,-1]}")
+	done
+	_describe -t osc-commands 'osc command' cmdlist
+    fi
+}
+
+_osc_cmd_getbinaries() {
+    _arguments \
+	'1:PROJECT:( `echo $OSC_PROJECTS` )' \
+	'2:PACKAGE:(PACKAGE)' \
+	'3:REPOSITORY:( `echo $OSC_BUILD_TARGETS` )' \
+	'4:ARCHITECTURE:(i586 x86_64)'
+}
+
+_osc_cmd_checkout() {
+    _arguments \
+	'1:PROJECT:( `echo $OSC_PROJECTS` )' \
+	'2:PACKAGE:(PACKAGE)'
+}
+
+_osc_cmd_buildlog() {
+    _arguments \
+	'1:REPOSITORY:( `echo $OSC_BUILD_TARGETS` )' \
+	'2:ARCHITECTURE:(i586 x86_64)'
+}
+
+_osc_cmd_submitreq() {
+    local hline
+    local -a cmdlist
+    local tag=0
+    _call_program help-commands osc help $cmd | while read -A hline; do
+        # start parsing from "usage:"
+	[[ $hline[1] = "usage:" ]] && tag=1
+	[[ $tag = 0 ]] && continue
+
+	if [[ $hline[1] =~ ^osc ]]; then
+	    shift hline; shift hline
+	elif ! [[ $hline[1] =~ ^- ]]; then
+            # Option has to start with a '-' or 'osc submitrequest'
+	    continue
+	fi
+
+	(( ${#hline} < 2 )) && continue
+
+	cmdlist=($cmdlist "${hline[1]%,}:${hline[2,-1]}")
+
+    done
+    
+    _describe -t osc-commands 'osc command' cmdlist
+}
+
+
+_osc_cmd_do() {
+    local hline
+    local -a cmdlist
+    local tag=0
+    
+    # only start completion if there's some '-' on the line
+    if ! [ "$words[2]" = "-" ]; then
+	_complete
+	return
+    fi
+
+    _call_program help-commands osc help $cmd | while read -A hline; do
+	# start parsing from "Options:"
+	[[ $hline[1] = "Options:" ]] && tag=1
+	[[ $tag = 0 ]] && continue
+	# Option has to start with a '-'
+	[[ $hline[1] =~ ^- ]] || continue
+	(( ${#hline} < 2 )) && continue
+
+	cmdlist=($cmdlist "${hline[1]%,}:${hline[2,-1]}")
+    done
+
+    if [ -n "$cmdlist" ]; then
+	_describe -t osc-commands 'osc command' cmdlist
+    else
+	_complete
+    fi
+}
+
+# Code to make sure _osc is run when we load it
+_osc "$@"
+
+

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -9,19 +9,9 @@
 #
 # Toggle verbose completions: zstyle ':completion:*:osc:*' verbose no
 #                             zstyle ':completion:*:osc-subcommand:*' verbose no
-# 
-# Use the variables $ZSH_OSC_BUILD_TARGETS_EXTRA and $ZSH_OSC_PROJECTS_EXTRA to
-# extend the list of possible completions in your ~/.zshrc like that:
-#  export OSC_PROJECTS_EXTRA="Base:System Base:shells"
 #
 # version 0.2
 #
-
-OSC_BUILD_TARGETS="openSUSE_13.1 openSUSE_13.2 openSUSE_Tumbleweed openSUSE_Factory SLE_11_SP3 SLE_12"
-
-# user defined variables $OSC_BUILD_TARGETS_EXTRA and
-# $OSC_PROJECTS_EXTRA can add to the project/build target list
-OSC_BUILD_TARGETS="$OSC_BUILD_TARGETS $ZSH_OSC_BUILD_TARGETS_EXTRA"
 
 # Main dispatcher
 
@@ -160,11 +150,25 @@ _osc_update_project_list() {
     fi
 }
 
+_osc_project_repositories() {
+    if [ ! -s $PWD/.osc/_build_repositories ] || \
+           _osc_call_me_maybe $PWD/.osc/_build_repositories ; then
+        osc repositories > /dev/null
+    fi
+    # Just check if file exist in case the call to the api failed
+    if [ -s $PWD/.osc/_build_repositories ] ; then
+        cat $PWD/.osc/_build_repositories | while read build_repository ; do
+            # Only output first word of each line
+            echo ${build_repository%\ *}
+        done | sort -u
+    fi
+}
+
 _osc_cmd_getbinaries() {
     _arguments \
 	'1:PROJECT:( `cat $osc_projects` )' \
 	'2:PACKAGE:(PACKAGE)' \
-	'3:REPOSITORY:( `echo $OSC_BUILD_TARGETS` )' \
+	'3:REPOSITORY:( `_osc_project_repositories`' \
 	'4:ARCHITECTURE:(i586 x86_64)'
 }
 
@@ -176,7 +180,7 @@ _osc_cmd_checkout() {
 
 _osc_cmd_buildlog() {
     _arguments \
-	'1:REPOSITORY:( `echo $OSC_BUILD_TARGETS` )' \
+	'1:REPOSITORY:( `_osc_project_repositories` )' \
 	'2:ARCHITECTURE:(i586 x86_64)'
 }
 

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -181,12 +181,16 @@ _osc_cmd_buildlog() {
 }
 
 _osc_cmd_submitreq() {
+    _osc_complete_help_commands 'options' 'option'
+}
+
+_osc_complete_help_commands() {
     local hline
     local -a cmdlist
     local tag=0
     _call_program help-commands osc help $cmd | while read -A hline; do
         # start parsing from "usage:"
-	[[ $hline[1] = "usage:" ]] && tag=1
+	[[ $hline[1] = "${1}:" ]] && tag=1
 	[[ $tag = 0 ]] && continue
 
 	if [[ $hline[1] =~ ^osc ]]; then
@@ -198,40 +202,26 @@ _osc_cmd_submitreq() {
 
 	(( ${#hline} < 2 )) && continue
 
-	cmdlist=($cmdlist "${hline[1]%,}:${hline[2,-1]}")
+    cmdlist=($cmdlist "${hline[1]%,}:${hline[2,-1]}")
 
     done
-    
-    _describe -t osc-commands 'osc command' cmdlist
+
+    if [ -n "$cmdlist" ] ; then
+        _describe -t osc-commands "osc $2" cmdlist
+    else
+        return 1
+    fi
 }
 
-
 _osc_cmd_do() {
-    local hline
-    local -a cmdlist
-    local tag=0
-    
     # only start completion if there's some '-' on the line
     if ! [ "$words[2]" = "-" ]; then
-	_complete
-	return
+	    _complete
+	    return
     fi
 
-    _call_program help-commands osc help $cmd | while read -A hline; do
-	# start parsing from "Options:"
-	[[ $hline[1] = "Options:" ]] && tag=1
-	[[ $tag = 0 ]] && continue
-	# Option has to start with a '-'
-	[[ $hline[1] =~ ^- ]] || continue
-	(( ${#hline} < 2 )) && continue
-
-	cmdlist=($cmdlist "${hline[1]%,}:${hline[2,-1]}")
-    done
-
-    if [ -n "$cmdlist" ]; then
-	_describe -t osc-commands 'osc command' cmdlist
-    else
-	_complete
+    if ! _osc_complete_help_commands 'options' 'option'; then
+        _complete
     fi
 }
 

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -82,17 +82,13 @@ _osc() {
 
     _osc_update_project_list
 
-	if [ "$cmd" = "submitreq" -o "$cmd" = "sr" ]; then
-	    _osc_cmd_submitreq
-	elif [ "$cmd" = "getbinaries" ]; then
-	    _osc_cmd_getbinaries
-	elif [ "$cmd" = "checkout" -o "$cmd" = "co" -o "$cmd" = "branch" ]; then
-	    _osc_cmd_checkout
-	elif [ "$cmd" = "buildlog" -o "$cmd" = "buildinfo" -o "$cmd" = "bl" ]; then
-	    _osc_cmd_buildlog
-	else
-	    _osc_cmd_do $cmd
-	fi
+    case $cmd in
+        submitrequest|submitreq|sr) _osc_cmd_submitreq ;;
+        getbinaries) _osc_cmd_getbinaries ;;
+        checkout|co|branch|getpac|bco|branchco) _osc_cmd_checkout ;;
+        buildlog|buildinfo|bl|blt|buildlogtail) _osc_cmd_buildlog ;;
+        *) _osc_cmd_do $cmd
+    esac
     else
 	local hline
 	local -a cmdlist

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -160,16 +160,35 @@ _osc_project_repositories() {
     fi
 }
 
+_osc_project_repositories_arches() {
+    if [ ! -s $PWD/.osc/_build_repositories ] || \
+           _osc_call_me_maybe $PWD/.osc/_build_repositories ; then
+        osc repositories > /dev/null
+    fi
+    # Just check if file exist in case the call to the api failed
+    if [ -s $PWD/.osc/_build_repositories ] ; then
+        grep -- $1 $PWD/.osc/_build_repositories | while read build_repository ; do
+            # Only output second word of each line
+            echo ${build_repository#*\ }
+        done | sort -u
+    fi
+}
+
+
 _osc_cmd_getbinaries() {
     if [ "$words[2]" = "-" ]; then
 	    _osc_complete_help_commands 'options' 'option'
 	    return
     else
+        if [ -n "$words[2]" ] ; then
+            local osc_project_repository_arch=$(_osc_project_repositories_arches \
+                                                    "${words[2]}")
+        fi
         _arguments \
 	        '1:PROJECT:( `cat $osc_projects` )' \
 	        '2:PACKAGE:(PACKAGE)' \
 	        '3:REPOSITORY:( `_osc_project_repositories`' \
-	        '4:ARCHITECTURE:(i586 x86_64)'
+	        '4:ARCHITECTURE:(`echo $osc_project_repository_arch`)'
     fi
 }
 
@@ -189,9 +208,13 @@ _osc_cmd_buildlog() {
 	    _osc_complete_help_commands 'options' 'option'
 	    return
     else
+        if [ -n "$words[2]" ] ; then
+            local osc_project_repository_arch=$(_osc_project_repositories_arches \
+                                                    "${words[2]}")
+        fi
         _arguments \
 	        '1:REPOSITORY:( `_osc_project_repositories` )' \
-	        '2:ARCHITECTURE:(i586 x86_64)'
+	        '2:ARCHITECTURE:(`echo $osc_project_repository_arch`)'
     fi
 }
 

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -161,23 +161,38 @@ _osc_project_repositories() {
 }
 
 _osc_cmd_getbinaries() {
-    _arguments \
-	'1:PROJECT:( `cat $osc_projects` )' \
-	'2:PACKAGE:(PACKAGE)' \
-	'3:REPOSITORY:( `_osc_project_repositories`' \
-	'4:ARCHITECTURE:(i586 x86_64)'
+    if [ "$words[2]" = "-" ]; then
+	    _osc_complete_help_commands 'options' 'option'
+	    return
+    else
+        _arguments \
+	        '1:PROJECT:( `cat $osc_projects` )' \
+	        '2:PACKAGE:(PACKAGE)' \
+	        '3:REPOSITORY:( `_osc_project_repositories`' \
+	        '4:ARCHITECTURE:(i586 x86_64)'
+    fi
 }
 
 _osc_cmd_checkout() {
-    _arguments \
-	'1:PROJECT:( `cat $osc_projects` )' \
-	'2:PACKAGE:(PACKAGE)'
+    if [ "$words[2]" = "-" ]; then
+	    _osc_complete_help_commands 'options' 'option'
+	    return
+    else
+        _arguments \
+	        '1:PROJECT:( `cat $osc_projects` )' \
+	        '2:PACKAGE:(PACKAGE)'
+    fi
 }
 
 _osc_cmd_buildlog() {
-    _arguments \
-	'1:REPOSITORY:( `_osc_project_repositories` )' \
-	'2:ARCHITECTURE:(i586 x86_64)'
+    if [ "$words[2]" = "-" ]; then
+	    _osc_complete_help_commands 'options' 'option'
+	    return
+    else
+        _arguments \
+	        '1:REPOSITORY:( `_osc_project_repositories` )' \
+	        '2:ARCHITECTURE:(i586 x86_64)'
+    fi
 }
 
 _osc_cmd_submitreq() {

--- a/contrib/osc.zsh
+++ b/contrib/osc.zsh
@@ -85,6 +85,7 @@ _osc() {
     case $cmd in
         submitrequest|submitreq|sr) _osc_cmd_submitreq ;;
         getbinaries) _osc_cmd_getbinaries ;;
+        build) _osc_cmd_build ;;
         checkout|co|branch|getpac|bco|branchco) _osc_cmd_checkout ;;
         buildlog|buildinfo|bl|blt|buildlogtail) _osc_cmd_buildlog ;;
         *) _osc_cmd_do $cmd
@@ -215,6 +216,22 @@ _osc_cmd_buildlog() {
         _arguments \
 	        '1:REPOSITORY:( `_osc_project_repositories` )' \
 	        '2:ARCHITECTURE:(`echo $osc_project_repository_arch`)'
+    fi
+}
+
+_osc_cmd_build() {
+    if [ "$words[2]" = "-" ]; then
+	    _osc_complete_help_commands 'options' 'option'
+	    return
+    else
+        if [ -n "$words[2]" ] ; then
+            local osc_project_repository_arch=$(_osc_project_repositories_arches \
+                                                    "${words[2]}")
+        fi
+        _arguments \
+	        '1:REPOSITORY:( `_osc_project_repositories` )' \
+	        '2:ARCHITECTURE:(`echo $osc_project_repository_arch`)' \
+            '3:Build Description:_files'
     fi
 }
 


### PR DESCRIPTION
Right now the zsh completition is packaged inside the zsh package on
OpenSUSE.
Several distributions either package it or the user has to import it
themselves.

It is better if it is stored here so any can pick it up in there zsh
package and put fixes in here.