### PR TITLE
model cleanup

### DIFF
--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -19,7 +19,7 @@ class MaintainershipHeader(BaseModel):
     """
     A model representing the maintainership document header.
     """
-    document: MaintainershipDocumentType = Field()
+    document: MaintainershipDocumentType = Field(default="obs-maintainers")
     version: str = Field(default="1.0")
 
 

--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -7,8 +7,8 @@ class MaintainerInfo(BaseModel):
     """
     A model representing users and groups associated with a project or package.
     """
-    users: Optional[List[str]] = Field(default=None)
-    groups: Optional[List[str]] = Field(default=None)
+    users: Optional[List[str]] = Field()
+    groups: Optional[List[str]] = Field()
 
 
 class MaintainershipDocumentType(str, Enum):

--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -82,7 +82,7 @@ class Maintainership(BaseModel):
           - sort keys
           - indent by 2 spaces
         """
-        return super().to_string(exclude_none=True, sort_keys=True, indent=2)
+        return super().to_string(sort_keys=True, indent=2)
 
     def get_package_maintainers_users(self, package: str) -> List[str]:
         if package not in self.packages:

--- a/osc/gitea_api/maintainership.py
+++ b/osc/gitea_api/maintainership.py
@@ -73,17 +73,6 @@ class Maintainership(BaseModel):
 
         return cls(**data)
 
-    def to_string(self):
-        """
-        Export _maintainership.json contents.
-
-        We always:
-          - exclude entries that have empty (None) value
-          - sort keys
-          - indent by 2 spaces
-        """
-        return super().to_string(sort_keys=True, indent=2)
-
     def get_package_maintainers_users(self, package: str) -> List[str]:
         if package not in self.packages:
             raise ValueError(f"Package '{package}' not found in maintainership data.")

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -508,8 +508,8 @@ class BaseModel(metaclass=ModelMeta):
         import json
 
         with open(path, "w", encoding="utf-8") as f:
-            # we prefer key ordering according to the fields in the model
-            json.dump(self.dict(), f, sort_keys=False, indent=4)
+            # we prefer fixed, well-defined key ordering
+            json.dump(self.dict(), f, sort_keys=True, indent=2)
 
     @classmethod
     def from_string(cls, text: str) -> "Self":
@@ -522,13 +522,18 @@ class BaseModel(metaclass=ModelMeta):
         obj = cls(**data)
         return obj
 
-    def to_string(self, *, sort_keys: bool = False, indent: int = 4) -> str:
+    def to_string(self) -> str:
         """
         Dump model to a json string.
