### PR TITLE
Use ssh key from ssh agent that contains comment 'obs=<apiurl-hostname>'

### DIFF
--- a/osc/conf.py
+++ b/osc/conf.py
@@ -306,6 +306,7 @@ class HostOptions(OscOptions):
              - keep empty for auto detection
              - path to the public SSH key
              - public SSH key filename (must be placed in ~/.ssh)
+             - fingerprint of a SSH key (2nd column of ``ssh-add -l``)
 
             NOTE: The private key may not be available on disk because it could be in a GPG keyring, on YubiKey or forwarded through SSH agent.
 

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -303,10 +303,19 @@ class HostOptions(OscOptions):
             """
             A pointer to public SSH key that corresponds with a private SSH used for authentication:
 
+             - keep empty for auto detection
              - path to the public SSH key
              - public SSH key filename (must be placed in ~/.ssh)
 
             NOTE: The private key may not be available on disk because it could be in a GPG keyring, on YubiKey or forwarded through SSH agent.
+
+            TIP: To give osc a hint which ssh key from the agent to use during auto detection,
+            append ``obs=<apiurl-hostname>`` to the **private** key's comment.
+            This will also work nicely during SSH agent forwarding, because the comments get forwarded too.
+
+             - To edit the key, run: ``ssh-keygen -c -f ~/.ssh/<private-key>``
+             - To query the key, run: ``ssh-keygen -y -f ~/.ssh/<private-key>``
+             - Example comment: ``<username@host> obs=api.example.com obs=api-test.example.com``
             """
         ),
     )  # type: ignore[assignment]

--- a/osc/connection.py
+++ b/osc/connection.py
@@ -568,6 +568,12 @@ class SignatureAuthHandler(AuthHandlerBase):
         self.user = user
         self.sshkey = sshkey
 
+        if self.sshkey:
+            # if only a file name is provided, prepend ~/.ssh
+            if "/" not in self.sshkey:
+                self.sshkey = os.path.join("~", ".ssh", self.sshkey)
+                self.sshkey = os.path.expanduser(self.sshkey)
+
         self.ssh_keygen_path = shutil.which("ssh-keygen")
         self.ssh_add_path = shutil.which("ssh-add")
 
@@ -612,11 +618,6 @@ class SignatureAuthHandler(AuthHandlerBase):
     def ssh_sign(self, data, namespace, keyfile=None):
         if not keyfile:
             keyfile = self.guess_keyfile()
-        else:
-            if '/' not in keyfile:
-                keyfile = f"~/.ssh/{keyfile}"
-            keyfile = os.path.expanduser(keyfile)
-
         cmd = [self.ssh_keygen_path, '-Y', 'sign', '-f', keyfile, '-n', namespace, '-q']
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding="utf-8")
         signature, _ = proc.communicate(data)

--- a/osc/connection.py
+++ b/osc/connection.py
@@ -591,13 +591,6 @@ class SignatureAuthHandler(AuthHandlerBase):
         else:
             return []
 
-    @staticmethod
-    def get_fingerprint(line):
-        parts = line.strip().split(b" ")
-        if len(parts) < 2:
-            raise ValueError(f"Unable to retrieve ssh key fingerprint from line: {line}")
-        return parts[1]
-
     def guess_keyfile(self):
         # `ssh-keygen -Y sign` requires a file with a key which is not available during ssh agent forwarding
         # that's why we need to list ssh-agent's keys and store the first one into a temp file


### PR DESCRIPTION
Fixes: #1245

To give osc a hint which ssh key from the agent to use, append `obs=<apiurl-hostname>` to the private key’s comment. Example comment: `<username@host> obs=api.example.com`

- To edit the key, run: `ssh-keygen -c -f ~/.ssh/<private-key>`
- To query the key, run: `ssh-keygen -y -f ~/.ssh/<private-key>`
