### PR TITLE
Implement 'exclude_files' and 'include_files' config options that allow skipping files in the 'checkout' command

### DIFF
--- a/behave/features/checkout.feature
+++ b/behave/features/checkout.feature
@@ -45,6 +45,27 @@ Scenario: Run `osc checkout` on a package, use a file size limit
      And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" exists
 
 
+Scenario: Run `osc checkout` on a package, exclude files
+   Given I set working directory to "{context.osc.temp}"
+    When I execute osc with args "checkout test:factory test-pkgA --setopt=exclude_files=*.changes"
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.spec" exists
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
+
+
+Scenario: Run `osc checkout` on a package, include files
+   Given I set working directory to "{context.osc.temp}"
+    When I execute osc with args "checkout test:factory test-pkgA --setopt=include_files=*.changes"
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.spec" does not exist
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" exists
+
+
+Scenario: Run `osc checkout` on a package, exclude and include files
+   Given I set working directory to "{context.osc.temp}"
+    When I execute osc with args "checkout test:factory test-pkgA --setopt=exclude_files=*.changes --setopt=include_files=*.changes"
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.spec" does not exist
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
+
+
 Scenario: Run `osc checkout` on a package in a specified revision
    Given I set working directory to "{context.osc.temp}"
     When I execute osc with args "checkout test:factory test-pkgA --revision=2"

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -189,6 +189,8 @@ DEFAULTS = {'apiurl': 'https://api.opensuse.org',
             'linkcontrol': '0',
             'include_request_from_project': '1',
             'local_service_run': '1',
+            "exclude_files": "",
+            "include_files": "",
 
             # Maintenance defaults to OBS instance defaults
             'maintained_attribute': 'OBS:Maintained',
@@ -811,6 +813,8 @@ def get_config(override_conffile=None,
 
     re_clist = re.compile('[, ]+')
     config['extra-pkgs'] = [i.strip() for i in re_clist.split(config['extra-pkgs'].strip()) if i]
+    config["exclude_files"] = [i.strip() for i in re_clist.split(config["exclude_files"].strip()) if i]
+    config["include_files"] = [i.strip() for i in re_clist.split(config["include_files"].strip()) if i]
 
     # collect the usernames, passwords and additional options for each api host
     api_host_options = {}

--- a/osc/core.py
+++ b/osc/core.py
@@ -1896,6 +1896,28 @@ class Package:
             if size and self.size_limit and int(size) > self.size_limit \
                     or skip_service and (e.get('name').startswith('_service:') or e.get('name').startswith('_service_')):
                 e.set('skipped', 'true')
+                continue
+
+            if conf.config["exclude_files"]:
+                exclude = False
+                for pattern in conf.config["exclude_files"]:
+                    if fnmatch.fnmatch(e.get("name"), pattern):
+                        exclude = True
+                        break
+                if exclude:
+                    e.set("skipped", "true")
+                    continue
+
+            if conf.config["include_files"]:
+                include = False
+                for pattern in conf.config["include_files"]:
+                    if fnmatch.fnmatch(e.get("name"), pattern):
+                        include = True
+                        break
+                if not include:
+                    e.set("skipped", "true")
+                    continue
+
         return ET.tostring(root, encoding=ET_ENCODING)
 
     def get_local_meta(self):


### PR DESCRIPTION
Examples:
    `osc checkout --setopt='include_files=*.spec *.changes'`
    `osc checkout --setopt='exclude_files=*.tar.* *.obscpio'`

Fixes: #1397

If you need an additional checkout speed boost, use the following option: `--setopt='check_for_request_on_action=0'`