### PR TITLE
Fix --prefer-pkgs for noinstall="1" packages in kiwi builds

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -1269,10 +1269,24 @@ def main(apiurl, store, opts, argv):
                     if name == filename:
                         print("Using prefered package: " + path + "/" + filename)
                         os.unlink(tffn)
-                        if opts.linksources:
-                            os.link(path + "/" + filename, tffn)
-                        else:
-                            os.symlink(path + "/" + filename, tffn)
+
+        if prefer_pkgs:
+            localpkgdir = "repos/_local/"
+            os.mkdir(localpkgdir)
+            buildargs.append("--kiwi-parameter")
+            buildargs.append("--add-repo")
+            buildargs.append("--kiwi-parameter")
+            buildargs.append(f"dir://./{localpkgdir}")
+            buildargs.append("--kiwi-parameter")
+            buildargs.append("--add-repotype")
+            buildargs.append("--kiwi-parameter")
+            buildargs.append("rpm-md")
+            for name, path in prefer_pkgs.items():
+                tffn = os.path.join(localpkgdir, os.path.basename(path))
+                if opts.linksources:
+                    os.link(path, tffn)
+                else:
+                    os.symlink(path, tffn)
 
     if build_type == 'kiwi':
         # Is a obsrepositories tag used?


### PR DESCRIPTION
For kiwi to find those packages, they have to be in one of the listed repos. Create a "_local" repo with all prefer-pkgs in buildinfo.

Note: The code currently doesn't look at noinstall at all, so any package in the buildinfo which is provided by --prefer-pkgs is treated as noinstall="1" and noinstall="0" simultaneously currently...