### PR TITLE
Allow undefined fields in Options and HostOptions

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -78,6 +78,7 @@ maintained_update_project_attribute = OBS:UpdateProject
 show_download_progress = 0
 vc-cmd = /usr/lib/build/vc
 status_mtime_heuristic = 0
+plugin-option = plugin-general-option
 
 [https://api.opensuse.org]
 credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
@@ -97,6 +98,7 @@ trusted_prj = openSUSE:* SUSE:*
 downloadurl = http://example.com/
 sshkey = ~/.ssh/id_rsa.pub
 disable_hdrmd5_check = 0
+plugin-option = plugin-host-option
 """
 
 
@@ -400,6 +402,22 @@ class TestExampleConfig(unittest.TestCase):
     def test_host_option_disable_hdrmd5_check(self):
         host_options = self.config["api_host_options"][self.config["apiurl"]]
         self.assertEqual(host_options["disable_hdrmd5_check"], False)
+
+    def test_extra_fields(self):
+        self.assertEqual(self.config["plugin-option"], "plugin-general-option")
+        self.assertEqual(self.config.extra_fields, {"plugin-option": "plugin-general-option"})
+
+        self.config["new-option"] = "value"
+        self.assertEqual(self.config["new-option"], "value")
+        self.assertEqual(self.config.extra_fields, {"plugin-option": "plugin-general-option", "new-option": "value"})
+
+        host_options = self.config["api_host_options"][self.config["apiurl"]]
+        self.assertEqual(host_options["plugin-option"], "plugin-host-option")
+        self.assertEqual(host_options.extra_fields, {"plugin-option": "plugin-host-option"})
+
+        host_options["new-option"] = "value"
+        self.assertEqual(host_options["new-option"], "value")
+        self.assertEqual(host_options.extra_fields, {"plugin-option": "plugin-host-option", "new-option": "value"})
 
 
 class TestFromParent(unittest.TestCase):


### PR DESCRIPTION
Plugins seem to be using oscrc and osc.conf.config to store their config options. All fields that are not known to osc are now stored in the 'extra_fields' dictionary and handled in __getitem__() and __setitem__() as they were regular fields. Such values are not checked for their types and the dictionary simply holds strings obtained from oscrc or anything the plugins set through the python API.