### PR TITLE
Add --no-timestamps parameter to build

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -880,6 +880,8 @@ def main(apiurl, store, opts, argv):
         pac = pac + ":" + opts.multibuild_package
     if opts.verbose_mode:
         buildargs.append('--verbose=%s' % opts.verbose_mode)
+    if opts.no_timestamps:
+        buildargs.append('--no-timestamps')
     if opts.wipe:
         buildargs.append("--wipe")
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7313,6 +7313,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='Do not use preinstall images for creating the build root.')
     @cmdln.option("--just-print-buildroot", action="store_true",
                   help="Print build root path and exit.")
+    @cmdln.option('--no-timestamps', '-s', '--strip-time', action='store_true',
+                  help='Hide the time prefix in output.')
     @cmdln.alias('chroot')
     @cmdln.alias('shell')
     @cmdln.alias('wipe')


### PR DESCRIPTION
Add --no-timestamps parameter which already exists in build.
Help text copied from build.
Include parameters for the same parameter in buildlog for easier
use.