### PR TITLE
Fix 'mv' command when renaming a file multiple times

### DIFF
--- a/behave/features/mv.feature
+++ b/behave/features/mv.feature
@@ -19,3 +19,36 @@ Scenario: Run `osc mv <file> <new-name>` in a package checkout
      """
      And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
      And file "{context.osc.temp}/test:factory/test-pkgA/new-name.changes" exists
+
+
+Scenario: Run `osc mv <file> <new-name>` several times
+    When I execute osc with args "mv test-pkgA.changes test-pkgA.changes-1"
+    Then the exit code is 0
+     And I execute osc with args "status"
+     And stdout is
+     """
+     D    test-pkgA.changes
+     A    test-pkgA.changes-1
+     """
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes-1" exists
+    When I execute osc with args "mv test-pkgA.changes-1 test-pkgA.changes-2"
+    Then the exit code is 0
+     And I execute osc with args "status"
+     And stdout is
+     """
+     D    test-pkgA.changes
+     A    test-pkgA.changes-2
+     """
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes-2" exists
+    When I execute osc with args "mv test-pkgA.changes-2 test-pkgA.changes-3"
+    Then the exit code is 0
+     And I execute osc with args "status"
+     And stdout is
+     """
+     D    test-pkgA.changes
+     A    test-pkgA.changes-3
+     """
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes" does not exist
+     And file "{context.osc.temp}/test:factory/test-pkgA/test-pkgA.changes-3" exists

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -9887,6 +9887,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         except oscerr.PackageFileConflict:
             # file is already tracked
             pass
+
+        # instantiate src_pkg *again* to load fresh state from .osc that was written on deleting a file in tgt_pkg
+        # it would be way better to use a single Package instance where possible
+        src_pkg = Package(source)
         src_pkg.delete_file(os.path.basename(source), force=opts.force)
 
     @cmdln.option('-d', '--delete', action='store_true',


### PR DESCRIPTION
Fixes: #1569