### PR TITLE
Use busybox compatible commands for completion

### DIFF
--- a/contrib/osc.complete
+++ b/contrib/osc.complete
@@ -152,12 +152,12 @@ fi
 update_projects_list ()
 {
     if test -s "${projects}" ; then
-        typeset -i ctime=$(command date -d "$(command stat -c '%z' ${projects})" +'%s')
-        typeset -i   now=$(command date -d now +'%s')
+        typeset -i ctime=$(command stat -c '%Z' ${projects})
+        typeset -i   now=$(command date +'%s')
         if ((now - ctime > 86400)) ; then
             if tmp=$(mktemp ${projects}.XXXXXX) ; then
                 command ${command} ls / >| $tmp
-	        mv -uf $tmp ${projects}
+	        mv -f $tmp ${projects}
 	    fi
         fi
     else


### PR DESCRIPTION
The current shell-completion script uses some commands specific to GNU Coreutils, namely `date` and `mv`.

This proposes the following changes:

 - use portable call to date(1)
 - use plain stat(1) for ctime
 - don't use mv -u

in order to make the completion work on non-gnu-coreutils systems, e.g. ones using busybox.
