### PR TITLE
Make `osc results --show-excluded` work in a project context

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6427,7 +6427,6 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             opts.hide_legend = None
             opts.name_filter = None
             opts.show_non_building = None
-            opts.show_excluded = None
             return self.do_prjresults('prjresults', opts, *args)
 
         if opts.xml and opts.csv:


### PR DESCRIPTION
The line, added in commit 8307a7063, almost 15 years ago seems to be obsolete, now.