+
+        We always:
+          - exclude entries that have empty (None) value
+          - sort keys
+          - indent by 2 spaces
         """
         import json
 
-        result = json.dumps(self.dict(), sort_keys=sort_keys, indent=indent)
+        result = json.dumps(self.dict(), sort_keys=True, indent=2)
         return result
 
     def do_snapshot(self):

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -58,7 +58,6 @@ __all__ = (
     "BaseModel",
     "XmlModel",
     "Field",
-    "NotSet",
     "FromParent",
     "Enum",
     "Dict",
@@ -71,19 +70,8 @@ __all__ = (
 )
 
 
-class NotSetClass:
-    def __repr__(self):
-        return "NotSet"
-
-    def __bool__(self):
-        return False
-
-
-NotSet = NotSetClass()
-
-
 class FromParent:
-    def __init__(self, field_name, *, fallback=NotSet):
+    def __init__(self, field_name, *, fallback=None):
         self.field_name = field_name
         self.fallback = fallback
 
@@ -95,14 +83,13 @@ class FromParent:
 class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
     def __init__(
         self,
-        default: Any = NotSet,
+        default: Any = None,
         description: Optional[str] = None,
         exclude: bool = False,
         get_callback: Optional[Callable] = None,
         **extra,
     ):
         # the default value; it can be a factory function that is lazily evaluated on the first use
-        # model sets it to None if it equals to NotSet (for better usability)
         self.default = default
 
         # a flag indicating, whether the default is a callable with lazy evalution
@@ -123,7 +110,7 @@ class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
             # append information about the default value
             if isinstance(self.default, FromParent):
                 self.__doc__ += f"\n\nDefault: inherited from parent config's field ``{self.default.field_name}``"
-            elif not isinstance(self.default, NotSetClass):
+            elif self.default is not None:
                 self.__doc__ += f"\n\nDefault: ``{self.default}``"
 
         # whether to exclude this field from export
@@ -308,13 +295,13 @@ class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
 
         if isinstance(self.default, FromParent):
             if obj._parent is None:
-                if not isinstance(self.default.fallback, NotSetClass):
+                if self.default.fallback is not None or self.is_optional:
                     return self.default.fallback
                 else:
                     raise RuntimeError(f"The field '{self.name}' has default {self.default} but the model has no parent set")
             return getattr(obj._parent, self.default.field_name or self.name)
 
-        if isinstance(self.default, NotSetClass):
+        if self.default is None and not self.is_optional:
             raise RuntimeError(f"The field '{self.name}' has no default")
 
         # make a deepcopy to avoid problems with mutable defaults
@@ -396,10 +383,6 @@ class ModelMeta(type):
             # set annotation for the getter so it shows up in sphinx
             field.get_copy.__func__.__annotations__ = {"return": field.type}
 
-            # set 'None' as the default for optional fields
-            if isinstance(field.default, NotSetClass) and field.is_optional:
-                field.default = None
-
         return new_cls
 
 
@@ -424,7 +407,7 @@ class BaseModel(metaclass=ModelMeta):
 
         for name, field in self.__fields__.items():
             if name not in kwargs:
-                if isinstance(field.default, NotSetClass) and not field.is_optional:
+                if field.default is None and not field.is_optional:
                     uninitialized_fields.append(field.name)
                 continue
             value = kwargs.pop(name)

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -424,7 +424,7 @@ class BaseModel(metaclass=ModelMeta):
 
         for name, field in self.__fields__.items():
             if name not in kwargs:
-                if isinstance(field.default, NotSetClass):
+                if isinstance(field.default, NotSetClass) and not field.is_optional:
                     uninitialized_fields.append(field.name)
                 continue
             value = kwargs.pop(name)

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -82,7 +82,7 @@ class NotSetClass:
 NotSet = NotSetClass()
 
 
-class FromParent(NotSetClass):
+class FromParent:
     def __init__(self, field_name, *, fallback=NotSet):
         self.field_name = field_name
         self.fallback = fallback

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -469,20 +469,20 @@ class BaseModel(metaclass=ModelMeta):
             return False
         return self._get_cmp_data() < other._get_cmp_data()
 
-    def dict(self, *, exclude_none: bool = False):
+    def dict(self):
         result = {}
         for name, field in self.__fields__.items():
             if field.exclude:
                 continue
             value = getattr(self, name)
-            if exclude_none and value is None:
+            if value is None:
                 continue
             if value is not None and field.is_model:
-                result[name] = value.dict(exclude_none=exclude_none)
+                result[name] = value.dict()
             elif value is not None and field.is_model_list:
-                result[name] = [i.dict(exclude_none=exclude_none) for i in value]
+                result[name] = [i.dict() for i in value]
             elif value is not None and field.is_model_dict:
-                result[name] = {k: v.dict(exclude_none=exclude_none) for k, v in value.items()}
+                result[name] = {k: v.dict() for k, v in value.items()}
             else:
                 result[name] = value
 
@@ -522,13 +522,13 @@ class BaseModel(metaclass=ModelMeta):
         obj = cls(**data)
         return obj
 
-    def to_string(self, *, exclude_none: bool = False, sort_keys: bool = False, indent: int = 4) -> str:
+    def to_string(self, *, sort_keys: bool = False, indent: int = 4) -> str:
         """
         Dump model to a json string.
         """
         import json
 
-        result = json.dumps(self.dict(exclude_none=exclude_none), sort_keys=sort_keys, indent=indent)
+        result = json.dumps(self.dict(), sort_keys=sort_keys, indent=indent)
         return result
 
     def do_snapshot(self):

--- a/osc/util/models.py
+++ b/osc/util/models.py
@@ -123,7 +123,7 @@ class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
             # append information about the default value
             if isinstance(self.default, FromParent):
                 self.__doc__ += f"\n\nDefault: inherited from parent config's field ``{self.default.field_name}``"
-            elif self.default is not NotSet:
+            elif not isinstance(self.default, NotSetClass):
                 self.__doc__ += f"\n\nDefault: ``{self.default}``"
 
         # whether to exclude this field from export
@@ -308,13 +308,13 @@ class Field(property, *([Any] if typing.TYPE_CHECKING else [])):
 
         if isinstance(self.default, FromParent):
             if obj._parent is None:
-                if self.default.fallback is not NotSet:
+                if not isinstance(self.default.fallback, NotSetClass):
                     return self.default.fallback
                 else:
                     raise RuntimeError(f"The field '{self.name}' has default {self.default} but the model has no parent set")
             return getattr(obj._parent, self.default.field_name or self.name)
 
-        if self.default is NotSet:
+        if isinstance(self.default, NotSetClass):
             raise RuntimeError(f"The field '{self.name}' has no default")
 
         # make a deepcopy to avoid problems with mutable defaults
@@ -397,7 +397,7 @@ class ModelMeta(type):
             field.get_copy.__func__.__annotations__ = {"return": field.type}
 
             # set 'None' as the default for optional fields
-            if field.default is NotSet and field.is_optional:
+            if isinstance(field.default, NotSetClass) and field.is_optional:
                 field.default = None
 
         return new_cls
@@ -424,7 +424,7 @@ class BaseModel(metaclass=ModelMeta):
 
         for name, field in self.__fields__.items():
             if name not in kwargs:
-                if field.default is NotSet:
+                if isinstance(field.default, NotSetClass):
                     uninitialized_fields.append(field.name)
                 continue
             value = kwargs.pop(name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
             text: str | None = Field()
 
         m = TestModel()
-        self.assertEqual(m.dict(), {"text": None})
+        self.assertEqual(m.dict(), {})
 
         self.assertRaises(TypeError, setattr, m.text, 123)
 
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
             sub: Optional[List[TestSubmodel]] = Field(default=None)
 
         m = TestModel()
-        self.assertEqual(m.dict(), {"a": "default", "b": None, "sub": None})
+        self.assertEqual(m.dict(), {"a": "default"})
 
         m.b = "B"
         m.sub = [{"text": "one"}, {"text": "two"}]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,14 +16,6 @@ class TestTyping(unittest.TestCase):
         self.assertEqual(typ, list)
 
 
-class TestNotSet(unittest.TestCase):
-    def test_repr(self):
-        self.assertEqual(repr(NotSet), "NotSet")
-
-    def test_bool(self):
-        self.assertEqual(bool(NotSet), False)
-
-
 class Test(unittest.TestCase):
     @unittest.skipIf(sys.version_info[:2] < (3, 10), "added in python 3.10")
     def test_union_or(self):


### PR DESCRIPTION
 - only produce one JSON format, there is no use for the bespoke format that is not reproducible with other tools
 - abolish NotSetClass