### PR TITLE
Maintainership converter command line tool

### DIFF
--- a/osc/commands_git/file.py
+++ b/osc/commands_git/file.py
@@ -1,0 +1,15 @@
+import osc.commandline_git
+
+
+class FileCommand(osc.commandline_git.GitObsCommand):
+    """
+    Manage files in a package
+    """
+
+    name = "file"
+
+    def init_arguments(self):
+        pass
+
+    def run(self, args):
+        self.parser.print_help()

--- a/osc/commands_git/file.py
+++ b/osc/commands_git/file.py
@@ -3,7 +3,7 @@ import osc.commandline_git
 
 class FileCommand(osc.commandline_git.GitObsCommand):
     """
-    Manage files in a package
+    Manage metadata files in a repo
     """
 
     name = "file"

--- a/osc/commands_git/file_maintainership.py
+++ b/osc/commands_git/file_maintainership.py
@@ -1,0 +1,16 @@
+import osc.commandline_git
+
+
+class FileMaintainershipCommand(osc.commandline_git.GitObsCommand):
+    """
+    Manage the _maintainership.json file
+    """
+
+    name = "maintainership"
+    parent = "FileCommand"
+
+    def init_arguments(self):
+        pass
+
+    def run(self, args):
+        self.parser.print_help()

--- a/osc/commands_git/file_maintainership_migrate.py
+++ b/osc/commands_git/file_maintainership_migrate.py
@@ -11,6 +11,13 @@ class FileMaintainershipMigrateCommand(osc.commandline_git.GitObsCommand):
 
     def init_arguments(self):
         self.add_argument(
+            "-i",
+            "--in-place",
+            action="store_true",
+            default=False,
+            help="Write the result back to the original file instead of printing to stdout",
+        )
+        self.add_argument(
             "path",
             nargs="?",
             default="_maintainership.json",
@@ -24,4 +31,9 @@ class FileMaintainershipMigrateCommand(osc.commandline_git.GitObsCommand):
             data = f.read()
 
         obj = maintainership.Maintainership.from_string(data)
-        print(obj.to_string())
+
+        if args.in_place:
+            with open(args.path, "w", encoding="utf-8") as f:
+                f.write(obj.to_string())
+        else:
+            print(obj.to_string())

--- a/osc/commands_git/file_maintainership_migrate.py
+++ b/osc/commands_git/file_maintainership_migrate.py
@@ -25,7 +25,14 @@ class FileMaintainershipMigrateCommand(osc.commandline_git.GitObsCommand):
         )
 
     def run(self, args):
+        import os
+        import sys
+
         from osc.gitea_api import maintainership
+
+        if not os.path.exists(args.path):
+            print(f"File not found: {args.path}", file=sys.stderr)
+            return
 
         with open(args.path, "r", encoding="utf-8") as f:
             data = f.read()

--- a/osc/commands_git/file_maintainership_migrate.py
+++ b/osc/commands_git/file_maintainership_migrate.py
@@ -1,12 +1,13 @@
 import osc.commandline_git
 
 
-class MaintainershipCommand(osc.commandline_git.GitObsCommand):
+class FileMaintainershipMigrateCommand(osc.commandline_git.GitObsCommand):
     """
     Read _maintainership.json and convert it from legacy format to the current format
     """
 
