### PR TITLE
Fix handling the default package argument on the command-line

### DIFF
--- a/behave/features/log.feature
+++ b/behave/features/log.feature
@@ -52,7 +52,6 @@ Scenario: Run `osc log` on revision range of a package
         """
 
 
-@wip
 Scenario: Run `osc log --patch` on revision range of a package
    Given I execute osc with args "log test:factory/test-pkgA --revision=1:2 --patch"
     Then the exit code is 0

--- a/behave/features/release.feature
+++ b/behave/features/release.feature
@@ -1,0 +1,43 @@
+Feature: `osc release` command
+
+
+Scenario: Run `osc log` on a project
+    When I execute osc with args "release test:factory --repo=standard --target-project=test:release --target-repository=distro-1-ga"
+    # release target is not properly configured in the testing container, but we're currently testing only the command-line options
+    Then the exit code is 1
+     And stdout contains "Releasing project 'test:factory' repository 'standard' to project 'test:release' repository 'distro-1-ga' options: delayed"
+
+
+Scenario: Run `osc log` on a package
+    When I execute osc with args "release test:factory/test-pkgA --repo=standard --target-project=test:release --target-repository=distro-1-ga"
+    Then the exit code is 0
+     And stdout contains "Releasing package 'test:factory/test-pkgA' repository 'standard' to project 'test:release' repository 'distro-1-ga' options: delayed"
+
+
+Scenario: Run `osc log` from a project checkout
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory"
+     And I set working directory to "{context.osc.temp}/test:factory"
+    When I execute osc with args "release --repo=standard --target-project=test:release --target-repository=distro-1-ga"
+    # release target is not properly configured in the testing container, but we're currently testing only the command-line options
+    Then the exit code is 1
+     And stdout contains "Releasing project 'test:factory' repository 'standard' to project 'test:release' repository 'distro-1-ga' options: delayed"
+
+
+Scenario: Run `osc log` from a package checkout
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory test-pkgA"
+     And I set working directory to "{context.osc.temp}/test:factory/test-pkgA"
+    When I execute osc with args "release --repo=standard --target-project=test:release --target-repository=distro-1-ga"
+    Then the exit code is 0
+     And stdout contains "Releasing package 'test:factory/test-pkgA' repository 'standard' to project 'test:release' repository 'distro-1-ga' options: delayed"
+
+
+Scenario: Run `osc log` from a package checkout with a given project
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory test-pkgA"
+     And I set working directory to "{context.osc.temp}/test:factory/test-pkgA"
+    When I execute osc with args "release test:factory --repo=standard --target-project=test:release --target-repository=distro-1-ga"
+    # release target is not properly configured in the testing container, but we're currently testing only the command-line options
+    Then the exit code is 1
+     And stdout contains "Releasing project 'test:factory' repository 'standard' to project 'test:release' repository 'distro-1-ga' options: delayed"

--- a/behave/features/setdevelproject-pkgcheckout.feature
+++ b/behave/features/setdevelproject-pkgcheckout.feature
@@ -14,7 +14,7 @@ Scenario: Run `osc setdevelproject <devel_project>`
     Then the exit code is 0
      And stdout is
         """
-        Setting devel project of package 'test:factory/test-pkgA' to package 'test:devel/test-pkgA'
+        Setting devel project of package 'test:factory/test-pkgA' to project 'test:devel'
         """
 
 

--- a/behave/features/setdevelproject-project-package.feature
+++ b/behave/features/setdevelproject-project-package.feature
@@ -12,7 +12,7 @@ Scenario: Run `osc setdevelproject <project> <package> <devel_project>`
     Then the exit code is 0
      And stdout is
         """
