### PR TITLE
Fix 'resolved' command to skip subdirectories in package checkouts

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -5990,7 +5990,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             self.argparse_error("Incorrect number of arguments.")
 
         args = parseargs(args)
-        pacs = Package.from_paths(args)
+        pacs = Package.from_paths(args, skip_dirs=True)
 
         for p in pacs:
             for filename in p.todo:

--- a/osc/obs_scm/package.py
+++ b/osc/obs_scm/package.py
@@ -89,12 +89,15 @@ class Package:
         return (self.name, self.prjname, self.apiurl) < (other.name, other.prjname, other.apiurl)
 
     @classmethod
-    def from_paths(cls, paths, progress_obj=None):
+    def from_paths(cls, paths, progress_obj=None, *, skip_dirs=False):
         """
         Return a list of Package objects from working copies in given paths.
         """
         packages = []
         for path in paths:
+            if skip_dirs and os.path.isdir(path):
+                continue
+
             package = cls(path, progress_obj)
             seen_package = None
             try:
@@ -116,7 +119,7 @@ class Package:
         return packages
 
     @classmethod
-    def from_paths_nofail(cls, paths, progress_obj=None):
+    def from_paths_nofail(cls, paths, progress_obj=None, *, skip_dirs=False):
         """
         Return a list of Package objects from working copies in given paths
         and a list of strings with paths that do not contain Package working copies.
@@ -124,6 +127,9 @@ class Package:
         packages = []
         failed_to_load = []
         for path in paths:
+            if skip_dirs and os.path.isdir(path):
+                continue
+
             try:
                 package = cls(path, progress_obj)
             except oscerr.NoWorkingCopy:


### PR DESCRIPTION
Fixes running 'osc resolved *' in a package checkout with a subdirectory.