### PR TITLE
Fix completion causing exiting shell in some cases

### DIFF
--- a/contrib/git-obs-complete.bash
+++ b/contrib/git-obs-complete.bash
@@ -1,4 +1,2 @@
-# exit immediately if argcomplete is not available
-[ -e '/usr/bin/register-python-argcomplete' ] || exit 0
-
-eval "$(register-python-argcomplete --shell bash git-obs)"
+[ -x '/usr/bin/register-python-argcomplete' ] && \
+    eval "$(register-python-argcomplete --shell bash git-obs)"

--- a/contrib/git-obs-complete.fish
+++ b/contrib/git-obs-complete.fish
@@ -1,4 +1,2 @@
-# exit immediately if argcomplete is not available
-[ -e '/usr/bin/register-python-argcomplete' ] || exit 0
-
-eval "$(register-python-argcomplete --shell fish git-obs)"
+[ -x '/usr/bin/register-python-argcomplete' ] && \
+    eval "$(register-python-argcomplete --shell fish git-obs)"

--- a/contrib/git-obs-complete.zsh
+++ b/contrib/git-obs-complete.zsh
@@ -1,4 +1,2 @@
-# exit immediately if argcomplete is not available
-[ -e '/usr/bin/register-python-argcomplete' ] || exit 0
-
-eval "$(register-python-argcomplete --shell zsh git-obs)"
+[ -x '/usr/bin/register-python-argcomplete' ] && \
+    eval "$(register-python-argcomplete --shell zsh git-obs)"


### PR DESCRIPTION
Calling 'exit 0' turned to be quite aggresive and caused exiting shell in some cases