### PR TITLE
Fix loading shell completions for 'git-obs'

### DIFF
--- a/contrib/git-obs-complete.bash
+++ b/contrib/git-obs-complete.bash
@@ -1,1 +1,4 @@
+# exit immediately if argcomplete is not available
+[ -e '/usr/bin/register-python-argcomplete' ] || exit 0
+
 eval "$(register-python-argcomplete --shell bash git-obs)"

--- a/contrib/git-obs-complete.fish
+++ b/contrib/git-obs-complete.fish
@@ -1,1 +1,4 @@
+# exit immediately if argcomplete is not available
+[ -e '/usr/bin/register-python-argcomplete' ] || exit 0
+
 eval "$(register-python-argcomplete --shell fish git-obs)"

--- a/contrib/git-obs-complete.zsh
+++ b/contrib/git-obs-complete.zsh
@@ -1,1 +1,4 @@
+# exit immediately if argcomplete is not available
+[ -e '/usr/bin/register-python-argcomplete' ] || exit 0
+
 eval "$(register-python-argcomplete --shell zsh git-obs)"


### PR DESCRIPTION
Don't load the completions when /usr/bin/register-python-argcomplete is not available