### PR TITLE
Support package linking of packages from scmsync projects

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -5838,12 +5838,17 @@ def link_pac(
             elm.clear()
             ET.SubElement(elm, 'disable')
 
+        root.remove('scmsync')
+
         dst_meta = ET.tostring(root, encoding=ET_ENCODING)
 
     if meta_change:
+        root = ET.fromstring(''.join(dst_meta))
+        for scmsync in root.findall('scmsync'):
+            root.remove(scmsync)
         edit_meta('pkg',
                   path_args=(dst_project, dst_package),
-                  data=dst_meta)
+                  data=ET.tostring(root, encoding=ET_ENCODING))
     # create the _link file
     # but first, make sure not to overwrite an existing one
     if '_link' in meta_get_filelist(apiurl, dst_project, dst_package):


### PR DESCRIPTION
It needs to remove the scmsync tag in package meta in that case (when creating a new package meta based on source).

I didn't that global in replace_pkg_meta() on purpose since this should be a case by case decision when it makes sense. We could add this there via an option though.

There is another problem in the api that it delivers package meta without title/description elements, but it is not accepting it. This is submitted there
via a seperate pull request.