### PR TITLE
Add conf.configure_apiurl() for configuring osc without reading oscrc

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -220,6 +220,7 @@ class OscTestCase(unittest.TestCase):
             shutil.rmtree(self.tmpdir)
         except:
             pass
+        os.environ.pop("OSC_CONFIG", "")
         self.assertTrue(len(EXPECTED_REQUESTS) == 0)
 
     def _get_fixtures_dir(self):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,7 +1,11 @@
 import importlib
+import os
 import unittest
 
 import osc.conf
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "conf_fixtures")
 
 
 class TestConf(unittest.TestCase):
@@ -12,6 +16,9 @@ class TestConf(unittest.TestCase):
     def tearDown(self):
         # reset the global `config` to avoid impacting tests from other classes
         importlib.reload(osc.conf)
+
+    def _get_fixtures_dir(self):
+        return FIXTURES_DIR
 
     def test_bool_opts_defaults(self):
         config = osc.conf.config
@@ -28,7 +35,8 @@ class TestConf(unittest.TestCase):
             self.assertIsInstance(config[opt], int, msg=f"option: '{opt}'")
 
     def test_bool_opts(self):
-        osc.conf.get_config()
+        oscrc = os.path.join(self._get_fixtures_dir(), "oscrc")
+        osc.conf.get_config(override_conffile=oscrc, override_no_keyring=True)
         config = osc.conf.config
         for opt in osc.conf._boolean_opts:
             if opt not in config:
@@ -36,7 +44,8 @@ class TestConf(unittest.TestCase):
             self.assertIsInstance(config[opt], bool, msg=f"option: '{opt}'")
 
     def test_int_opts(self):
-        osc.conf.get_config()
+        oscrc = os.path.join(self._get_fixtures_dir(), "oscrc")
+        osc.conf.get_config(override_conffile=oscrc, override_no_keyring=True)
         config = osc.conf.config
         for opt in osc.conf._integer_opts:
             if opt not in config:

--- a/tests/test_grabber.py
+++ b/tests/test_grabber.py
@@ -12,7 +12,7 @@ class TestMirrorGroup(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp(prefix='osc_test')
         # reset the global `config` in preparation for running the tests
         importlib.reload(osc.conf)
-        osc.conf.get_config()
+        osc.conf.configure_apiurl("http://example.com", "Admin", password="opensuse")
 
     def tearDown(self):
         # reset the global `config` to avoid impacting tests from other classes


### PR DESCRIPTION
Fixes: #1371 