### PR TITLE
fix[git-obs]: use rather git-obs command name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ osc =
 
 [options.entry_points]
 console_scripts =
-    obs-git = osc.commandline_git:main
+    git-obs = osc.commandline_git:main
     osc = osc.babysitter:main
 
 [flake8]


### PR DESCRIPTION
It works with git better and uses git-something mechanism.