### PR TITLE
Propagate exit code from the run() and do_() commandline methods

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,8 +103,9 @@ jobs:
     steps:
       - name: "Install packages"
         run: |
+            sudo sh -c '. /etc/os-release; echo "deb [trusted=yes] http://download.opensuse.org/repositories/openSUSE:Tools/xUbuntu_${VERSION_ID} ./" > /etc/apt/sources.list.d/openSUSE-Tools.list'
             sudo apt-get -y update
-            sudo apt-get -y --no-install-recommends install python3-behave diffstat diffutils python3 python3-cryptography python3-pip python3-rpm python3-setuptools python3-urllib3
+            sudo apt-get -y --no-install-recommends install python3-behave diffstat diffutils python3 python3-cryptography python3-pip python3-rpm python3-setuptools python3-urllib3 obs-build obs-service-set-version
 
       - name: "Checkout sources"
         uses: actions/checkout@v3

--- a/behave/README.md
+++ b/behave/README.md
@@ -54,6 +54,12 @@ $ podman stop|kill obs-server
 $ podman rmi obs-server
 ```
 
+Install test dependencies
+-------------------------
+```
+$ zypper install python3-behave diffstat diffutils obs-service-replace_using_env python3 python3-cryptography python3-pip python3-rpm python3-setuptools python3-urllib3 build obs-service-set_version
+```
+
 Run tests
 ---------
 

--- a/behave/features/service.feature
+++ b/behave/features/service.feature
@@ -1,0 +1,11 @@
+Feature: `osc service` command
+
+
+Scenario: Run `osc service manualrun`
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory test-pkgA"
+     And I set working directory to "{context.osc.temp}/test:factory/test-pkgA"
+     And I copy file "{context.fixtures}/pac/_service-set_version-invalid" to "{context.osc.temp}/test:factory/test-pkgA/_service"
+    When I execute osc with args "service manualrun"
+    Then stdout contains "Aborting: service call failed"
+     And the exit code is 255

--- a/behave/features/steps/common.py
+++ b/behave/features/steps/common.py
@@ -87,28 +87,36 @@ def run_in_context(context, cmd, can_fail=False, **run_args):
 def step_impl(context, text):
     if re.search(text.format(context=context), context.cmd_stdout):
         return
-    raise AssertionError("Stdout doesn't contain expected pattern: %s" % text)
+    found = context.cmd_stdout.rstrip().split("\n")
+    found_str = "\n".join(found)
+    raise AssertionError(f"Stdout doesn't contain the expected pattern: {text}\n\nActual stdout:\n{found_str}")
 
 
 @behave.step("stdout doesn't contain \"{text}\"")
 def step_impl(context, text):
     if not re.search(text.format(context=context), context.cmd_stdout):
         return
-    raise AssertionError("Stdout is not supposed to contain pattern: %s" % text)
+    found = context.cmd_stdout.rstrip().split("\n")
+    found_str = "\n".join(found)
+    raise AssertionError(f"Stdout is not supposed to contain pattern: {text}\n\nActual stdout:\n{found_str}")
 
 
 @behave.step("stderr contains \"{text}\"")
 def step_impl(context, text):
     if re.search(text.format(context=context), context.cmd_stderr):
         return
-    raise AssertionError("Stderr doesn't contain expected pattern: %s" % text)
+    found = context.cmd_stderr.rstrip().split("\n")
+    found_str = "\n".join(found)
+    raise AssertionError(f"Stderr doesn't contain the expected pattern: {text}\n\nActual stderr:\n{found_str}")
 
 
 @behave.step("stderr doesn't contain \"{text}\"")
 def step_impl(context, text):
     if not re.search(text.format(context=context), context.cmd_stderr):
         return
-    raise AssertionError("Stderr is not supposed to contain pattern: %s" % text)
+    found = context.cmd_stderr.rstrip().split("\n")
+    found_str = "\n".join(found)
+    raise AssertionError(f"Stderr is not supposed to contain pattern: {text}\n\nActual stderr:\n{found_str}")
 
 
 @behave.step("stdout is")

--- a/behave/fixtures/pac/_service-set_version-invalid
+++ b/behave/fixtures/pac/_service-set_version-invalid
@@ -1,0 +1,5 @@
+<services>
+  <service name="set_version" mode="manual">
+    <param name="fromfile">invalid</param>
+  </service>
+</services>

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -2828,7 +2828,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         for srid in supersede:
             change_request_state(apiurl, srid, 'superseded',
                                  f'superseded by {rid}', rid)
-        return rid
 
     @cmdln.option('-m', '--message', metavar='TEXT',
                   help='specify message TEXT')

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -245,7 +245,7 @@ class MainCommand(Command):
         if not cmd:
             self.parser.error("Please specify a command")
         self.post_parse_args(args)
-        cmd.run(args)
+        return cmd.run(args)
 
     def load_command(self, cls, module_prefix):
         mod_cls_name = f"{module_prefix}.{cls.__name__}"
@@ -502,10 +502,10 @@ class OscMainCommand(MainCommand):
                     # handler doesn't take positional args via *args
                     if args.positional_args:
                         self.parser.error(f"unrecognized arguments: " + " ".join(args.positional_args))
-                    self.func(args.command, args)
+                    return self.func(args.command, args)
                 else:
                     # handler takes positional args via *args
-                    self.func(args.command, args, *args.positional_args)
+                    return self.func(args.command, args, *args.positional_args)
 
         return LegacyCommandWrapper
 
@@ -561,7 +561,8 @@ class OscMainCommand(MainCommand):
         cmd.load_legacy_commands()
         if run:
             args = cmd.parse_args(args=argv)
-            cmd.run(args)
+            exit_code = cmd.run(args)
+            sys.exit(exit_code)
         else:
             args = None
         return cmd, args


### PR DESCRIPTION
Fixes: #1532