### PR TITLE
Make Token.triggered_at optional as it's not available in the oficially released OBS code

### DIFF
--- a/osc/obs_api/token.py
+++ b/osc/obs_api/token.py
@@ -94,7 +94,7 @@ class Token(XmlModel):
         ),
     )
 
-    triggered_at: str = Field(
+    triggered_at: Optional[str] = Field(
         xml_attribute=True,
         description=textwrap.dedent(
             """


### PR DESCRIPTION
Fixes: #1891