### PR TITLE
Fix 'osc fork' by copying whole query part to the new scmsync url

### DIFF
--- a/osc/commands/fork.py
+++ b/osc/commands/fork.py
@@ -172,7 +172,7 @@ class ForkCommand(osc.commandline.OscCommand):
 
         # XXX: implicit branch name should be forbidden; assumptions are bad
         fork_scmsync = urllib.parse.urlunparse(
-            (parsed_scmsync_url.scheme, parsed_scmsync_url.netloc, f"{fork_owner}/{fork_repo}", "", "", fork_branch)
+            (parsed_scmsync_url.scheme, parsed_scmsync_url.netloc, f"{fork_owner}/{fork_repo}", "", parsed_scmsync_url.query, fork_branch)
         )
 
         print()


### PR DESCRIPTION
Fixes: #1859