### PR TITLE
ci: Suppress mypy failure

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: pip install mypy
       - run: pip install types-cryptography types-urllib3
       - run: pip install distro keyring progressbar ruamel.yaml zstandard
-      - run: mypy osc
+      - run: mypy osc || echo "failure suppressed"
 
   darker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is no much point in always failing mypy in the current state. I suggest suppressing the failure until it is ready and make PRs green again