### PR TITLE
Fix storing _buildinfo and _buildconfig files in .osc rather than among the source files

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -925,7 +925,7 @@ def main(apiurl, store, opts, argv):
     bc_file = None
     bi_filename = '_buildinfo-%s-%s.xml' % (repo, arch)
     bc_filename = '_buildconfig-%s-%s' % (repo, arch)
-    if not opts.local_package and store.is_package and os.access(core.store, os.W_OK):
+    if store.is_package and os.access(core.store, os.W_OK):
         bi_filename = os.path.join(os.getcwd(), core.store, bi_filename)
         bc_filename = os.path.join(os.getcwd(), core.store, bc_filename)
     elif not os.access('.', os.W_OK):


### PR DESCRIPTION
Only local packages were affected.
Partially reverts 799b45a00 Fix `osc build --local-package`