-    name = "maintainership-converter"
+    name = "migrate"
+    parent = "FileMaintainershipCommand"
 
     def init_arguments(self):
         self.add_argument(

--- a/osc/commands_git/maintainership_converter.py
+++ b/osc/commands_git/maintainership_converter.py
@@ -1,0 +1,26 @@
+import osc.commandline_git
+
+
+class MaintainershipCommand(osc.commandline_git.GitObsCommand):
+    """
+    Read _maintainership.json and convert it from legacy format to the current format
+    """
+
+    name = "maintainership-converter"
+
+    def init_arguments(self):
+        self.add_argument(
+            "path",
+            nargs="?",
+            default="_maintainership.json",
+            help="Path to the _maintainership.json file (default: %(default)s)",
+        )
+
+    def run(self, args):
+        from osc.gitea_api import maintainership
+
+        with open(args.path, "r", encoding="utf-8") as f:
+            data = f.read()
+
+        obj = maintainership.Maintainership.from_string(data)
+        print(obj.to_string())

--- a/tests/test_maintainership_converter.py
+++ b/tests/test_maintainership_converter.py
@@ -20,12 +20,12 @@ class TestMaintainershipConverter(unittest.TestCase):
             f.write(text)
         return path
 
-    def _run_converter(self, path):
+    def _run_converter(self, path, in_place=False):
         from osc.commands_git.file_maintainership_migrate import FileMaintainershipMigrateCommand
 
         cmd = FileMaintainershipMigrateCommand.__new__(FileMaintainershipMigrateCommand)
 
-        args = type("Args", (), {"path": path})()
+        args = type("Args", (), {"path": path, "in_place": in_place})()
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
             cmd.run(args)
@@ -103,6 +103,21 @@ class TestMaintainershipConverter(unittest.TestCase):
             f.write("not valid json")
         with self.assertRaises(json.JSONDecodeError):
             self._run_converter(path)
+
+    def test_in_place(self):
+        """With --in-place, result is written back to the file."""
+        path = self._write_file('{"":["alice","@group"],"pkg1":["bob"]}')
+        output = self._run_converter(path, in_place=True)
+        self.assertEqual(output, "")
+
+        with open(path, "r", encoding="utf-8") as f:
+            result = json.load(f)
+
+        self.assertEqual(result["header"]["document"], "obs-maintainers")
+        self.assertEqual(result["header"]["version"], "1.0")
+        self.assertEqual(result["project"]["users"], ["alice"])
+        self.assertEqual(result["project"]["groups"], ["group"])
+        self.assertEqual(result["packages"]["pkg1"]["users"], ["bob"])
 
 
 if __name__ == "__main__":

--- a/tests/test_maintainership_converter.py
+++ b/tests/test_maintainership_converter.py
@@ -1,0 +1,109 @@
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+
+class TestMaintainershipConverter(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="osc_test_maintainership_converter_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, text):
+        path = os.path.join(self.tmpdir, "_maintainership.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def _run_converter(self, path):
+        from osc.commands_git.maintainership_converter import MaintainershipCommand
+
+        cmd = MaintainershipCommand.__new__(MaintainershipCommand)
+
+        args = type("Args", (), {"path": path})()
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            cmd.run(args)
+        return stdout.getvalue()
+
+    def test_legacy_format_converted(self):
+        """Legacy format is converted to v1.0 format."""
+        path = self._write_file(
+            '{"":["project-maintainer","@project-group"], "package1":["alice","@pkg1-group"], "package2":["bob"]}'
+        )
+        output = self._run_converter(path)
+        result = json.loads(output)
+
+        self.assertEqual(result["header"]["document"], "obs-maintainers")
+        self.assertEqual(result["header"]["version"], "1.0")
+
+        self.assertEqual(result["project"]["users"], ["project-maintainer"])
+        self.assertEqual(result["project"]["groups"], ["project-group"])
+
+        self.assertEqual(result["packages"]["package1"]["users"], ["alice"])
+        self.assertEqual(result["packages"]["package1"]["groups"], ["pkg1-group"])
+
+        self.assertEqual(result["packages"]["package2"]["users"], ["bob"])
+        self.assertIsNone(result["packages"]["package2"]["groups"])
+
+    def test_v1_format_passthrough(self):
+        """v1.0 format is printed unchanged."""
+        path = self._write_file(
+            '{"header":{"document":"obs-maintainers","version":"1.0"},'
+            '"project":{"users":["alice"],"groups":null},'
+            '"packages":{"pkg1":{"users":["bob"],"groups":["team"]},'
+            '"pkg2":{"users":null,"groups":["team"]}}}'
+        )
+        output = self._run_converter(path)
+        result = json.loads(output)
+
+        self.assertEqual(result["header"]["document"], "obs-maintainers")
+        self.assertEqual(result["header"]["version"], "1.0")
+        self.assertEqual(result["project"]["users"], ["alice"])
+        self.assertEqual(result["packages"]["pkg1"]["users"], ["bob"])
+        self.assertEqual(result["packages"]["pkg1"]["groups"], ["team"])
+
+    def test_legacy_empty_project_maintainers(self):
+        """Legacy format with no project-level maintainers."""
+        path = self._write_file('{"package1":["alice"]}')
+        output = self._run_converter(path)
+        result = json.loads(output)
+
+        self.assertEqual(result["header"]["document"], "obs-maintainers")
+        self.assertIsNone(result["project"]["users"])
+        self.assertIsNone(result["project"]["groups"])
+        self.assertEqual(result["packages"]["package1"]["users"], ["alice"])
+
+    def test_legacy_groups_only(self):
+        """Legacy format with only groups, no users."""
+        path = self._write_file('{"":["@admins","@maintainers"],"pkg":["@team"]}')
+        output = self._run_converter(path)
+        result = json.loads(output)
+
+        self.assertIsNone(result["project"]["users"])
+        self.assertEqual(result["project"]["groups"], ["admins", "maintainers"])
+        self.assertIsNone(result["packages"]["pkg"]["users"])
+        self.assertEqual(result["packages"]["pkg"]["groups"], ["team"])
+
+    def test_file_not_found(self):
+        """Non-existent file raises an error."""
+        path = os.path.join(self.tmpdir, "nonexistent.json")
+        with self.assertRaises(FileNotFoundError):
+            self._run_converter(path)
+
+    def test_invalid_json(self):
+        """Invalid JSON raises an error."""
+        path = os.path.join(self.tmpdir, "_maintainership.json")
+        with open(path, "w") as f:
+            f.write("not valid json")
+        with self.assertRaises(json.JSONDecodeError):
+            self._run_converter(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_maintainership_converter.py
+++ b/tests/test_maintainership_converter.py
@@ -21,9 +21,9 @@ class TestMaintainershipConverter(unittest.TestCase):
         return path
 
     def _run_converter(self, path):
-        from osc.commands_git.maintainership_converter import MaintainershipCommand
+        from osc.commands_git.file_maintainership_migrate import FileMaintainershipMigrateCommand
 
-        cmd = MaintainershipCommand.__new__(MaintainershipCommand)
+        cmd = FileMaintainershipMigrateCommand.__new__(FileMaintainershipMigrateCommand)
 
         args = type("Args", (), {"path": path})()
         stdout = io.StringIO()

--- a/tests/test_maintainership_converter.py
+++ b/tests/test_maintainership_converter.py
@@ -26,10 +26,11 @@ class TestMaintainershipConverter(unittest.TestCase):
         cmd = FileMaintainershipMigrateCommand.__new__(FileMaintainershipMigrateCommand)
 
         args = type("Args", (), {"path": path, "in_place": in_place})()
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
+        self._stdout = io.StringIO()
+        self._stderr = io.StringIO()
+        with contextlib.redirect_stdout(self._stdout), contextlib.redirect_stderr(self._stderr):
             cmd.run(args)
-        return stdout.getvalue()
+        return self._stdout.getvalue()
 
     def test_legacy_format_converted(self):
         """Legacy format is converted to v1.0 format."""
@@ -91,10 +92,11 @@ class TestMaintainershipConverter(unittest.TestCase):
         self.assertEqual(result["packages"]["pkg"]["groups"], ["team"])
 
     def test_file_not_found(self):
-        """Non-existent file raises an error."""
+        """Non-existent file prints a message to stderr."""
         path = os.path.join(self.tmpdir, "nonexistent.json")
-        with self.assertRaises(FileNotFoundError):
-            self._run_converter(path)
+        output = self._run_converter(path)
+        self.assertEqual(output, "")
+        self.assertIn("File not found", self._stderr.getvalue())
 
     def test_invalid_json(self):
         """Invalid JSON raises an error."""


### PR DESCRIPTION
Fixes https://github.com/openSUSE/openSUSE-git/issues/311

- [x] convert from [legacy](https://src.opensuse.org/openSUSE/git-workflow-documentation/src/branch/main/architecture/hlfs/bot-group-management.md#backward-compatibility-legacy-format) to [latest](https://src.opensuse.org/openSUSE/git-workflow-documentation/src/branch/main/architecture/hlfs/bot-group-management.md#maintainership-data-format) format
- [x] print the produced content to the CLI output
- [x] `-i` to replace the same file content with the new format

### How to use it
- print the new format to the CLI output:
`git-obs file maintainership migrate _maintainership.json` 
- replace the current `_maintainership.json` file content with the content in the new format
`git-obs file maintainership migrate -i _maintainership.json`