### PR TITLE
Fix a few pylint errors

### DIFF
--- a/osc/cmdln.py
+++ b/osc/cmdln.py
@@ -7,6 +7,7 @@ import argparse
 import inspect
 import sys
 import textwrap
+from typing import NoReturn
 
 
 def option(*args, **kwargs):
@@ -213,7 +214,7 @@ class Cmdln:
             for option_args, option_kwargs in options:
                 subparser.add_argument(*option_args, **option_kwargs)
 
-    def argparse_error(self, *args, **kwargs):
+    def argparse_error(self, *args, **kwargs) -> NoReturn:
         """
         Raise an argument parser error.
         Automatically pick the right parser for the main program or a subcommand.

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8300,7 +8300,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         store.assert_is_package()
 
         if command in ('runall', 'ra', 'run', 'localrun', 'manualrun', 'disabledrun', 'lr', 'mr', 'dr', 'r'):
-            p = Package(".")
             if command  in ("localrun", "lr"):
                 mode = "local"
             elif command in ("manualrun", "mr"):
@@ -8310,6 +8309,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             elif command in ("runall", "ra"):
                 mode = "all"
 
+        p = Package(".")
         return p.run_source_services(mode, singleservice, opts.verbose)
 
     @cmdln.option('-a', '--arch', metavar='ARCH',

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -23,7 +23,7 @@ from functools import cmp_to_key
 from operator import itemgetter
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import List
+from typing import List, NoReturn
 from urllib.parse import urlsplit
 from urllib.error import HTTPError
 
@@ -6669,7 +6669,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         strip_time = opts.strip_time or conf.config['buildlog_strip_time']
         print_buildlog(apiurl, project, package, repository, arch, offset, strip_time, opts.last, opts.lastsucceeded)
 
-    def print_repos(self, repos_only=False, exc_class=oscerr.WrongArgs, exc_msg='Missing arguments', project=None):
+    def print_repos(
+        self, repos_only=False, exc_class=oscerr.WrongArgs, exc_msg="Missing arguments", project=None
+    ) -> NoReturn:
         from .core import is_package_dir
         from .core import is_project_dir
 

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -4359,8 +4359,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if not args or len(args) > 2:
             raise oscerr.WrongArgs('Wrong number of arguments.')
-        if len(args) >= 1:
-            package = args[0]
+        package = args[0]
         if len(args) >= 2:
             tproject = self._process_project_name(args[1])
 


### PR DESCRIPTION
Add type annotation to appease pylint

This always throws an exception, so anntotating it NoReturn allows
pylint to notice some exhaustive choice, removing these false errors:

osc/commandline.py:2232:68: E0606: Possibly using variable 'dst_package' before assignment (possibly-used-before-assignment)
osc/commandline.py:2448:68: E0606: Possibly using variable 'dst_package' before assignment (possibly-used-before-assignment)

---

Remove tautological condition to appease pylint

The exception above would have already triggered otherwise. Thus
removing this pylint error:

osc/commandline.py:4371:38: E0601: Using variable 'package' before assignment (used-before-assignment)

---

Add type annotation to appease pylint

This always throws an exception, so anntotating it NoReturn allows
pylint to notice some exhaustive choice, removing this false errors:

osc/commandline.py:6581:78: E0606: Possibly using variable 'arch' before assignment (possibly-used-before-assignment)

---

Fix possible use before assignment

Doing the assignment conditionally doesn't make sense here, so move it
outside the condition.

osc/commandline.py:8311:15: E0606: Possibly using variable 'p' before assignment (possibly-used-before-assignment)