### PR TITLE
fix autocompletion for new locations

### DIFF
--- a/contrib/complete.sh
+++ b/contrib/complete.sh
@@ -1,6 +1,6 @@
 test -z "$BASH_VERSION" && return
 complete -o default _nullcommand >/dev/null 2>&1 || return
 complete -r _nullcommand >/dev/null 2>&1         || return
-test -s /usr/share/osc/complete && complete -o default -C /usr/share/osc/complete osc
-test -s /usr/lib64/osc/complete && complete -o default -C /usr/lib64/osc/complete osc
+test -s /usr/share/osc/complete && complete -o default -C /usr/share/osc/complete osc && return
+test -s /usr/lib64/osc/complete && complete -o default -C /usr/lib64/osc/complete osc && return
 test -s /usr/lib/osc/complete   && complete -o default -C /usr/lib/osc/complete osc


### PR DESCRIPTION
When complete is installed in `/usr/share` or `/usr/lib64`, the last test command (`/usr/lib`) fails and causes whole `osc` autocompletion to fail.

Fix it by adding a `return` to the former two -- if they succeed.