### PR TITLE
Fix GitStore to error out properly if there is no 'origin' remote in the git repo

### DIFF
--- a/behave/features/addcontainers-prjcheckout.feature
+++ b/behave/features/addcontainers-prjcheckout.feature
@@ -13,5 +13,5 @@ Scenario: Run `osc addcontainers`
     Then the exit code is 1
      And stderr is
         """
-        Directory '{context.osc.temp}/test:factory' is not a working copy of a package
+        Directory '{context.osc.temp}/test:factory' is not an OBS SCM working copy of a package
         """

--- a/behave/features/develproject-prjcheckout.feature
+++ b/behave/features/develproject-prjcheckout.feature
@@ -13,5 +13,5 @@ Scenario: Run `osc develproject`
     Then the exit code is 1
      And stderr is
         """
-        Directory '{context.osc.temp}/test:factory' is not a working copy of a package
+        Directory '{context.osc.temp}/test:factory' is not an OBS SCM working copy of a package
         """

--- a/behave/features/setdevelproject-prjcheckout.feature
+++ b/behave/features/setdevelproject-prjcheckout.feature
@@ -13,5 +13,5 @@ Scenario: Run `osc setdevelproject <devel_project>`
     Then the exit code is 1
      And stderr is
         """
-        Directory '{context.osc.temp}/test:factory' is not a working copy of a package
+        Directory '{context.osc.temp}/test:factory' is not an OBS SCM working copy of a package
         """

--- a/behave/features/showlinked-prjcheckout.feature
+++ b/behave/features/showlinked-prjcheckout.feature
@@ -13,5 +13,5 @@ Scenario: Run `osc showlinked`
     Then the exit code is 1
      And stderr is
         """
-        Directory '{context.osc.temp}/test:factory' is not a working copy of a package
+        Directory '{context.osc.temp}/test:factory' is not an OBS SCM working copy of a package
         """

--- a/osc/babysitter.py
+++ b/osc/babysitter.py
@@ -98,14 +98,6 @@ def run(prg, argv=None):
         print(e, file=sys.stderr)
     except oscerr.NoWorkingCopy as e:
         print(e, file=sys.stderr)
-        if os.path.isdir('.git'):
-            print("Current directory looks like git.", file=sys.stderr)
-        if os.path.isdir('.hg'):
-            print("Current directory looks like mercurial.", file=sys.stderr)
-        if os.path.isdir('.svn'):
-            print("Current directory looks like svn.", file=sys.stderr)
-        if os.path.isdir('CVS'):
-            print("Current directory looks like cvs.", file=sys.stderr)
     except HTTPError as e:
         print('Server returned an error:', e, file=sys.stderr)
         if hasattr(e, 'osc_msg'):

--- a/osc/git_scm/store.py
+++ b/osc/git_scm/store.py
@@ -38,7 +38,11 @@ class GitStore:
         self._project = None
 
         if check and not any([self.is_project, self.is_package]):
-            msg = f"Directory '{self.path}' is not a GIT working copy"
+            msg = f"Directory '{self.path}' is not a Git SCM working copy"
+            raise oscerr.NoWorkingCopy(msg)
+
+        if check and not self.scmurl:
+            msg = f"Directory '{self.path}' is a Git SCM repo that lacks the 'origin' remote"
             raise oscerr.NoWorkingCopy(msg)
 
         # TODO: decide if we need explicit 'git lfs pull' or not
@@ -46,12 +50,12 @@ class GitStore:
 
     def assert_is_project(self):
         if not self.is_project:
-            msg = f"Directory '{self.path}' is not a GIT working copy of a project"
+            msg = f"Directory '{self.path}' is not a Git SCM working copy of a project"
             raise oscerr.NoWorkingCopy(msg)
 
     def assert_is_package(self):
         if not self.is_package:
-            msg = f"Directory '{self.path}' is not a GIT working copy of a package"
+            msg = f"Directory '{self.path}' is not a Git SCM working copy of a package"
             raise oscerr.NoWorkingCopy(msg)
 
     def _run_git(self, args):
@@ -148,4 +152,7 @@ class GitStore:
 
     @property
     def scmurl(self):
-        return self._run_git(["remote", "get-url", "origin"])
+        try:
+            return self._run_git(["remote", "get-url", "origin"])
+        except subprocess.CalledProcessError:
+            return None


### PR DESCRIPTION
Fixes: #1391