### PR TITLE
fix: make osc up --expand-link a no-op on non-linked packages

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -6154,20 +6154,22 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                 directory = xml_fromstring(meta)
                 li_node = directory.find('linkinfo')
                 if li_node is None:
-                    print(f'Revision \'{rev}\' is no link', file=sys.stderr)
-                    sys.exit(1)
-                li = Linkinfo()
-                li.read(li_node)
-                if li.haserror() and opts.expand_link:
-                    raise oscerr.LinkExpandError(pacs[0].prjname, pacs[0].name,
-                                                 li.error)
-                rev = li.lsrcmd5
-                if opts.expand_link:
-                    rev = li.xsrcmd5
-                if rev is None:
-                    # 2 cases: a) unexpand and passed rev has linkerror
-                    #          b) expand and passed rev is already expanded
-                    rev = directory.get('srcmd5')
+                    # not a link: --expand-link/--unexpand-link are no-ops,
+                    # fall back to the plain revision instead of failing
+                    rev = directory.get('srcmd5') or rev
+                else:
+                    li = Linkinfo()
+                    li.read(li_node)
+                    if li.haserror() and opts.expand_link:
+                        raise oscerr.LinkExpandError(pacs[0].prjname, pacs[0].name,
+                                                     li.error)
+                    rev = li.lsrcmd5
+                    if opts.expand_link:
+                        rev = li.xsrcmd5
+                    if rev is None:
+                        # 2 cases: a) unexpand and passed rev has linkerror
+                        #          b) expand and passed rev is already expanded
+                        rev = directory.get('srcmd5')
         else:
             rev = None
 


### PR DESCRIPTION
Closes #2131.

`osc up -e -r REV` previously aborted with `Revision REV is no link` when run on a package that has no source link, forcing callers to branch on link status before invoking it. This makes `--expand-link`/`--unexpand-link` a no-op when `linkinfo` is absent and falls back to the plain `srcmd5` of the requested revision, so the same command works for both linked and non-linked packages.