### PR TITLE
Add `results --fail-on-error/-F` flag

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6049,6 +6049,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='list packages vertically instead horizontally for entire project')
     @cmdln.option('-w', '--watch', action='store_true',
                         help='watch the results until all finished building')
+    @cmdln.option('-F', '--fail-on-error', action='store_true',
+                        help='fail with exit 1 if any build has errored')
     @cmdln.option('-s', '--status-filter',
                         help='only show packages with the given build status')
     @cmdln.option('-f', '--failed', action='store_true',
@@ -6162,7 +6164,13 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             kwargs['wait'] = opts.watch
             kwargs['printJoin'] = '\n'
             kwargs['format'] = opts.format
-            get_results(**kwargs)
+
+            out = {}
+            get_results(out=out, **kwargs)
+
+            if opts.fail_on_error and out['failed']:
+                sys.exit(1)
+
 
     # WARNING: this function is also called by do_results. You need to set a default there
     #          as well when adding a new option!

--- a/osc/core.py
+++ b/osc/core.py
@@ -4096,7 +4096,16 @@ def format_results(results, format):
     return [format % r for r in results]
 
 
-def get_results(apiurl: str, project: str, package: str, verbose=False, printJoin="", *args, **kwargs):
+def get_results(
+    apiurl: str,
+    project: str,
+    package: str,
+    verbose=False,
+    printJoin="",
+    out: Optional[dict] = None,
+    *args,
+    **kwargs
+):
     """returns list of/or prints a human readable status for the specified package"""
     # hmm the function name is a bit too generic - something like
     # get_package_results_human would be better, but this would break the existing
@@ -4106,6 +4115,7 @@ def get_results(apiurl: str, project: str, package: str, verbose=False, printJoi
         format = '%(rep)-20s %(arch)-10s %(pkg)-30s %(status)s'
     r = []
     printed = False
+    failed = False
     multibuild_packages = kwargs.pop('multibuild_packages', [])
     show_excluded = kwargs.pop('showexcl', False)
     code_filter = kwargs.get('code')
@@ -4148,12 +4158,21 @@ def get_results(apiurl: str, project: str, package: str, verbose=False, printJoi
             if code_filter is None or code_filter == res['code']:
                 r.append(format % res)
 
+            if res['code'] in ('failed', 'broken', 'unresolvable'):
+                failed = True
+
         if printJoin:
             if printed:
                 # will print a newline if already a result was printed (improves readability)
                 print()
             print(printJoin.join(r))
             printed = True
+
+    if out is None:
+        out = {}
+
+    out["failed"] = failed
+
     return r
 
 


### PR DESCRIPTION
This allows to exit with `1` in case any build fails to provide feedback to end-user scripts.

Refers to: https://github.com/kubernetes/release/issues/3632