### PR TITLE
Produce standard JSON formatting whan saving _maintainership.json

### DIFF
--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -506,8 +506,8 @@ class BaseModel(metaclass=ModelMeta):
         import json
 
         with open(path, "w", encoding="utf-8") as f:
-            # we prefer key ordering according to the fields in the model
-            json.dump(self.dict(), f, sort_keys=False, indent=4)
+            # we prefer fixed, well-defined key ordering
+            json.dump(self.dict(), f, sort_keys=True, indent=2)
 
     @classmethod
     def from_string(cls, text: str) -> "Self":


### PR DESCRIPTION
To be able to perform automated updates to the _maintainership.json file it needs to be in a format that is standardized and deterministic so that any tool can produce bit-identical output for the same data.

The format is close to what `jq -S` produces but not quite the same.

One minor problem is different amount of indentation.

The more serious problem is bespoke ordering of dictionary keys that is specific to this particular implementation. The only widely implemented key ordering is alphabetical.

While 'as is' key ordering may be possible with some implementations it is not as widely available, and causes non-determinism when adding new package entries.

Fixes: #2115