### PR TITLE
Redirect venv warnings from stderr to debug output

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -271,7 +271,7 @@ class MainCommand(Command):
 
     def load_commands(self):
         if IN_VENV:
-            output.print_msg("Running in virtual environment, skipping loading plugins installed outside the virtual environment.", print_to="stderr")
+            output.print_msg("Running in virtual environment, skipping loading plugins installed outside the virtual environment.", print_to="debug")
 
         for module_prefix, module_path in self.MODULES:
             module_path = os.path.expanduser(module_path)
@@ -10231,7 +10231,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
     def _load_plugins(self):
         if IN_VENV:
-            output.print_msg("Running in virtual environment, skipping loading legacy plugins.", print_to="stderr")
+            output.print_msg("Running in virtual environment, skipping loading legacy plugins.", print_to="debug")
             return
 
         plugin_dirs = [


### PR DESCRIPTION
The message was disturbing during regular use on NixOS because the file system layout doesn't conform with FHS and sys.base_prefix != sys.prefix.

Fixes: #1584