### PR TITLE
Fix apiurl_aliases handling in OscOptions.__getitem__

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -3870,7 +3870,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         src_apiurl = conf.config['apiurl']
         if opts.to_apiurl:
-            tgt_apiurl = conf.config['apiurl_aliases'].get(opts.to_apiurl, opts.to_apiurl)
+            tgt_apiurl = conf.config.apiurl_aliases.get(opts.to_apiurl, opts.to_apiurl)
         else:
             tgt_apiurl = src_apiurl
 

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -144,9 +144,10 @@ class OscOptions(BaseModel):
     def __getitem__(self, name):
         field_name = self._get_field_name(name)
 
-        if field_name is None:
+        if field_name is None and not hasattr(self, name):
             return self.extra_fields[name]
 
+        field_name = field_name or name
         try:
             return getattr(self, field_name)
         except AttributeError:
@@ -156,10 +157,11 @@ class OscOptions(BaseModel):
     def __setitem__(self, name, value):
         field_name = self._get_field_name(name)
 
-        if field_name is None:
+        if field_name is None and not hasattr(self, name):
             self.extra_fields[name] = value
             return
 
+        field_name = field_name or name
         setattr(self, field_name, value)
 
     # compat function with the config dict
@@ -1617,7 +1619,7 @@ def config_set_option(section, opt, val=None, delete=False, update=True, creds_m
     cp = get_configParser(config['conffile'])
 
     if section != 'general':
-        section = config['apiurl_aliases'].get(section, section)
+        section = config.apiurl_aliases.get(section, section)
         scheme, host, path = \
             parse_apisrv_url(config.get('scheme', 'https'), section)
         section = urljoin(scheme, host, path)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import shutil
 import tempfile
@@ -104,6 +105,7 @@ plugin-option = plugin-host-option
 
 class TestExampleConfig(unittest.TestCase):
     def setUp(self):
+        importlib.reload(osc.conf)
         self.tmpdir = tempfile.mkdtemp(prefix="osc_test_")
         self.oscrc = os.path.join(self.tmpdir, "oscrc")
         with open(self.oscrc, "w", encoding="utf-8") as f:
@@ -407,6 +409,13 @@ class TestExampleConfig(unittest.TestCase):
         self.assertEqual(self.config["plugin-option"], "plugin-general-option")
         self.assertEqual(self.config.extra_fields, {"plugin-option": "plugin-general-option"})
 
+        # write to an existing attribute instead of extra_fields
+        self.config.attrib = 123
+        self.assertEqual(self.config["attrib"], 123)
+        self.config["attrib"] = 456
+        self.assertEqual(self.config["attrib"], 456)
+        self.assertEqual(self.config.extra_fields, {"plugin-option": "plugin-general-option"})
+
         self.config["new-option"] = "value"
         self.assertEqual(self.config["new-option"], "value")
         self.assertEqual(self.config.extra_fields, {"plugin-option": "plugin-general-option", "new-option": "value"})
@@ -418,6 +427,11 @@ class TestExampleConfig(unittest.TestCase):
         host_options["new-option"] = "value"
         self.assertEqual(host_options["new-option"], "value")
         self.assertEqual(host_options.extra_fields, {"plugin-option": "plugin-host-option", "new-option": "value"})
+
+    def test_apiurl_aliases(self):
+        expected = {"https://api.opensuse.org": "https://api.opensuse.org", "osc": "https://api.opensuse.org"}
+        self.assertEqual(self.config.apiurl_aliases, expected)
+        self.assertEqual(self.config["apiurl_aliases"], expected)
 
 
 class TestFromParent(unittest.TestCase):


### PR DESCRIPTION
Fixes: #1439 