### PR TITLE
Fix crash in 'updatepacmetafromspec' command when working with an incomplete spec

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4370,8 +4370,10 @@ def read_meta_from_spec(specfile, *args):
     section_pat = r'^%s\s*?$'
     for section in sections:
         m = re.compile(section_pat % section, re.I | re.M).search(''.join(lines))
-        if m:
-            start = lines.index(m.group() + '\n') + 1
+        if m is None:
+            spec_data[section] = ""
+            continue
+        start = lines.index(m.group() + '\n') + 1
         data = []
         for line in lines[start:]:
             if line.startswith('%'):


### PR DESCRIPTION
Fixes: #1506
