### PR TITLE
spec: Recommend python3-zstandard to support opening control.tar.zst

### DIFF
--- a/contrib/osc.spec
+++ b/contrib/osc.spec
@@ -96,6 +96,9 @@ Recommends:     %{use_python_pkg}-distro
 Recommends:     %{use_python_pkg}-keyring
 Recommends:     %{use_python_pkg}-keyring-keyutils
 
+# needed for opening control.tar.zst in debquery
+Recommends:     %{use_python_pkg}-zstandard
+
 Recommends:     %{obs_build_pkg}
 Recommends:     ca-certificates
 Recommends:     diffstat


### PR DESCRIPTION
Fixes: #1607