### PR TITLE
Fix --sccache help typo

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7648,7 +7648,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
     @cmdln.option('--pkg-ccache', metavar='/path/to/_ccache.tar',
                   help='path to an existing uncompressed archive ccache. Using this option implies --ccache')
     @cmdln.option('--sccache', action='store_true',
-                  help='use sccache to speed up rebuilds. Conflicts with --cache')
+                  help='use sccache to speed up rebuilds. Conflicts with --ccache')
     @cmdln.option('--sccache-uri', metavar='redis://127.0.0.1:6389',
                   help='Optional remote URI for sccache storage. Implies --sccache.')
     @cmdln.option('--with', metavar='X', dest='_with', action='append',


### PR DESCRIPTION
Assuming this is a typo as --cache does not exist