### PR TITLE
Fix api_host_options for custom CAs

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -211,7 +211,7 @@ if not os.path.isfile('/usr/lib/build/vc') and os.path.isfile('/usr/lib/obs-buil
     DEFAULTS['vc-cmd'] = '/usr/lib/obs-build/vc'
 
 api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj',
-                    'downloadurl', 'sshkey', 'disable_hdrmd5_check']
+                    'downloadurl', 'sshkey', 'disable_hdrmd5_check', 'cacert']
 
 
 # _integer_opts and _boolean_opts specify option types for both global options as well as api_host_options
@@ -868,7 +868,7 @@ def get_config(override_conffile=None,
         api_host_options[apiurl] = APIHostOptionsEntry(entry)
 
         optional = (
-            'realname', 'email', 'sslcertck', 'cafile', 'capath', 'sshkey', 'allow_http',
+            'realname', 'email', 'sslcertck', 'cafile', 'capath', 'sshkey', 'allow_http', 'cacert',
             credentials.AbstractCredentialsManager.config_entry,
         )
         for key in optional:
@@ -886,6 +886,9 @@ def get_config(override_conffile=None,
 
         if 'sslcertck' not in api_host_options[apiurl]:
             api_host_options[apiurl]['sslcertck'] = True
+
+        if 'cacert' not in api_host_options[apiurl]:
+            api_host_options[apiurl]['cacert'] = False
 
         if 'allow_http' not in api_host_options[apiurl]:
             api_host_options[apiurl]['allow_http'] = False

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -211,7 +211,7 @@ if not os.path.isfile('/usr/lib/build/vc') and os.path.isfile('/usr/lib/obs-buil
     DEFAULTS['vc-cmd'] = '/usr/lib/obs-build/vc'
 
 api_host_options = ['user', 'pass', 'passx', 'aliases', 'http_headers', 'realname', 'email', 'sslcertck', 'cafile', 'capath', 'trusted_prj',
-                    'downloadurl', 'sshkey', 'disable_hdrmd5_check', 'cacert']
+                    'downloadurl', 'sshkey', 'disable_hdrmd5_check']
 
 
 # _integer_opts and _boolean_opts specify option types for both global options as well as api_host_options
@@ -868,7 +868,7 @@ def get_config(override_conffile=None,
         api_host_options[apiurl] = APIHostOptionsEntry(entry)
 
         optional = (
-            'realname', 'email', 'sslcertck', 'cafile', 'capath', 'sshkey', 'allow_http', 'cacert',
+            'realname', 'email', 'sslcertck', 'cafile', 'capath', 'sshkey', 'allow_http',
             credentials.AbstractCredentialsManager.config_entry,
         )
         for key in optional:
@@ -887,8 +887,11 @@ def get_config(override_conffile=None,
         if 'sslcertck' not in api_host_options[apiurl]:
             api_host_options[apiurl]['sslcertck'] = True
 
-        if 'cacert' not in api_host_options[apiurl]:
-            api_host_options[apiurl]['cacert'] = False
+        if 'cafile' not in api_host_options[apiurl]:
+            api_host_options[apiurl]['cafile'] = None
+
+        if 'capath' not in api_host_options[apiurl]:
+            api_host_options[apiurl]['capath'] = None
 
         if 'allow_http' not in api_host_options[apiurl]:
             api_host_options[apiurl]['allow_http'] = False

--- a/osc/connection.py
+++ b/osc/connection.py
@@ -261,6 +261,9 @@ def http_request(method: str, url: str, headers=None, data=None, file=None, retr
             pool_kwargs["ssl_context"] = ssl_context
             # turn cert verification off if sslcertck = 0
 
+            if options["cacert"]:
+                ssl_context.load_verify_locations(cafile=options["cacert"])
+
             # urllib3 v1
             pool_kwargs["cert_reqs"] = "CERT_REQUIRED" if options["sslcertck"] else "CERT_NONE"
 

--- a/osc/connection.py
+++ b/osc/connection.py
@@ -261,8 +261,8 @@ def http_request(method: str, url: str, headers=None, data=None, file=None, retr
             pool_kwargs["ssl_context"] = ssl_context
             # turn cert verification off if sslcertck = 0
 
-            if options["cacert"]:
-                ssl_context.load_verify_locations(cafile=options["cacert"])
+            if options["cafile"] or options["capath"]:
+                ssl_context.load_verify_locations(cafile=options["cafile"], capath=options["capath"])
 
             # urllib3 v1
             pool_kwargs["cert_reqs"] = "CERT_REQUIRED" if options["sslcertck"] else "CERT_NONE"

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -90,6 +90,7 @@ email = admin@example.com
 sslcertck = 1
 cafile = unused
 capath = unused
+cacert = /path/to/custom_cacert
 trusted_prj = openSUSE:* SUSE:*
 downloadurl = http://example.com/
 sshkey = ~/.ssh/id_rsa.pub
@@ -361,6 +362,10 @@ class TestExampleConfig(unittest.TestCase):
     def test_host_option_capath(self):
         host_options = self.config["api_host_options"][self.config["apiurl"]]
         self.assertEqual(host_options["capath"], "unused")
+
+    def test_host_option_cacert(self):
+        host_options = self.config["api_host_options"][self.config["apiurl"]]
+        self.assertEqual(host_options["cacert"], "/path/to/custom_cacert")
 
     def test_host_option_sshkey(self):
         host_options = self.config["api_host_options"][self.config["apiurl"]]

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -88,9 +88,8 @@ http_headers =
 realname = The Administrator
 email = admin@example.com
 sslcertck = 1
-cafile = unused
-capath = unused
-cacert = /path/to/custom_cacert
+cafile = /path/to/custom_cacert.pem
+capath = /path/to/custom_cacert.d/
 trusted_prj = openSUSE:* SUSE:*
 downloadurl = http://example.com/
 sshkey = ~/.ssh/id_rsa.pub
@@ -357,15 +356,11 @@ class TestExampleConfig(unittest.TestCase):
 
     def test_host_option_cafile(self):
         host_options = self.config["api_host_options"][self.config["apiurl"]]
-        self.assertEqual(host_options["cafile"], "unused")
+        self.assertEqual(host_options["cafile"], "/path/to/custom_cacert.pem")
 
     def test_host_option_capath(self):
         host_options = self.config["api_host_options"][self.config["apiurl"]]
-        self.assertEqual(host_options["capath"], "unused")
-
-    def test_host_option_cacert(self):
-        host_options = self.config["api_host_options"][self.config["apiurl"]]
-        self.assertEqual(host_options["cacert"], "/path/to/custom_cacert")
+        self.assertEqual(host_options["capath"], "/path/to/custom_cacert.d/")
 
     def test_host_option_sshkey(self):
         host_options = self.config["api_host_options"][self.config["apiurl"]]


### PR DESCRIPTION
Currently, osc seems to only support custom CAs if they are installed system-wide.

This PR adds an `api_host_option`, which allows custom CAs to be defined in `oscrc` API blocks. This is supposed to address concerns like #1158.

@dmach @Firstyear @mgerstner @msmeissn