### PR TITLE
Improve 'maintenancerequest' command to inherit description from superseded request

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4259,7 +4259,14 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print(f'Using target project \'{target_project}\'{release_in}')
 
         if not opts.message:
-            opts.message = edit_message()
+            msg = ""
+            if opts.supersede:
+                from .obs_api import Request
+
+                req = Request.from_api(apiurl, opts.supersede)
+                msg = req.description + "\n"
+            opts.message = edit_message(template=f"{msg}")
+
 
         supersede_existing = False
         reqs = []


### PR DESCRIPTION
Commit 083fdf3b introduced a feature for the 'submitrequest' command where the submission description is pre-populated with one of a superseded request.
Here, the same is introduced for the `maintenancerequest` command.   
The behavior of `osc mr -s 1234` is identical to `osc sr -s 1234` - see Issue 1575.