### PR TITLE
Defer counting cores to later

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -737,6 +737,8 @@ def main(apiurl, store, opts, argv):
         buildargs.append('--threads=%s' % opts.threads)
     if opts.jobs:
         buildargs.append('--jobs=%s' % opts.jobs)
+    elif config['build-jobs'] == 0:
+        buildargs.append('--jobs=%s' % os.cpu_count)
     elif config['build-jobs'] > 1:
         buildargs.append('--jobs=%s' % config['build-jobs'])
     if opts.icecream or config['icecream'] != '0':

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -974,7 +974,7 @@ class Options(OscOptions):
     )  # type: ignore[assignment]
 
     build_jobs: Optional[int] = Field(
-        default=os.cpu_count,
+        default=0,
         description=textwrap.dedent(
             """
             The number of parallel processes during the build.


### PR DESCRIPTION
Defer counting cores to later
so that `man5/oscrc.5` does not vary in the `build-jobs` value.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).