### PR TITLE
Fix TypeError in response_to_exception() in gitea_api

### DIFF
--- a/osc/gitea_api/exceptions.py
+++ b/osc/gitea_api/exceptions.py
@@ -18,7 +18,7 @@ def response_to_exception(response: GiteaHTTPResponse, *, context: Optional[dict
       for example: ``conn.request("GET", url, context={"owner": owner, "repo": repo})``
     """
     data = response.json()
-    messages = [data["message"]] + data.get("errors", [])
+    messages = [data["message"]] + (data.get("errors", None) or [])
 
     for cls in EXCEPTION_CLASSES:
         if cls.RESPONSE_STATUS is not None and cls.RESPONSE_STATUS != response.status:


### PR DESCRIPTION
Gitea seems to be inconsistent in including the "errors" entry in responses. It may be completely missing or set to null/None.

Fixes: #1797