### PR TITLE
results: Add support for --format for default text mode

### DIFF
--- a/behave/features/results.feature
+++ b/behave/features/results.feature
@@ -1,0 +1,141 @@
+Feature: `osc results` command
+
+
+Scenario: Run `osc results` with no arguments
+   When I execute osc with args "results"
+   Then the exit code is 2
+    And stderr is
+        """
+        No project given
+        """
+
+
+Scenario: Run `osc results <project>/<package>`
+   When I execute osc with args "results test:factory/multibuild-pkg"
+   Then stdout is
+        """
+        standard             x86_64     multibuild-pkg                 disabled
+        standard             x86_64     multibuild-pkg:flavor1         disabled
+        standard             x86_64     multibuild-pkg:flavor2         disabled
+        standard             i586       multibuild-pkg                 disabled
+        standard             i586       multibuild-pkg:flavor1         disabled
+        standard             i586       multibuild-pkg:flavor2         disabled
+        """
+
+
+Scenario: Run `osc results` from a package checkout
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory/multibuild-pkg"
+     And I set working directory to "{context.osc.temp}/test:factory/multibuild-pkg"
+   When I execute osc with args "results"
+   Then stdout is
+        """
+        standard             x86_64     multibuild-pkg                 disabled
+        standard             x86_64     multibuild-pkg:flavor1         disabled
+        standard             x86_64     multibuild-pkg:flavor2         disabled
+        standard             i586       multibuild-pkg                 disabled
+        standard             i586       multibuild-pkg:flavor1         disabled
+        standard             i586       multibuild-pkg:flavor2         disabled
+        """
+
+
+Scenario: Run `osc results <project>/<package>`, no multibuild flavors
+   When I execute osc with args "results test:factory/multibuild-pkg --no-multibuild"
+   Then stdout is
+        """
+        standard             x86_64     multibuild-pkg                 disabled
+        standard             i586       multibuild-pkg                 disabled
+        """
+
+
+Scenario: Run `osc results` from a package checkout, multibuild flavor specified
+   Given I set working directory to "{context.osc.temp}"
+     And I execute osc with args "checkout test:factory/multibuild-pkg"
+     And I set working directory to "{context.osc.temp}/test:factory/multibuild-pkg"
+   When I execute osc with args "results -M flavor1"
+   Then stdout is
+        """
+        standard             x86_64     multibuild-pkg:flavor1         disabled
+        standard             i586       multibuild-pkg:flavor1         disabled
+        """
+
+Scenario: Run `osc results <project>/<package>`, specified output format
+   When I execute osc with args "results test:factory/multibuild-pkg --format='%(repository)s|%(arch)s|%(package)s|%(code)s'"
+   Then stdout is
+        """
+        standard|x86_64|multibuild-pkg|disabled
+        standard|x86_64|multibuild-pkg:flavor1|disabled
+        standard|x86_64|multibuild-pkg:flavor2|disabled
+        standard|i586|multibuild-pkg|disabled
+        standard|i586|multibuild-pkg:flavor1|disabled
+        standard|i586|multibuild-pkg:flavor2|disabled
+        """
+
+
+Scenario: Run `osc results <project>/<package>`, csv output
+   When I execute osc with args "results test:factory/multibuild-pkg --csv"
+   Then stdout matches
+        """
+        "standard","x86_64","multibuild-pkg","publish.*","False","disabled",""
+        "standard","x86_64","multibuild-pkg:flavor1","publish.*","False","disabled",""
+        "standard","x86_64","multibuild-pkg:flavor2","publish.*","False","disabled",""
+        "standard","i586","multibuild-pkg","publish.*","False","disabled",""
+        "standard","i586","multibuild-pkg:flavor1","publish.*","False","disabled",""
+        "standard","i586","multibuild-pkg:flavor2","publish.*","False","disabled",""
+        """
+
+
+Scenario: Run `osc results <project>/<package>`, csv output, multibuild flavor specified
+   When I execute osc with args "results test:factory/multibuild-pkg --csv -M flavor1"
+   Then stdout matches
+        """
+        "standard","x86_64","multibuild-pkg:flavor1","publish.*","False","disabled",""
+        "standard","i586","multibuild-pkg:flavor1","publish.*","False","disabled",""
+        """
+
+
+Scenario: Run `osc results <project>/<package>`, csv output, specified output format (columns)
+   When I execute osc with args "results test:factory/multibuild-pkg --csv --format='repository,arch,package,code'"
+   Then stdout is
+        """
+        "standard","x86_64","multibuild-pkg","disabled"
+        "standard","x86_64","multibuild-pkg:flavor1","disabled"
+        "standard","x86_64","multibuild-pkg:flavor2","disabled"
+        "standard","i586","multibuild-pkg","disabled"
+        "standard","i586","multibuild-pkg:flavor1","disabled"
+        "standard","i586","multibuild-pkg:flavor2","disabled"
+        """
+
+
+Scenario: Run `osc results <project>/<package>`, xml output
+   When I execute osc with args "results test:factory/multibuild-pkg --xml"
+   Then stdout matches
+        """
+        <resultlist state=".*">
+          <result project="test:factory" repository="standard" arch="x86_64" code="publish.*" state="publish.*">
+            <status package="multibuild-pkg" code="disabled"/>
+            <status package="multibuild-pkg:flavor1" code="disabled"/>
+            <status package="multibuild-pkg:flavor2" code="disabled"/>
+          </result>
+          <result project="test:factory" repository="standard" arch="i586" code="publish.*" state="publish.*">
+            <status package="multibuild-pkg" code="disabled"/>
+            <status package="multibuild-pkg:flavor1" code="disabled"/>
+            <status package="multibuild-pkg:flavor2" code="disabled"/>
+          </result>
+        </resultlist>
+        """
+
+
+Scenario: Run `osc results <project>/<package>`, xml output, multibuild flavor specified
+   When I execute osc with args "results test:factory/multibuild-pkg --xml -M flavor1"
+   Then stdout matches
+        """
+        <resultlist state=".*">
+          <result project="test:factory" repository="standard" arch="x86_64" code="publish.*" state="publish.*">
+            <status package="multibuild-pkg:flavor1" code="disabled" />
+          </result>
+          <result project="test:factory" repository="standard" arch="i586" code="publish.*" state="publish.*">
+            <status package="multibuild-pkg:flavor1" code="disabled" />
+          </result>
+        </resultlist>
+        """

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6090,6 +6090,12 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if opts.failed and opts.status_filter:
             raise oscerr.WrongArgs('-s and -f cannot be used together')
 