-        Setting devel project of package 'test:factory/test-pkgA' to package 'test:devel/test-pkgA'
+        Setting devel project of package 'test:factory/test-pkgA' to project 'test:devel'
         """
 
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -634,10 +634,10 @@ def pop_args(
     try:
         arg1 = args.pop(0)
     except IndexError:
-        if not arg1_is_optional and not arg1_default:
-            raise oscerr.OscValueError(f"Please specify a {arg1_name}") from None
         arg1 = arg1_default
         used_arg1_default = True
+        if arg1 is None and not arg1_is_optional:
+            raise oscerr.OscValueError(f"Please specify a {arg1_name}") from None
 
     if not isinstance(arg1, (str, type(None))):
         raise TypeError(f"{arg1_name.capitalize()} should be 'str', found: {type(arg1).__name__}")
@@ -654,10 +654,11 @@ def pop_args(
         try:
             arg2  = args.pop(0)
         except IndexError:
-            if not arg2_is_optional and not arg2_default and not used_arg1_default:
-                # arg2 is not optional and it wasn't specified together with arg1
+            if used_arg1_default:
+                # we use arg2_default only after arg1_default was used
+                arg2 = arg2_default
+            if arg2 is None and not arg2_is_optional:
                 raise oscerr.OscValueError(f"Please specify a {arg2_name}") from None
-            arg2 = arg2_default
 
         if not isinstance(arg2, (str, type(None))):
             raise TypeError(f"{arg2_name.capitalize()} should be 'str', found: {type(arg2).__name__}")

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -236,7 +236,7 @@ class TestPopProjectPackageFromArgs(unittest.TestCase):
             args, package_is_optional=True, default_package="default-package",
         )
         self.assertEqual(project, "project")
-        self.assertEqual(package, "default-package")
+        self.assertEqual(package, None)
         self.assertEqual(args, [])
 
     def test_default_project_package(self):
@@ -402,10 +402,7 @@ class TestPopRepositoryArchFromArgs(unittest.TestCase):
 
     def test_default_arch(self):
         args = ["repo"]
-        repo, arch = pop_repository_arch_from_args(args, default_arch="arch")
-        self.assertEqual(repo, "repo")
-        self.assertEqual(arch, "arch")
-        self.assertEqual(args, [])
+        self.assertRaises(OscValueError, pop_repository_arch_from_args, args, default_arch="arch")
 
 
 class TestPopProjectPackageRepositoryArchFromArgs(unittest.TestCase):
@@ -498,14 +495,12 @@ class TestPopProjectPackageRepositoryArchFromArgs(unittest.TestCase):
 
     def test_default_package(self):
         args = ["project"]
-        project, package, repo, arch = pop_project_package_repository_arch_from_args(
-            args, default_package="package", repository_is_optional=True
+        self.assertRaises(
+            OscValueError,
+            pop_project_package_repository_arch_from_args,
+            args, default_package="package",
+            repository_is_optional=True,
         )
-        self.assertEqual(project, "project")
-        self.assertEqual(package, "package")
-        self.assertEqual(repo, None)
-        self.assertEqual(arch, None)
-        self.assertEqual(args, [])
 
     def test_missing_repository(self):
         args = ["project", "package"]
@@ -554,14 +549,12 @@ class TestPopProjectPackageRepositoryArchFromArgs(unittest.TestCase):
 
     def test_default_arch(self):
         args = ["project", "package", "repository"]
-        project, package, repo, arch = pop_project_package_repository_arch_from_args(
-            args, default_arch="arch"
+        self.assertRaises(
+            OscValueError,
+            pop_project_package_repository_arch_from_args,
+            args,
+            default_arch="arch",
         )
-        self.assertEqual(project, "project")
-        self.assertEqual(package, "package")
-        self.assertEqual(repo, "repository")
-        self.assertEqual(arch, "arch")
-        self.assertEqual(args, [])
 
     def test_no_working_copy(self):
         args = ["repo", "arch"]
@@ -703,14 +696,12 @@ class TestPopProjectPackageTargetProjectTargetPackageFromArgs(unittest.TestCase)
 
     def test_default_package(self):
         args = ["project"]
-        project, package, target_project, target_package = pop_project_package_targetproject_targetpackage_from_args(
-            args, default_package="package", target_project_is_optional=True
+        self.assertRaises(
+            OscValueError,
+            pop_project_package_targetproject_targetpackage_from_args,
+            args, default_package="package",
+            target_project_is_optional=True,
         )
-        self.assertEqual(project, "project")
-        self.assertEqual(package, "package")
-        self.assertEqual(target_project, None)
-        self.assertEqual(target_package, None)
-        self.assertEqual(args, [])
 
     def test_missing_target_project(self):
         args = ["project", "package"]
@@ -769,14 +760,13 @@ class TestPopProjectPackageTargetProjectTargetPackageFromArgs(unittest.TestCase)
 
     def test_default_target_package(self):
         args = ["project", "package", "target-project"]
-        project, package, target_project, target_package = pop_project_package_targetproject_targetpackage_from_args(
-            args, default_target_package="target-package"
+
+        self.assertRaises(
+            OscValueError,
+            pop_project_package_targetproject_targetpackage_from_args,
+            args,
+            default_target_package="target-package",
         )
-        self.assertEqual(project, "project")
-        self.assertEqual(package, "package")
-        self.assertEqual(target_project, "target-project")
-        self.assertEqual(target_package, "target-package")
-        self.assertEqual(args, [])
 
     def test_no_working_copy(self):
         args = ["target-project", "target-package"]


### PR DESCRIPTION
If the project was explicitly specified from the command-line, avoid using the default package because that would be frequently obtained from the current working copy and that leads to unexpected results.