### PR TITLE
Implement 'git-obs --quiet' option (that mutes printing gitea settings now)

### DIFF
--- a/behave/features/git-login.feature
+++ b/behave/features/git-login.feature
@@ -97,7 +97,7 @@ Scenario: Remove a credentials login entry
 
 
 Scenario: Update a credentials login entry
-    When I execute git-obs with args "login update alice --new-name=NEW_NAME --new-url=NEW_URL --new-user=NEW_USER --new-token=1234567890123456789012345678901234567890 --new-ssh-key= --set-as-default"
+    When I execute git-obs with args "login update alice --new-name=NEW_NAME --new-url=NEW_URL --new-user=NEW_USER --new-token=1234567890123456789012345678901234567890 --new-ssh-key= --new-quiet=1 --set-as-default"
     Then the exit code is 0
      And stderr is
          """
@@ -117,6 +117,7 @@ Scenario: Update a credentials login entry
         Default              : true
         URL                  : NEW_URL
         User                 : NEW_USER
+        Quiet                : yes
         """
     When I execute git-obs with args "login list"
     Then stdout is
@@ -130,6 +131,7 @@ Scenario: Update a credentials login entry
         Default              : true
         URL                  : NEW_URL
         User                 : NEW_USER
+        Quiet                : yes
 
         Name                 : bob
         URL                  : http://localhost:{context.podman.container.ports[gitea_http]}

--- a/osc/commandline_git.py
+++ b/osc/commandline_git.py
@@ -77,7 +77,17 @@ class GitObsCommand(osc.commandline_common.Command):
     def gitea_conn(self, value):
         self.main_command.gitea_conn = value
 
+    @property
+    def quiet(self):
+        if self.main_command._args.quiet:
+            return True
+        if self.gitea_login and self.gitea_login.quiet:
+            return True
+        return False
+
     def print_gitea_settings(self):
+        if self.quiet:
+            return
         print(f"Using the following Gitea settings:", file=sys.stderr)
         print(f" * Config path: {self.gitea_conf.path}", file=sys.stderr)
         print(f" * Login (name of the entry in the config file): {self.gitea_login.name}", file=sys.stderr)
@@ -176,6 +186,13 @@ class GitObsMainCommand(osc.commandline_common.MainCommand):
         self._gitea_conn = None
 
     def init_arguments(self):
+        self.add_argument(
+            "-q",
+            "--quiet",
+            action="store_true",
+            help="Mute unnecessary output",
+        )
+
         self.add_argument(
             "--gitea-config",
             help="Path to gitea config. Default: $GIT_OBS_CONFIG or ~/.config/tea/config.yml.",

--- a/osc/commands/fork.py
+++ b/osc/commands/fork.py
@@ -19,6 +19,13 @@ class ForkCommand(osc.commandline.OscCommand):
     post_parse_args = osc.commandline_git.GitObsMainCommand.post_parse_args
     print_gitea_settings = osc.commandline_git.GitObsCommand.print_gitea_settings
 
+    def quiet(self):
+        if self.main_command.args.quiet:
+            return True
+        if self.gitea_login and self.gitea_login.quiet:
+            return True
+        return False
+
     def init_arguments(self):
         # inherit global options from the main git-obs command
         osc.commandline_git.GitObsMainCommand.init_arguments(self)

--- a/osc/commands_git/login_add.py
+++ b/osc/commands_git/login_add.py
@@ -22,6 +22,7 @@ class LoginAddCommand(osc.commandline_git.GitObsCommand):
         self.parser.add_argument("--token", help="Gitea access token; omit or set to '-' to invoke a secure interactive prompt")
         self.parser.add_argument("--ssh-key", metavar="PATH", help="Path to a private SSH key").completer = complete_ssh_key_path
         self.parser.add_argument("--git-uses-http", action="store_true", help="Git uses http(s) instead of SSH", default=None)
+        self.parser.add_argument("--quiet", action="store_true", help="Mute unnecessary output when using this login entry")
         self.parser.add_argument("--set-as-default", help="Set the new login entry as default", action="store_true", default=None)
 
     def run(self, args):

--- a/osc/commands_git/login_update.py
+++ b/osc/commands_git/login_update.py
@@ -23,6 +23,7 @@ class LoginUpdateCommand(osc.commandline_git.GitObsCommand):
         self.parser.add_argument("--new-token", metavar="TOKEN", help="Gitea access token; set to '-' to invoke a secure interactive prompt")
         self.parser.add_argument("--new-ssh-key", metavar="PATH", help="Path to a private SSH key").completer = complete_ssh_key_path
         self.parser.add_argument("--new-git-uses-http", help="Git uses http(s) instead of SSH", choices=["0", "1", "yes", "no"], default=None)
+        self.parser.add_argument("--new-quiet", help="Mute unnecessary output when using this login entry", choices=["0", "1", "yes", "no"], default=None)
         self.parser.add_argument("--set-as-default", action="store_true", help="Set the login entry as default")
 
     def run(self, args):
@@ -51,6 +52,13 @@ class LoginUpdateCommand(osc.commandline_git.GitObsCommand):
         else:
             new_git_uses_http = None
 
+        if args.new_quiet in ("0", "no"):
+            new_quiet = False
+        elif args.new_quiet in ("1", "yes"):
+            new_quiet = True
+        else:
+            new_quiet = None
+
         updated_login_obj = self.gitea_conf.update_login(
             args.name,
             new_name=args.new_name,
@@ -59,6 +67,7 @@ class LoginUpdateCommand(osc.commandline_git.GitObsCommand):
             new_token=args.new_token,
             new_ssh_key=args.new_ssh_key,
             new_git_uses_http=new_git_uses_http,
+            new_quiet=new_quiet,
             set_as_default=args.set_as_default,
         )
         print("")

--- a/osc/gitea_api/conf.py
+++ b/osc/gitea_api/conf.py
@@ -21,6 +21,7 @@ class Login(BaseModel):
     token: str = Field()  # type: ignore[assignment]
     ssh_key: Optional[str] = Field()  # type: ignore[assignment]
     git_uses_http: Optional[bool] = Field()  # type: ignore[assignment]
+    quiet: Optional[bool] = Field()  # type: ignore[assignment]
     default: Optional[bool] = Field()  # type: ignore[assignment]
 
     class AlreadyExists(oscerr.OscBaseError):
@@ -69,6 +70,8 @@ class Login(BaseModel):
             table.add("Private SSH key path", self.ssh_key)
         if self.git_uses_http:
             table.add("Git uses http(s)", "yes" if self.git_uses_http else "no")
+        if self.quiet:
+            table.add("Quiet", "yes" if self.quiet else "no")
         if show_token:
             # tokens are stored in the plain text, there's not reason to protect them too much
             # let's only hide them from the output by default
@@ -212,6 +215,7 @@ class Config:
         new_token: Optional[str] = None,
         new_ssh_key: Optional[str] = None,
         new_git_uses_http: Optional[bool] = None,
+        new_quiet: Optional[bool] = None,
         set_as_default: Optional[bool] = None,
     ) -> Login:
         login = self.get_login(name)
@@ -235,6 +239,9 @@ class Config:
         else:
             # remove from the config instead of setting to False
             login.git_uses_http = None
+
+        if new_quiet is not None:
+            login.quiet = new_quiet
 
         if set_as_default:
             login.default = True


### PR DESCRIPTION
Fixes: #1929