### PR TITLE
fix crash when settings like realname are not set.

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -8913,7 +8913,8 @@ def vc_export_env(apiurl: str, quiet=False):
 
     for (tag, val) in tag2val.items():
         for env in tag2envs[tag]:
-            os.environ[env] = val
+            if val:
+                os.environ[env] = val
 
 
 class MultibuildFlavorResolver:


### PR DESCRIPTION
Otherwise:
  File "/usr/lib/python3.11/site-packages/osc/core.py", line 451, in execute
    result = self._execute(dir, old_dir, callmode, singleservice, verbose)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/osc/core.py", line 493, in _execute
    vc_export_env(self.apiurl)
  File "/usr/lib/python3.11/site-packages/osc/core.py", line 8917, in vc_export_env
    os.environ[env] = val
    ~~~~~~~~~~^^^^^
  File "<frozen os>", line 684, in __setitem__
  File "<frozen os>", line 758, in encode
TypeError: str expected, not NoneType