### PR TITLE
Add `--no-pager` global option

### DIFF
--- a/contrib/osc.complete
+++ b/contrib/osc.complete
@@ -75,7 +75,7 @@ oscrc="${XDG_CONFIG_HOME}/osc/oscrc"
 
 command=osc
 oscopts=(--version --help --debugger --post-mortem --traceback --http-full-debug
-    --debug --apiurl -A --config -c --no-keyring --no-gnome-keyring --verbose --quiet)
+    --debug --apiurl -A --config -c --no-keyring --no-gnome-keyring --no-pager --verbose --quiet)
 osccmds=(abortbuild add addremove aggregatepac api ar bco bl blt branch branchco
     bsdevelproject bse bugowner build buildconfig buildhist buildhistory buildinfo
     buildlog buildlogtail cat changedevelreq changedevelrequest checkconstraints checkin checkout


### PR DESCRIPTION
Commands:
```sh
osc --no-pager submitrequest diff
osc --no-pager request -d show $ID
osc --no-pager diff
osc --no-pager diff --link
osc --no-pager rdiff $REMOTE
osc --no-pager pdiff
```

Also note this commented line (undecided, need context):
https://github.com/openSUSE/osc/blame/master/osc/commandline.py#L5197