### PR TITLE
Improve 'getbinaries' command by accepting '-M' / '--multibuild-package' option outside checkouts

### DIFF
--- a/behave/features/getbinaries-project-package-repo-arch-file.feature
+++ b/behave/features/getbinaries-project-package-repo-arch-file.feature
@@ -16,8 +16,10 @@ Scenario: Run `osc getbinaries <project> <package> <repo> <arch> <file>`
 
 Scenario: Run `osc getbinaries <project> <package> <repo> <arch> <file> --multibuild-package=<flavor>`
     When I execute osc with args "getbinaries test:factory multibuild-pkg standard x86_64 multibuild-pkg-flavor1-1-1.x86_64.rpm --multibuild-package=flavor1"
-    # the option is allowed only in a package checkout
-    Then the exit code is 2
+    Then directory listing of "{context.osc.temp}/binaries/" is
+        """
+        multibuild-pkg-flavor1-1-1.x86_64.rpm
+        """
 
 
 Scenario: Run `osc getbinaries <project> <package>:<flavor> <repo> <arch> <file>` where file is a package

--- a/behave/features/getbinaries-project-package-repo-arch.feature
+++ b/behave/features/getbinaries-project-package-repo-arch.feature
@@ -19,8 +19,13 @@ Scenario: Run `osc getbinaries <project> <package> <repo> <arch>`
 
 Scenario: Run `osc getbinaries <project> <package> <repo> <arch> --multibuild-package=<flavor>`
     When I execute osc with args "getbinaries test:factory multibuild-pkg standard x86_64 --multibuild-package=flavor1"
-    # the option is allowed only in a package checkout
-    Then the exit code is 2
+    Then directory listing of "{context.osc.temp}/binaries/" is
+        """
+        multibuild-pkg-flavor1-1-1.x86_64.rpm
+        _buildenv
+        _statistics
+        rpmlint.log
+        """
 
 
 Scenario: Run `osc getbinaries <project> <package>:<flavor> <repo> <arch>`

--- a/behave/features/getbinaries-project-repo-arch.feature
+++ b/behave/features/getbinaries-project-repo-arch.feature
@@ -35,8 +35,13 @@ Scenario: Run `osc getbinaries <project> <repo> <arch>`
 
 Scenario: Run `osc getbinaries <project> <repo> <arch> --multibuild-package=<flavor>`
     When I execute osc with args "getbinaries test:factory standard x86_64 --multibuild-package=flavor1"
-    # the option is allowed only in a package checkout
-    Then the exit code is 2
+    Then directory tree in "{context.osc.temp}/binaries/" is
+        """
+        multibuild-pkg-flavor1-1-1.x86_64.rpm
+        multibuild-pkg:flavor1/_buildenv
+        multibuild-pkg:flavor1/_statistics
+        multibuild-pkg:flavor1/rpmlint.log
+        """
 
 
 Scenario: Run `osc getbinaries <project> <repo> <arch> --debuginfo`

--- a/behave/features/getbinaries-repo-arch-prjcheckout.feature
+++ b/behave/features/getbinaries-repo-arch-prjcheckout.feature
@@ -37,8 +37,13 @@ Scenario: Run `osc getbinaries <repo> <arch>` from a project checkout
 
 Scenario: Run `osc getbinaries <repo> <arch> --multibuild-package=<flavor>` from a project checkout
     When I execute osc with args "getbinaries standard x86_64 --multibuild-package=flavor1"
-    # the option is allowed only in a package checkout
-    Then the exit code is 2
+    Then directory tree in "{context.osc.temp}/test:factory/binaries/" is
+        """
+        multibuild-pkg-flavor1-1-1.x86_64.rpm
+        multibuild-pkg:flavor1/_buildenv
+        multibuild-pkg:flavor1/_statistics
+        multibuild-pkg:flavor1/rpmlint.log
+        """
 
 
 Scenario: Run `osc getbinaries <repo> <arch> --sources` from a project checkout

--- a/behave/features/getbinaries-repo-prjcheckout.feature
+++ b/behave/features/getbinaries-repo-prjcheckout.feature
@@ -40,8 +40,14 @@ Scenario: Run `osc getbinaries <repo>` from a project checkout
 
 Scenario: Run `osc getbinaries <repo> --multibuild-package=<flavor>` from a project checkout
     When I execute osc with args "getbinaries standard --multibuild-package=flavor1"
-    # the option is allowed only in a package checkout
-    Then the exit code is 2
+    Then directory tree in "{context.osc.temp}/test:factory/binaries/" is
+        """
+        multibuild-pkg-flavor1-1-1.i586.rpm
+        multibuild-pkg-flavor1-1-1.x86_64.rpm
+        multibuild-pkg:flavor1/_buildenv
+        multibuild-pkg:flavor1/_statistics
+        multibuild-pkg:flavor1/rpmlint.log
+        """
 
 
 Scenario: Run `osc getbinaries <repo> --sources` from a project checkout


### PR DESCRIPTION
Fixes: #1565