### PR TITLE
buildlog: flush TTY buffer

### DIFF
--- a/osc/core.py
+++ b/osc/core.py
@@ -4668,6 +4668,8 @@ def print_buildlog(
             data = buildlog_strip_time(data)
         # to protect us against control characters (CVE-2012-1095)
         output_buffer.write(sanitize_text(data))
+        if output_buffer.isatty():
+            output_buffer.flush()
 
     query = {'nostream': '1', 'start': f'{offset}'}
     if last:


### PR DESCRIPTION
While a package is being built, the `osc blt` command shows a live log. Up until recently, this worked fine, but recently (I don't know exactly when, sorry, probably after Arch upgraded Python to 3.14) invoking `osc blt` doesn't show anything until `Ctrl+C` is hit.

Fix this by flushing the output buffer explicitly if the output goes to TTY.

Fixes: https://github.com/openSUSE/osc/issues/2040