### PR TITLE
Fix crash for fetching updateinfo.xml

### DIFF
--- a/osc/fetch.py
+++ b/osc/fetch.py
@@ -172,7 +172,7 @@ class Fetcher:
                 if pac_obj is None:
                     print('Unsupported file type: ', tmpfile, file=sys.stderr)
                     sys.exit(1)
-                canonname = pac_obj.binary
+                canonname = bytes(pac_obj.binary, 'utf-8')
         decoded_canonname = decode_it(canonname)
         if b'/' in canonname or '/' in decoded_canonname:
             raise oscerr.OscIOError(None, 'canonname contains a slash')


### PR DESCRIPTION
This is no rpm, but a string here. Needs to become a bytes object.

(OBS got fixed to deliver updateinfo.xml in buildinfo for productcomposer builds now leading to this crash)