### PR TITLE
Make most of the fields in KeyinfoPubkey and KeyinfoSslcert models optional

### DIFF
--- a/osc/obs_api/keyinfo_pubkey.py
+++ b/osc/obs_api/keyinfo_pubkey.py
@@ -4,27 +4,27 @@ from ..util.models import *  # pylint: disable=wildcard-import,unused-wildcard-i
 class KeyinfoPubkey(XmlModel):
     XML_TAG = "pubkey"
 
-    keyid: str = Field(
+    keyid: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    userid: str = Field(
+    userid: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    algo: str = Field(
+    algo: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    keysize: str = Field(
+    keysize: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    expires: int = Field(
+    expires: Optional[int] = Field(
         xml_attribute=True,
     )
 
-    fingerprint: str = Field(
+    fingerprint: Optional[str] = Field(
         xml_attribute=True,
     )
 
@@ -34,6 +34,10 @@ class KeyinfoPubkey(XmlModel):
 
     def get_expires_str(self) -> str:
         import datetime
+
+        if self.expires is None:
+            return ""
+
         return datetime.datetime.fromtimestamp(self.expires).strftime("%Y-%m-%d %H:%M:%S")
 
     def to_human_readable_string(self) -> str:

--- a/osc/obs_api/keyinfo_sslcert.py
+++ b/osc/obs_api/keyinfo_sslcert.py
@@ -8,7 +8,7 @@ class KeyinfoSslcert(XmlModel):
         xml_attribute=True,
     )
 
-    serial: str = Field(
+    serial: Optional[str] = Field(
         xml_attribute=True,
     )
 
@@ -16,23 +16,23 @@ class KeyinfoSslcert(XmlModel):
         xml_attribute=True,
     )
 
-    subject: str = Field(
+    subject: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    algo: str = Field(
+    algo: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    keysize: str = Field(
+    keysize: Optional[str] = Field(
         xml_attribute=True,
     )
 
-    begins: int = Field(
+    begins: Optional[int] = Field(
         xml_attribute=True,
     )
 
-    expires: int = Field(
+    expires: Optional[int] = Field(
         xml_attribute=True,
     )
 
@@ -46,10 +46,18 @@ class KeyinfoSslcert(XmlModel):
 
     def get_begins_str(self) -> str:
         import datetime
+
+        if self.begins is None:
+            return ""
+
         return datetime.datetime.fromtimestamp(self.begins).strftime("%Y-%m-%d %H:%M:%S")
 
     def get_expires_str(self) -> str:
         import datetime
+
+        if self.expires is None:
+            return ""
+
         return datetime.datetime.fromtimestamp(self.expires).strftime("%Y-%m-%d %H:%M:%S")
 
     def to_human_readable_string(self) -> str:

--- a/osc/output/tty.py
+++ b/osc/output/tty.py
@@ -44,6 +44,9 @@ def colorize(text, color):
     if not color:
         return text
 
+    if not text:
+        return text
+
     result = ""
     for i in color.split(","):
         result += ESCAPE_CODES[i]

--- a/tests/test_keyinfo.py
+++ b/tests/test_keyinfo.py
@@ -1,0 +1,43 @@
+import unittest
+
+from osc import obs_api
+
+
+class TestKeyinfo(unittest.TestCase):
+    def test_empty_pubkey(self):
+        ki = obs_api.Keyinfo()
+        ki.pubkey_list = [{"value": "<pubkey>"}]
+
+        expected = """
+Type        : GPG public key
+User ID     : 
+Algorithm   : 
+Key size    : 
+Expires     : 
+Fingerprint : 
+<pubkey>""".strip()
+        actual = ki.pubkey_list[0].to_human_readable_string()
+        self.assertEqual(expected, actual)
+
+    def test_empty_sslcert(self):
+        ki = obs_api.Keyinfo()
+        ki.sslcert_list = [{"value": "<pubkey>"}]
+
+        expected = """
+Type        : SSL certificate
+Subject     : 
+Key ID      : 
+Serial      : 
+Issuer      : 
+Algorithm   : 
+Key size    : 
+Begins      : 
+Expires     : 
+Fingerprint : 
+<pubkey>""".strip()
+        actual = ki.sslcert_list[0].to_human_readable_string()
+        self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -74,6 +74,13 @@ Key    : Value
 """.strip()
         self.assertEqual(str(t), expected)
 
+    def test_empty_value_no_color(self):
+        t = KeyValueTable()
+        t.add("Key", "", color="bold")
+
+        expected = "Key : "
+        self.assertEqual(str(t), expected)
+
 
 class TestPrintMsg(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes: #1596