### PR TITLE
Add rootless build support for 'qemu' VM type

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -614,7 +614,7 @@ def calculate_prj_pac(store, opts, descr):
 
 
 def calculate_build_root_user(vm_type):
-    if vm_type in ("kvm", "podman"):
+    if vm_type in ("kvm", "podman", "qemu"):
         return getpass.getuser()
     return None
 


### PR DESCRIPTION
Fixes https://github.com/openSUSE/osc/issues/1511

Works for me. For example:
1. Install the `qemu-arm` package
2. `osc co openSUSE:Factory:ARM/bc`
3. `cd $_`
4. `osc build standard aarch64 bc.spec --vm-type=qemu`

Root is not required anymore with this small change.