### PR TITLE
Readd makeurl debug output

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -3656,6 +3656,7 @@ def makeurl(apiurl: str, path: List[str], query: Optional[dict] = None):
             query[f"{key}[]"] = value
 
     query_str = urlencode(query, doseq=True)
+    _private.print_msg("makeurl:", path_str+"?"+query_str, print_to="debug")
 
     return urlunsplit((apiurl_scheme, apiurl_netloc, path_str, query_str, ""))
 


### PR DESCRIPTION
This was lost in refactoring commit 3f14cef53a853296d7f60bf7b14eb86615842cf9
yet it was very useful to discover API queries

I slightly changed the format, so it is easier to use as input
to `osc api`