+        if opts.multibuild_package and opts.no_multibuild:
+            self.argparser.error("-M/--multibuild-package and --no-multibuild are mutually exclusive")
+
+        if opts.xml and opts.format:
+            self.argparser.error("--xml and --format are mutually exclusive")
+
         if opts.failed:
             opts.status_filter = 'failed'
             opts.brief = True

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6055,7 +6055,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('', '--csv', action='store_true', default=False,
                   help='generate output in CSV format')
     @cmdln.option('', '--format', default='%(repository)s|%(arch)s|%(state)s|%(dirty)s|%(code)s|%(details)s',
-                  help='format string for csv output')
+                  help='format string for default or csv output (not supported for xml)')
     @cmdln.option('--show-excluded', action='store_true',
                   help='show repos that are excluded for this package')
     def do_results(self, subcmd, opts, *args):
@@ -6129,6 +6129,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             kwargs['verbose'] = opts.verbose
             kwargs['wait'] = opts.watch
             kwargs['printJoin'] = '\n'
+            kwargs['format'] = opts.format
             get_results(**kwargs)
 
     # WARNING: this function is also called by do_results. You need to set a default there

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6054,7 +6054,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='generate output in XML (former results_meta)')
     @cmdln.option('', '--csv', action='store_true', default=False,
                   help='generate output in CSV format')
-    @cmdln.option('', '--format', default='%(repository)s|%(arch)s|%(state)s|%(dirty)s|%(code)s|%(details)s',
+    @cmdln.option('', '--format', default=None,
                   help='format string for default or csv output (not supported for xml)')
     @cmdln.option('--show-excluded', action='store_true',
                   help='show repos that are excluded for this package')
@@ -6123,6 +6123,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     print(decode_it(xml), end='')
                 else:
                     # csv formatting
+                    if opts.format is None:
+                        opts.format='%(repository)s|%(arch)s|%(state)s|%(dirty)s|%(code)s|%(details)s'
                     results = [r for r, _ in result_xml_to_dicts(xml)]
                     print('\n'.join(format_results(results, opts.format)))
         else:

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6055,7 +6055,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('', '--csv', action='store_true', default=False,
                   help='generate output in CSV format')
     @cmdln.option('', '--format', default=None,
-                  help='format string for default or csv output (not supported for xml)')
+                  help="Change the format of the text (default) or csv output. Not supported for xml output.\n"
+                       "Supported fields: project, package, repository, arch, state, dirty, code, details.\n"
+                       "Text output format requires using the field names in form of named fields for string interpolation: ``%%(field)s``.\n"
+                       "CSV output format requires field names separated with commas.")
     @cmdln.option('--show-excluded', action='store_true',
                   help='show repos that are excluded for this package')
     def do_results(self, subcmd, opts, *args):

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6124,7 +6124,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 else:
                     # csv formatting
                     if opts.format is None:
-                        opts.format='%(repository)s|%(arch)s|%(state)s|%(dirty)s|%(code)s|%(details)s'
+                        opts.format = '%(repository)s|%(arch)s|%(state)s|%(dirty)s|%(code)s|%(details)s'
                     results = [r for r, _ in result_xml_to_dicts(xml)]
                     print('\n'.join(format_results(results, opts.format)))
         else:

