### PR TITLE
models: Correctly handle optional values

### DIFF
--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -19,7 +19,7 @@ class MaintainershipHeader(BaseModel):
     """
     A model representing the maintainership document header.
     """
-    document: MaintainershipDocumentType = Field()
+    document: MaintainershipDocumentType = Field(default="obs-maintainers")
     version: str = Field(default="1.0")
 
 

--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -40,25 +40,27 @@ class Maintainership(BaseModel):
 
         data = json.loads(text)
 
+        def ug_to_dict(users, groups):
+            result = {}
+            if users:
+                result["users"] = users
+            if groups:
+                result["groups"] = groups
+            return result
+
         if data.get("header", None) is None:
             # format: legacy
             # entry with "" name holds project maintainers
             project_data = data.pop("", [])
             p_users = [i for i in project_data if not i.startswith("@")]
             p_groups = [i[1:] for i in project_data if i.startswith("@")]
-            project = {
-                "users": p_users if p_users else None,
-                "groups": p_groups if p_groups else None,
-            }
+            project = ug_to_dict(p_users, p_groups)
             packages = {}
             for package, package_data in data.items():
                 if isinstance(package_data, list):
                     pkg_users = [i for i in package_data if not i.startswith("@")]
                     pkg_groups = [i[1:] for i in package_data if i.startswith("@")]
