### PR TITLE
Improve 'getbinaries' command by ignoring source and debuginfo filters when a binary name is specified

### DIFF
--- a/behave/features/getbinaries-project-package-repo-arch-file.feature
+++ b/behave/features/getbinaries-project-package-repo-arch-file.feature
@@ -32,6 +32,7 @@ Scenario: Run `osc getbinaries <project> <package> <repo> <arch> <file>` where f
     When I execute osc with args "getbinaries test:factory multibuild-pkg standard x86_64 multibuild-pkg-1-1.src.rpm"
     Then directory listing of "{context.osc.temp}/binaries/" is
         """
+        multibuild-pkg-1-1.src.rpm
         """
 
 
@@ -47,6 +48,7 @@ Scenario: Run `osc getbinaries <project> <package> <repo> <arch> <file>` where f
     When I execute osc with args "getbinaries test:factory multibuild-pkg standard x86_64 multibuild-pkg-debuginfo-1-1.x86_64.rpm"
     Then directory listing of "{context.osc.temp}/binaries/" is
         """
+        multibuild-pkg-debuginfo-1-1.x86_64.rpm
         """
 
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8151,6 +8151,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             else:
                 package = [package]
 
+        if binary is not None:
+            output.print_msg("Binary filename was specified, ignoring source and debuginfo filters", print_to="debug")
+            opts.sources = True
+            opts.debuginfo = True
+
         # Set binary target directory and create if not existing
         target_dir = os.path.normpath(opts.destdir)
         if not os.path.isdir(target_dir):


### PR DESCRIPTION
Fixes: #1555