### PR TITLE
Fix behave failure when not defined git-osc-precommit-hook

### DIFF
--- a/behave/features/git-osc-precommit-hook.feature
+++ b/behave/features/git-osc-precommit-hook.feature
@@ -3,6 +3,7 @@ Feature: `git-osc-precommit-hook` command
 
 Background:
    Given I set working directory to "{context.osc.temp}"
+     And I defined git-osc-precommit-hook
      And I execute git-obs with args "repo fork pool/test-GitPkgA"
      And I execute git-obs with args "repo clone Admin/test-GitPkgA --no-ssh-strict-host-key-checking"
      And I set working directory to "{context.osc.temp}/test-GitPkgA"

--- a/behave/features/steps/osc.py
+++ b/behave/features/steps/osc.py
@@ -138,6 +138,11 @@ class GitObs(CommandBase):
         return cmd
 
 
+@behave.step("I defined git-osc-precommit-hook")
+def step_impl(context):
+    if not context.config.userdata.get("git-osc-precommit-hook"):
+        context.scenario.skip()
+
 @behave.step("I execute osc with args \"{args}\"")
 def step_impl(context, args):
     args = args.format(context=context)


### PR DESCRIPTION
When I run the command `behave -Dosc=../osc-wrapper.py -Dgit-obs=../git-obs.py` as defined in behave/README.md I get output:

```
Failing scenarios:
  features/git-osc-precommit-hook.feature:15  Run git-osc-precommit-hook

64 features passed, 1 failed, 0 skipped
196 scenarios passed, 1 failed, 0 skipped
1052 steps passed, 1 failed, 2 skipped, 0 undefined
```

With the proposed patch the output is:
```
64 features passed, 0 failed, 1 skipped
196 scenarios passed, 0 failed, 1 skipped
1046 steps passed, 0 failed, 10 skipped, 0 undefined
```

