### PR TITLE
Change 'repairwc' command to always run all repair steps

### DIFF
--- a/behave/features/repairwc.feature
+++ b/behave/features/repairwc.feature
@@ -17,11 +17,13 @@ Scenario: Run `osc repairwc` on a project without .osc/_osclib_version
      And I set working directory to "{context.osc.temp}/test:factory"
      And I remove file "{context.osc.temp}/test:factory/.osc/_osclib_version"
     When I execute osc with args "status"
-    Then the exit code is 1
+    Then the exit code is 0
+     And file "{context.osc.temp}/test:factory/.osc/_osclib_version" does not exist
     When I execute osc with args "repairwc"
     Then the exit code is 0
     When I execute osc with args "status"
     Then the exit code is 0
+     And file "{context.osc.temp}/test:factory/.osc/_osclib_version" exists
 
 
 Scenario: Run `osc repairwc` on a package
@@ -41,7 +43,9 @@ Scenario: Run `osc repairwc` on a package without .osc/_osclib_version
      And I remove file "{context.osc.temp}/test:factory/test-pkgA/.osc/_osclib_version"
     When I execute osc with args "status"
     Then the exit code is 1
+     And file "{context.osc.temp}/test:factory/test-pkgA/.osc/_osclib_version" does not exist
     When I execute osc with args "repairwc"
     Then the exit code is 0
     When I execute osc with args "status"
     Then the exit code is 0
+     And file "{context.osc.temp}/test:factory/test-pkgA/.osc/_osclib_version" exists

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -10106,8 +10106,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                     dirty_files = getattr(e, "dirty_files", [])
                     if '_apiurl' in dirty_files and (not apiurl or not opts.force_apiurl):
                         apiurl = get_apiurl(apiurls)
-                    prj = Project(i, getPackageList=False, wc_check=False)
-                    prj.wc_repair(apiurl)
+
+                prj = Project(i, getPackageList=False, wc_check=False)
+                prj.wc_repair(apiurl)
+
                 for p in prj.pacs_have:
                     if p in prj.pacs_broken:
                         continue
@@ -10127,8 +10129,11 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 dirty_files = getattr(e, "dirty_files", [])
                 if '_apiurl' in dirty_files and (not apiurl or not opts.force_apiurl):
                     apiurl = get_apiurl(apiurls)
-                p = Package(pdir, wc_check=False)
-                p.wc_repair(apiurl)
+
+            p = Package(pdir, wc_check=False)
+            repaired = p.wc_repair(apiurl)
+
+            if repaired:
                 print(f'done. Please check the state of the wc (via \'osc status {i}\').')
             else:
                 print(f'osc: working copy \'{i}\' is not inconsistent', file=sys.stderr)

--- a/osc/obs_scm/project.py
+++ b/osc/obs_scm/project.py
@@ -139,13 +139,16 @@ class Project:
                 dirty_files.append(fname)
         return dirty_files
 
-    def wc_repair(self, apiurl: Optional[str] = None):
+    def wc_repair(self, apiurl: Optional[str] = None) -> bool:
+        repaired: bool = False
+
         store = Store(self.dir, check=False)
         store.assert_is_project()
 
         # there was a time when osc did not write _osclib_version file; let's assume these checkouts have version 1.0
         if not store.exists("_osclib_version"):
             store.write_string("_osclib_version", "1.0")
+            repaired = True
 
         if not store.exists("_apiurl") or apiurl:
             if apiurl is None:
@@ -157,6 +160,9 @@ class Project:
             conf.parse_apisrv_url(None, apiurl)
             store.apiurl = apiurl
             self.apiurl = apiurl
+            repaired = True
+
+        return repaired
 
     def checkout_missing_pacs(self, sinfos, expand_link=False, unexpand_link=False):
         from ..core import checkout_package


### PR DESCRIPTION
... even if the working copy loads without an exception