### PR TITLE
Check for both upper and lowercase values for http/s_proxy

### DIFF
--- a/osc/connection.py
+++ b/osc/connection.py
@@ -91,7 +91,7 @@ def enable_http_debug(config):
 
 
 def get_proxy_manager(env):
-    proxy_url = os.environ.get(env, None)
+    proxy_url = os.environ.get(env.upper(), None) or os.environ.get(env.lower(), None)
 
     if not proxy_url:
         return


### PR DESCRIPTION
When running osc checkout command under leap 15.6 the command got stuck. Running the `osc --trace checkout home:user`  command showed that the issue was due to the proxy check function that only looks for upper case values.

The global values entered in the `/etc/sysconfig/proxy` are exported as lowercase values to the system. This PR modifies the function to look for both upper and lowercase values.

