### PR TITLE
Fix 'rebuild' command so the '--all' option conflicts with the 'package' argument

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7847,10 +7847,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if not (opts.all or package or repo or arch or code):
             raise oscerr.WrongOptions('No option has been provided. If you want to rebuild all packages of the entire project, use --all option.')
 
-        if opts.all:
-            # ignore the package name which can come from a working copy
-            packages = [None]
-        elif opts.multibuild_package:
+        if opts.all and package:
+            self.argparser.error("Option '--all' conflicts with the 'package' argument. Omit the argument or run osc from outside a package working copy.")
+
+        if opts.multibuild_package:
             resolver = MultibuildFlavorResolver(apiurl, project, package, use_local=False)
             packages = resolver.resolve_as_packages(opts.multibuild_package)
         else:


### PR DESCRIPTION
Fixes: #1560 