### PR TITLE
Don't retry requests on 504 Gateway Timeout

### DIFF
--- a/osc/connection.py
+++ b/osc/connection.py
@@ -248,7 +248,6 @@ def http_request(method: str, url: str, headers=None, data=None, file=None):
                 500,  # Internal Server Error
                 502,  # Bad Gateway
                 503,  # Service Unavailable
-                504,  # Gateway Timeout
             ),
             # don't raise because we want an actual response rather than a MaxRetryError with "too many <status_code> error responses" message
             raise_on_status=False,


### PR DESCRIPTION
Proxy that is in front of OBS may timeout which would trigger a retry. At the same time, the request may succeed.
Some operations may lead to creating duplicate entries such as requests. Removing 504 from retries seems to be the easiest fix.