### PR TITLE
Fix progress bar code to support progressbar2

### DIFF
--- a/osc/meter.py
+++ b/osc/meter.py
@@ -13,6 +13,7 @@ from typing import Optional
 try:
     import progressbar as pb
     have_pb_module = True
+    using_pb_progressbar2 = tuple(map(int, pb.__version__.split('.'))) >= (3, 1)
 except ImportError:
     have_pb_module = False
 
@@ -62,9 +63,14 @@ class PBTextMeter(TextMeterBase):
         for i in self.bar.widgets:
             if not isinstance(i, pb.Bar):
                 continue
-            i.marker = " "
-            i.left = " "
-            i.right = " "
+            if using_pb_progressbar2:
+                i.marker = lambda _progress, _data, _width: " "
+                i.left = lambda _progress, _data, _width: " "
+                i.right = lambda _progress, _data, _width: " "
+            else:
+                i.marker = " "
+                i.left = " "
+                i.right = " "
 
         self.bar.finish()
 


### PR DESCRIPTION
The progress bar code in `meter.PBTextMeter` touches some third-party class state to hide the bar after the job is completed. This works fine for the unmaintained 2018 progressbar library (https://pypi.org/project/progressbar/), however is not compatible with the later progressbar2 fork (https://pypi.org/project/progressbar2/) and causes a crash.