### PR TITLE
Assume openSUSE:Factory if project cannot be determined

### DIFF
--- a/osc/git_scm/store.py
+++ b/osc/git_scm/store.py
@@ -136,12 +136,8 @@ class GitStore:
                 # read project from parent directory that contains a project with .osc metadata
                 self._project = self.project_obs_scm_store.project
             if not self._project:
-                # HACK: guess project from git branch
-                branch = self._run_git(["branch", "--show-current"])
-                if branch == "factory":
-                    self._project = "openSUSE:Factory"
-                else:
-                    raise oscerr.NoWorkingCopy(f"Couldn't map git branch '{branch}' to a project")
+                # HACK: assume openSUSE:Factory project if project metadata is missing
+                self._project = "openSUSE:Factory"
         return self._project
 
     @project.setter


### PR DESCRIPTION
Don't assume "factory" branch is needed to build against Factory. This should be the default build configuration.

As-is, it's impossible to initiate a build from other branches, even when using --alternative-project= so having a default is probably advisable. Also, devel projects are being imported with "main" as their default branches.