### PR TITLE
submit: continue superseding on per-SR HTTP 403 errors

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -693,6 +693,33 @@ def ensure_no_remaining_args(args):
     raise oscerr.WrongArgs(f"Unexpected args: {args_str}")
 
 
+def supersede_requests_lenient(apiurl, request_ids, superseder_id, message_template="superseded by {sid}"):
+    """
+    Supersede each request in ``request_ids`` with ``superseder_id``.
+
+    HTTP 403 errors on individual requests (e.g. lack of permission to
+    modify someone else's request) are downgraded to warnings so that the
+    remaining requests are still superseded.  See openSUSE/osc#2130.
+    """
+    from .core import change_request_state
+    from .output import print_msg
+
+    for req in request_ids:
+        try:
+            change_request_state(
+                apiurl, str(req), 'superseded',
+                message_template.format(sid=superseder_id), superseder_id,
+            )
+        except HTTPError as e:
+            if e.code == 403:
+                print_msg(
+                    f"could not supersede request {req}: {e}",
+                    print_to="warning",
+                )
+                continue
+            raise
+
+
 class Osc(cmdln.Cmdln):
     """
     openSUSE commander is a command-line interface to the Open Build Service.
@@ -2142,9 +2169,7 @@ class Osc(cmdln.Cmdln):
                     myreqs += [value]
 
             if len(myreqs) > 0:
-                for req in myreqs:
-                    change_request_state(apiurl, str(req), 'superseded',
-                                         f'superseded by {sr_ids[0]}', sr_ids[0])
+                supersede_requests_lenient(apiurl, myreqs, sr_ids[0])
 
             sys.exit('Successfully finished')
 
@@ -2299,9 +2324,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print(f"{obs_url}/request/show/{result}")
 
         if supersede_existing:
-            for req in reqs:
-                change_request_state(apiurl, req.reqid, 'superseded',
-                                     f'superseded by {result}', result)
+            supersede_requests_lenient(apiurl, [r.reqid for r in reqs], result)
 
         if opts.supersede:
             change_request_state(apiurl, opts.supersede, 'superseded',
@@ -2732,9 +2755,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         root = xml_parse(f).getroot()
         rid = root.get('id')
         print(f"Request {rid} created")
-        for srid in supersede:
-            change_request_state(apiurl, srid, 'superseded',
-                                 f'superseded by {rid}', rid)
+        supersede_requests_lenient(apiurl, supersede, rid)
 
     @cmdln.option('-m', '--message', metavar='TEXT',
                   help='specify message TEXT')

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -693,31 +693,6 @@ def ensure_no_remaining_args(args):
     raise oscerr.WrongArgs(f"Unexpected args: {args_str}")
 
 
-def supersede_requests_lenient(apiurl, request_ids, superseder_id, message_template="superseded by {sid}"):
-    """
-    Supersede each request in ``request_ids`` with ``superseder_id``.
-
-    HTTP 403 errors on individual requests (e.g. lack of permission to
-    modify someone else's request) are downgraded to warnings so that the
-    remaining requests are still superseded.  See openSUSE/osc#2130.
-    """
-    from .core import change_request_state
-    from .output import print_msg
-
-    for req in request_ids:
-        try:
-            change_request_state(
-                apiurl, str(req), 'superseded',
-                message_template.format(sid=superseder_id), superseder_id,
-            )
-        except HTTPError as e:
-            if e.code == 403:
-                print_msg(
-                    f"could not supersede request {req}: {e}",
-                    print_to="warning",
-                )
-                continue
-            raise
 
 
 class Osc(cmdln.Cmdln):
@@ -2169,7 +2144,8 @@ class Osc(cmdln.Cmdln):
                     myreqs += [value]
 
             if len(myreqs) > 0:
-                supersede_requests_lenient(apiurl, myreqs, sr_ids[0])
+                for req in myreqs:
+                    change_request_state(apiurl, str(req), 'superseded', f'superseded by {sr_ids[0]}', sr_ids[0], can_fail=True)
 
             sys.exit('Successfully finished')
 
@@ -2324,7 +2300,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
             print(f"{obs_url}/request/show/{result}")
 
         if supersede_existing:
-            supersede_requests_lenient(apiurl, [r.reqid for r in reqs], result)
+            for req in reqs:
+                change_request_state(apiurl, req.reqid, 'superseded', f'superseded by {result}', result, can_fail=True)
 
         if opts.supersede:
             change_request_state(apiurl, opts.supersede, 'superseded',
@@ -2755,7 +2732,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         root = xml_parse(f).getroot()
         rid = root.get('id')
         print(f"Request {rid} created")
-        supersede_requests_lenient(apiurl, supersede, rid)
+        for srid in supersede:
+            change_request_state(apiurl, srid, 'superseded', f'superseded by {rid}', rid, can_fail=True)
 
     @cmdln.option('-m', '--message', metavar='TEXT',
                   help='specify message TEXT')

--- a/osc/core.py
+++ b/osc/core.py
@@ -2287,7 +2287,7 @@ def change_review_state(
     return root.get('code')
 
 
-def change_request_state(apiurl: str, reqid, newstate, message="", supersed=None, force=False, keep_packages_locked=False):
+def change_request_state(apiurl: str, reqid, newstate, message="", supersed=None, force=False, keep_packages_locked=False, can_fail: bool = False):
     query = {"cmd": "changestate", "newstate": newstate}
     if supersed:
         query['superseded_by'] = supersed
@@ -2297,7 +2297,14 @@ def change_request_state(apiurl: str, reqid, newstate, message="", supersed=None
         query['keep_packages_locked'] = "1"
     u = makeurl(apiurl,
                 ['request', reqid], query=query)
-    f = http_POST(u, data=message)
+    try:
+        f = http_POST(u, data=message)
+    except HTTPError as e:
+        if can_fail:
+            from .output import print_msg
+            print_msg(f"could not change state of request {reqid}: {e}", print_to="warning")
+            return None
+        raise
 
     root = xml_parse(f).getroot()
     return root.get('code', 'unknown')

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -846,7 +846,9 @@ class TestChangeRequestStateCanFail(unittest.TestCase):
 
         self.assertIsNone(result)
         self.assertEqual(warn.call_count, 1)
-        self.assertEqual(warn.call_args.kwargs.get("print_to"), "warning")
+        # call_args is (args, kwargs); .kwargs attr exists on Python >= 3.8
+        call_kwargs = warn.call_args[1] if warn.call_args else {}
+        self.assertEqual(call_kwargs.get("print_to"), "warning")
 
     def test_without_can_fail_raises(self):
         """Without can_fail, HTTPErrors still propagate."""

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 import unittest.mock
+from urllib.error import HTTPError
 
 from osc.commandline import Command
 from osc.commandline import MainCommand
@@ -12,6 +13,7 @@ from osc.commandline import pop_project_package_from_args
 from osc.commandline import pop_project_package_repository_arch_from_args
 from osc.commandline import pop_project_package_targetproject_targetpackage_from_args
 from osc.commandline import pop_repository_arch_from_args
+from osc.commandline import supersede_requests_lenient
 from osc.oscerr import NoWorkingCopy, OscValueError
 from osc.store import Store
 
@@ -819,6 +821,58 @@ class TestPopProjectPackageTargetProjectTargetPackageFromArgs(unittest.TestCase)
             pop_project_package_targetproject_targetpackage_from_args,
             args,
         )
+
+
+class TestSupersedeLenient(unittest.TestCase):
+    """Regression tests for openSUSE/osc#2130."""
+
+    def _make_403(self, reqid):
+        return HTTPError(
+            url=f"https://example.com/request/{reqid}",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=None,
+        )
+
+    def test_continues_on_403(self):
+        """A 403 on one request must not abort superseding of the others."""
+        calls = []
+
+        def fake_change(apiurl, reqid, *_a, **_kw):
+            calls.append(reqid)
+            if reqid == "815980":
+                raise self._make_403(reqid)
+            return "ok"
+
+        with unittest.mock.patch(
+            "osc.core.change_request_state", side_effect=fake_change,
+        ), unittest.mock.patch(
+            "osc.output.print_msg",
+        ) as warn:
+            supersede_requests_lenient(
+                "https://api", ["815980", "1206225"], "1350147",
+            )
+
+        # both requests were attempted
+        self.assertEqual(calls, ["815980", "1206225"])
+        # the 403 produced a warning rather than an exception
+        self.assertEqual(warn.call_count, 1)
+        self.assertEqual(warn.call_args.kwargs.get("print_to"), "warning")
+
+    def test_non_403_still_raises(self):
+        """Non-403 HTTPErrors must still propagate (no silent failures)."""
+        def fake_change(apiurl, reqid, *_a, **_kw):
+            raise HTTPError(
+                url="https://example.com/request/1",
+                code=500, msg="Server Error", hdrs=None, fp=None,
+            )
+
+        with unittest.mock.patch(
+            "osc.core.change_request_state", side_effect=fake_change,
+        ):
+            with self.assertRaises(HTTPError):
+                supersede_requests_lenient("https://api", ["1"], "2")
 
 
 if __name__ == "__main__":

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -13,7 +13,7 @@ from osc.commandline import pop_project_package_from_args
 from osc.commandline import pop_project_package_repository_arch_from_args
 from osc.commandline import pop_project_package_targetproject_targetpackage_from_args
 from osc.commandline import pop_repository_arch_from_args
-from osc.commandline import supersede_requests_lenient
+from osc.core import change_request_state
 from osc.oscerr import NoWorkingCopy, OscValueError
 from osc.store import Store
 
@@ -823,56 +823,38 @@ class TestPopProjectPackageTargetProjectTargetPackageFromArgs(unittest.TestCase)
         )
 
 
