### PR TITLE
Allow setlinkrev to set a specific vrev

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -3601,6 +3601,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='Do not expand revision the specified or latest rev')
     @cmdln.option('-u', '--unset', action='store_true',
                   help='remove revision in link, it will point always to latest revision')
+    @cmdln.option('--vrev', metavar='vrev',
+                  help='Enforce a given vrev')
     def do_setlinkrev(self, subcmd, opts, *args):
         """
         Updates a revision number in a source link
@@ -3643,7 +3645,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         for p in packages:
             try:
-                rev = set_link_rev(apiurl, project, p, revision=rev, expand=not opts.use_plain_revision)
+                rev = set_link_rev(apiurl, project, p, revision=rev, expand=not opts.use_plain_revision, vrev=opts.vrev)
             except HTTPError as e:
                 if e.code != 404:
                     raise

--- a/osc/core.py
+++ b/osc/core.py
@@ -7717,7 +7717,7 @@ def owner(
     return res
 
 
-def set_link_rev(apiurl: str, project: str, package: str, revision="", expand=False, msg: str=None):
+def set_link_rev(apiurl: str, project: str, package: str, revision="", expand=False, msg: str=None, vrev: str=None):
     url = makeurl(apiurl, ["source", project, package, "_link"])
     try:
         f = http_GET(url)
@@ -7725,7 +7725,7 @@ def set_link_rev(apiurl: str, project: str, package: str, revision="", expand=Fa
     except HTTPError as e:
         e.osc_msg = f'Unable to get _link file in package \'{package}\' for project \'{project}\''
         raise
-    revision = _set_link_rev(apiurl, project, package, root, revision, expand=expand)
+    revision = _set_link_rev(apiurl, project, package, root, revision, expand=expand, setvrev=vrev)
     l = ET.tostring(root, encoding=ET_ENCODING)
 
     if not msg:
@@ -7738,7 +7738,7 @@ def set_link_rev(apiurl: str, project: str, package: str, revision="", expand=Fa
     return revision
 
 
-def _set_link_rev(apiurl: str, project: str, package: str, root, revision="", expand=False):
+def _set_link_rev(apiurl: str, project: str, package: str, root, revision="", expand=False, setvrev: str=None):
     """
     Updates the rev attribute of the _link xml. If revision is set to None
     the rev and vrev attributes are removed from the _link xml.
@@ -7762,7 +7762,9 @@ def _set_link_rev(apiurl: str, project: str, package: str, root, revision="", ex
     if revision:
         root.set('rev', revision)
     # add vrev when revision is a srcmd5
-    if not revision_is_empty(vrev) and not revision_is_empty(revision) and len(revision) >= 32:
+    if setvrev:
+        root.set('vrev', setvrev)
+    elif not revision_is_empty(vrev) and not revision_is_empty(revision) and len(revision) >= 32:
         root.set('vrev', vrev)
     return revision
 


### PR DESCRIPTION
Allow setlinkrev to set a specific vrev

This helps mitigate OBS-305
and https://github.com/openSUSE/open-build-service/issues/15079