### PR TITLE
compat: accept extra kwargs in OscArgumentParser._get_formatter for P…

### DIFF
--- a/osc/commandline_common.py
+++ b/osc/commandline_common.py
@@ -17,8 +17,10 @@ IN_VENV = getattr(sys, "real_prefix", sys.base_prefix) != sys.prefix
 
 
 class OscArgumentParser(argparse.ArgumentParser):
-    def _get_formatter(self):
-        # cache formatter to speed things a little bit up
+    def _get_formatter(self, *args, **kwargs):
+        # Accept extra parameters (like `file` in Python 3.15) while
+        # keeping the original behaviour: cache and return a formatter
+        # instance created with the parser program name.
         if not hasattr(self, "_formatter"):
             self._formatter = self.formatter_class(prog=self.prog)
         return self._formatter


### PR DESCRIPTION
- Fixes the regression on Python 3.15 caused by argparse passing the file parameter to _get_formatter().

- Keeps existing behavior: the formatter is still cached and created with prog=self.prog.

- No other functional change.

Referencs: https://bugzilla.redhat.com/show_bug.cgi?id=2481412
fixes https://github.com/openSUSE/osc/issues/2156"