### PR TITLE
Make GitObsCommand.add_argument_owner_repo() and add_argument_owner_repo_pull() reusable by allowing setting 'dest' argument

### DIFF
--- a/osc/commandline_git.py
+++ b/osc/commandline_git.py
@@ -96,16 +96,18 @@ class GitObsCommand(osc.commandline_common.Command):
         print("", file=sys.stderr)
 
     def add_argument_owner_repo(self, **kwargs):
+        dest = kwargs.pop("dest", "owner_repo")
         return self.add_argument(
-            "owner_repo",
+            dest,
             action=OwnerRepoAction,
             help="Owner and repo: (format: <owner>/<repo>)",
             **kwargs,
         )
 
     def add_argument_owner_repo_pull(self, **kwargs):
+        dest = kwargs.pop("dest", "owner_repo_pull")
         return self.add_argument(
-            "owner_repo_pull",
+            dest,
             action=OwnerRepoPullAction,
             help="Owner, repo and pull request number (format: <owner>/<repo>#<pull-request-number>)",
             **kwargs,


### PR DESCRIPTION
Refactors out part of https://github.com/openSUSE/osc/pull/1961