--- a/osc/core.py
+++ b/osc/core.py
@@ -4101,8 +4101,13 @@ def get_results(apiurl: str, project: str, package: str, verbose=False, printJoi
     # hmm the function name is a bit too generic - something like
     # get_package_results_human would be better, but this would break the existing
     # api (unless we keep get_results around as well)...
-    result_line_templ = '%(rep)-20s %(arch)-10s %(status)s'
-    result_line_mb_templ = '%(rep)-20s %(arch)-10s %(pkg)-30s %(status)s'
+    format = kwargs.pop('format')
+    if format is None:
+        result_line_templ = '%(rep)-20s %(arch)-10s %(status)s'
+        result_line_mb_templ = '%(rep)-20s %(arch)-10s %(pkg)-30s %(status)s'
+    else:
+        result_line_templ = format
+        result_line_mb_templ = format
     r = []
     printed = False
     multibuild_packages = kwargs.pop('multibuild_packages', [])

--- a/osc/core.py
+++ b/osc/core.py
@@ -4103,11 +4103,7 @@ def get_results(apiurl: str, project: str, package: str, verbose=False, printJoi
     # api (unless we keep get_results around as well)...
     format = kwargs.pop('format')
     if format is None:
-        result_line_templ = '%(rep)-20s %(arch)-10s %(status)s'
-        result_line_mb_templ = '%(rep)-20s %(arch)-10s %(pkg)-30s %(status)s'
-    else:
-        result_line_templ = format
-        result_line_mb_templ = format
+        format = '%(rep)-20s %(arch)-10s %(pkg)-30s %(status)s'
     r = []
     printed = False
     multibuild_packages = kwargs.pop('multibuild_packages', [])
@@ -4150,10 +4146,7 @@ def get_results(apiurl: str, project: str, package: str, verbose=False, printJoi
             # of the repository if the result is already prefiltered by the backend. So we need
             # to filter out the repository states.
             if code_filter is None or code_filter == res['code']:
-                if is_multi:
-                    r.append(result_line_mb_templ % res)
-                else:
-                    r.append(result_line_templ % res)
+                r.append(format % res)
 
         if printJoin:
             if printed:


### PR DESCRIPTION
In this PR, we allow the `--format` option to work for `osc results` for the default text mode as well, not only `--csv`.

This workaround allows to resolve/workaround the following issues (by specifying the format in CSV):

* Fixes #1578
* Fixes #1579

#### Motivation

We want to be able to run `osc results --watch` using a specific format, with the same filtering options supported by default (e.g. multibuild packages, do not show excluded archs, etc.). This is not currently possible due to the limitations of the `--csv` option.

#### Context

The `osc results` command currently does not support any way of formatting the output, except when using the `--csv` option. However, this option is limited as it does not support `--multibuild-package`, and it shows all excluded packages by default (even if `--show-excluded` is not specified).

#### Examples

* Format all packages:

```
$ osc results -A api.opensuse.org openSUSE:Factory opensuse-tumbleweed-image --repo=images \
    --format '%(repository)s %(package)s %(arch)s %(code)s %(state)s'
images opensuse-tumbleweed-image:docker x86_64 succeeded unpublished
images opensuse-tumbleweed-image:lxc x86_64 succeeded unpublished
images opensuse-tumbleweed-image:networkd x86_64 succeeded unpublished
```

* Show also excluded packages:

```
$ osc results -A api.opensuse.org openSUSE:Factory opensuse-tumbleweed-image --repo=images \
    --format '%(repository)s %(package)s %(arch)s %(code)s %(state)s' --show-excluded
images opensuse-tumbleweed-image local excluded unpublished
images opensuse-tumbleweed-image:docker local excluded unpublished
images opensuse-tumbleweed-image:lxc local excluded unpublished
images opensuse-tumbleweed-image:networkd local excluded unpublished
images opensuse-tumbleweed-image x86_64 excluded unpublished
images opensuse-tumbleweed-image:docker x86_64 succeeded unpublished
images opensuse-tumbleweed-image:lxc x86_64 succeeded unpublished
images opensuse-tumbleweed-image:networkd x86_64 succeeded unpublished
images opensuse-tumbleweed-image i586 excluded unpublished
images opensuse-tumbleweed-image:docker i586 excluded unpublished
images opensuse-tumbleweed-image:lxc i586 excluded unpublished
images opensuse-tumbleweed-image:networkd i586 excluded unpublished
```

* Show only results for a specific multibuild package:

```
$ osc results -A api.opensuse.org openSUSE:Factory opensuse-tumbleweed-image --repo=images \
    --format '%(repository)s %(package)s %(arch)s %(code)s %(state)s' --multibuild-package=docker
images opensuse-tumbleweed-image:docker x86_64 succeeded unpublished
```