-class TestSupersedeLenient(unittest.TestCase):
-    """Regression tests for openSUSE/osc#2130."""
+class TestChangeRequestStateCanFail(unittest.TestCase):
+    """Regression tests for openSUSE/osc#2130: can_fail kwarg."""
 
-    def _make_403(self, reqid):
+    def _make_http_error(self, code, reqid="1"):
         return HTTPError(
             url=f"https://example.com/request/{reqid}",
-            code=403,
-            msg="Forbidden",
+            code=code,
+            msg="Error",
             hdrs=None,
             fp=None,
         )
 
-    def test_continues_on_403(self):
-        """A 403 on one request must not abort superseding of the others."""
-        calls = []
-
-        def fake_change(apiurl, reqid, *_a, **_kw):
-            calls.append(reqid)
-            if reqid == "815980":
-                raise self._make_403(reqid)
-            return "ok"
-
+    def test_can_fail_suppresses_any_http_error(self):
+        """can_fail=True returns None and warns instead of raising."""
         with unittest.mock.patch(
-            "osc.core.change_request_state", side_effect=fake_change,
+            "osc.core.http_POST", side_effect=self._make_http_error(403),
         ), unittest.mock.patch(
             "osc.output.print_msg",
         ) as warn:
-            supersede_requests_lenient(
-                "https://api", ["815980", "1206225"], "1350147",
-            )
+            result = change_request_state("https://api", "815980", "superseded", can_fail=True)
 
-        # both requests were attempted
-        self.assertEqual(calls, ["815980", "1206225"])
-        # the 403 produced a warning rather than an exception
+        self.assertIsNone(result)
         self.assertEqual(warn.call_count, 1)
         self.assertEqual(warn.call_args.kwargs.get("print_to"), "warning")
 
-    def test_non_403_still_raises(self):
-        """Non-403 HTTPErrors must still propagate (no silent failures)."""
-        def fake_change(apiurl, reqid, *_a, **_kw):
-            raise HTTPError(
-                url="https://example.com/request/1",
-                code=500, msg="Server Error", hdrs=None, fp=None,
-            )
-
+    def test_without_can_fail_raises(self):
+        """Without can_fail, HTTPErrors still propagate."""
         with unittest.mock.patch(
-            "osc.core.change_request_state", side_effect=fake_change,
+            "osc.core.http_POST", side_effect=self._make_http_error(403),
         ):
             with self.assertRaises(HTTPError):
-                supersede_requests_lenient("https://api", ["1"], "2")
+                change_request_state("https://api", "1", "superseded")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Catch HTTP 403 on each individual `change_request_state` call when superseding existing SRs, log a warning, and continue with the remaining requests instead of aborting the whole loop. Fixes #2130.