### PR TITLE
Fix build-install CI job

### DIFF
--- a/.github/workflows/build-install.yaml
+++ b/.github/workflows/build-install.yaml
@@ -9,6 +9,7 @@ on:
       - 'NEWS'
       - 'README.md'
       - 'doc/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-install.yaml
+++ b/.github/workflows/build-install.yaml
@@ -17,7 +17,6 @@ concurrency:
 jobs:
   rpmbuild:
     name: 'rpmbuild test'
-    needs: unit-ro
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "master" ]
   schedule:
     - cron: "13 12 * * 6"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/**'
       - '**.py'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
       - '**.py'
       - 'behave/**'
       - 'tests/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The job unit-ro is from a different file, so "needs" can not find it.
Remove it as there is no dependency.

An alternative would be to merge both files into one. It might save work
on some broken PRs.

---

Allow manual triggering of all Github CI jobs