-                    packages[package] = {
-                        "users": pkg_users if pkg_users else None,
-                        "groups": pkg_groups if pkg_groups else None,
-                    }
+                    packages[package] = ug_to_dict(pkg_users, pkg_groups)
             data = {
                 # version is the default (latest), because we do conversion to that format
                 "header": {"document": "obs-maintainers"},

--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -7,8 +7,8 @@ class MaintainerInfo(BaseModel):
     """
     A model representing users and groups associated with a project or package.
     """
-    users: Optional[List[str]] = Field(default=None)
-    groups: Optional[List[str]] = Field(default=None)
+    users: Optional[List[str]] = Field()
+    groups: Optional[List[str]] = Field()
 
 
 class MaintainershipDocumentType(str, Enum):

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -424,7 +424,7 @@ class BaseModel(metaclass=ModelMeta):
 
         for name, field in self.__fields__.items():
             if name not in kwargs:
-                if isinstance(field.default, NotSetClass):
+                if isinstance(field.default, NotSetClass) and not field.is_optional:
                     uninitialized_fields.append(field.name)
                 continue
             value = kwargs.pop(name)

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -451,9 +451,9 @@ class BaseModel(metaclass=ModelMeta):
     def _get_cmp_data(self):
         result = []
         for name, field in self.__fields__.items():
-            if field.exclude:
-                continue
             value = getattr(self, name)
+            if value is None:
+                continue
             if isinstance(value, dict):
                 value = sorted(list(value.items()))
             result.append((name, value))
@@ -475,6 +475,8 @@ class BaseModel(metaclass=ModelMeta):
             if field.exclude:
                 continue
             value = getattr(self, name)
+            if value is None:
+                continue
             if value is not None and field.is_model:
                 result[name] = value.dict()
             elif value is not None and field.is_model_list:

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -82,7 +82,7 @@ class NotSetClass:
 NotSet = NotSetClass()
 
 
-class FromParent(NotSetClass):
+class FromParent:
     def __init__(self, field_name, *, fallback=NotSet):
         self.field_name = field_name
         self.fallback = fallback

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -123,7 +123,7 @@ class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
             # append information about the default value
             if isinstance(self.default, FromParent):
                 self.__doc__ += f"\n\nDefault: inherited from parent config's field ``{self.default.field_name}``"
-            elif self.default is not NotSet:
+            elif not isinstance(self.default, NotSetClass):
                 self.__doc__ += f"\n\nDefault: ``{self.default}``"
 
         # whether to exclude this field from export
@@ -308,13 +308,13 @@ class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
 
         if isinstance(self.default, FromParent):
             if obj._parent is None:
-                if self.default.fallback is not NotSet:
+                if not isinstance(self.default.fallback, NotSetClass):
                     return self.default.fallback
                 else:
                     raise RuntimeError(f"The field '{self.name}' has default {self.default} but the model has no parent set")
             return getattr(obj._parent, self.default.field_name or self.name)
 
-        if self.default is NotSet:
+        if isinstance(self.default, NotSetClass):
             raise RuntimeError(f"The field '{self.name}' has no default")
 
         # make a deepcopy to avoid problems with mutable defaults
@@ -397,7 +397,7 @@ class ModelMeta(type):
             field.get_copy.__func__.__annotations__ = {"return": field.type}
 
             # set 'None' as the default for optional fields
-            if field.default is NotSet and field.is_optional:
+            if isinstance(field.default, NotSetClass) and field.is_optional:
                 field.default = None
 
         return new_cls
@@ -424,7 +424,7 @@ class BaseModel(metaclass=ModelMeta):
 
         for name, field in self.__fields__.items():
             if name not in kwargs:
-                if field.default is NotSet:
+                if isinstance(field.default, NotSetClass):
                     uninitialized_fields.append(field.name)
                 continue
             value = kwargs.pop(name)

--- a/tests/test_maintainership_converter.py
+++ b/tests/test_maintainership_converter.py
@@ -50,7 +50,7 @@ class TestMaintainershipConverter(unittest.TestCase):
         self.assertEqual(result["packages"]["package1"]["groups"], ["pkg1-group"])
 
         self.assertEqual(result["packages"]["package2"]["users"], ["bob"])
-        self.assertIsNone(result["packages"]["package2"]["groups"])
+        self.assertNotIn("groups", result["packages"]["package2"])
 
     def test_v1_format_passthrough(self):
         """v1.0 format is printed unchanged."""
@@ -76,8 +76,8 @@ class TestMaintainershipConverter(unittest.TestCase):
         result = json.loads(output)
 
         self.assertEqual(result["header"]["document"], "obs-maintainers")
-        self.assertIsNone(result["project"]["users"])
-        self.assertIsNone(result["project"]["groups"])
+        self.assertNotIn("users", result["project"])
+        self.assertNotIn("groups", result["project"])
         self.assertEqual(result["packages"]["package1"]["users"], ["alice"])
 
     def test_legacy_groups_only(self):
@@ -86,9 +86,9 @@ class TestMaintainershipConverter(unittest.TestCase):
         output = self._run_converter(path)
         result = json.loads(output)
 
-        self.assertIsNone(result["project"]["users"])
+        self.assertNotIn("users", result["project"])
         self.assertEqual(result["project"]["groups"], ["admins", "maintainers"])
-        self.assertIsNone(result["packages"]["pkg"]["users"])
+        self.assertNotIn("users", result["packages"]["pkg"])
         self.assertEqual(result["packages"]["pkg"]["groups"], ["team"])
 
     def test_file_not_found(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
             text: str | None = Field()
 
         m = TestModel()
-        self.assertEqual(m.dict(), {"text": None})
+        self.assertEqual(m.dict(), {})
 
         self.assertRaises(TypeError, setattr, m.text, 123)
 
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
             sub: Optional[List[TestSubmodel]] = Field(default=None)
 
         m = TestModel()
-        self.assertEqual(m.dict(), {"a": "default", "b": None, "sub": None})
+        self.assertEqual(m.dict(), {"a": "default"})
 
         m.b = "B"
         m.sub = [{"text": "one"}, {"text": "two"}]


### PR DESCRIPTION
While the models have the notion of an optional value the optional values are not really optional, and are always present.

This is a partial solution that correctly handles the NotSet value as not present.

However, the Optional type is still defined as union with None, not NotSet.

This is the result of basing models on the failry poorly designed python typing. The Optional(x) alias for Union(X, None) is defined using functionality that is not available outside the typing module, making it impossible to define own alias for Union(X, NotSet).

Fixes: #2114