### PR TITLE
Set pacsuffix='deb' if binarytype=='deb' in osc/build.py

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -111,7 +111,7 @@ class Buildinfo:
         # are we building .rpm or .deb?
         # XXX: shouldn't we deliver the type via the buildinfo?
         self.pacsuffix = 'rpm'
-        if self.buildtype in ('dsc', 'collax', 'deb'):
+        if self.buildtype in ('dsc', 'collax') or self.binarytype == 'deb':
             self.pacsuffix = 'deb'
         if self.buildtype == 'arch':
             self.pacsuffix = 'arch'


### PR DESCRIPTION
Checks binarytype == 'deb' when setting pacsuffix to allow debbuilder package caching. Fixes the change introduced in 4edd4799a1fbee180c9d8743dd87feb4b09abd1e , which causes 100% package cache miss when building with debbuild.