### PR TITLE
Add 'mergeable' field to the output of 'git-obs pr get' and other places using the same output format

### DIFF
--- a/behave/features/git-pr.feature
+++ b/behave/features/git-pr.feature
@@ -20,6 +20,7 @@ Background:
         State       : open
         Draft       : no
         Merged      : no
+        Mergeable   : (yes|no)
         Allow edit  : yes
         Author      : Admin \(admin@example.com\)
         Source      : Admin/test-GitPkgA, branch: factory, commit: .*
@@ -48,6 +49,7 @@ Scenario: List pull requests
         State       : open
         Draft       : no
         Merged      : no
+        Mergeable   : (yes|no)
         Allow edit  : yes
         Author      : Admin \(admin@example.com\)
         Source      : Admin/test-GitPkgA, branch: factory, commit: .*
@@ -110,6 +112,7 @@ Scenario: Get a pull request
         State       : open
         Draft       : no
         Merged      : no
+        Mergeable   : (yes|no)
         Allow edit  : yes
         Author      : Admin \(admin@example.com\)
         Source      : Admin/test-GitPkgA, branch: factory, commit: .*
@@ -144,6 +147,7 @@ Scenario: Get a pull request with labels
         Labels      : bug feature
         Draft       : no
         Merged      : no
+        Mergeable   : (yes|no)
         Allow edit  : yes
         Author      : Admin \(admin@example.com\)
         Source      : Admin/test-GitPkgA, branch: factory, commit: .*
@@ -320,6 +324,7 @@ Scenario: Rebase a pull request checkout to non fast-forwardable changes
 #         State       : closed
 #         Draft       : no
 #         Merged      : yes
+#         Mergeable   : (yes|no)
 #         Allow edit  : yes
 #         Author      : Admin \(admin@example.com\)
 #         Source      : Admin/test-GitPkgA, branch: factory, commit: ........................................

--- a/osc/gitea_api/pr.py
+++ b/osc/gitea_api/pr.py
@@ -185,6 +185,12 @@ class PullRequest(GiteaModel):
         return self._data["merged_at"]
 
     @property
+    def mergeable(self) -> Optional[bool]:
+        if not self.is_pull_request:
+            return None
+        return self._data.get("mergeable")
+
+    @property
     def allow_maintainer_edit(self) -> Optional[bool]:
         if not self.is_pull_request:
             return None
@@ -302,6 +308,7 @@ class PullRequest(GiteaModel):
         if self.is_pull_request:
             table.add("Draft", yes_no(self.draft))
             table.add("Merged", yes_no(self.merged))
+            table.add("Mergeable", yes_no(self.mergeable))
             table.add("Allow edit", yes_no(self.allow_maintainer_edit))
         table.add("Author", f"{self.user_obj.login_full_name_email}")
         if self.is_pull_request:

--- a/tests/test_gitea_api_pr.py
+++ b/tests/test_gitea_api_pr.py
@@ -19,6 +19,7 @@ class TestGiteaApiPullRequest(unittest.TestCase):
             "allow_maintainer_edit": False,
             "draft": False,
             "merged": False,
+            "mergeable": True,
             "base": {
                 "ref": "base-branch",
                 "sha": "base-commit",
@@ -54,6 +55,7 @@ class TestGiteaApiPullRequest(unittest.TestCase):
         self.assertEqual(obj.user_obj.login, "alice")
         self.assertEqual(obj.draft, False)
         self.assertEqual(obj.merged, False)
+        self.assertEqual(obj.mergeable, True)
         self.assertEqual(obj.allow_maintainer_edit, False)
 
         self.assertEqual(obj.base_owner, "base-owner")
@@ -97,6 +99,7 @@ class TestGiteaApiPullRequest(unittest.TestCase):
         self.assertEqual(obj.user_obj.login, "alice")
         self.assertEqual(obj.draft, None)
         self.assertEqual(obj.merged, None)
+        self.assertEqual(obj.mergeable, None)
         self.assertEqual(obj.allow_maintainer_edit, None)
 
         self.assertEqual(obj.base_owner, "base-owner")


### PR DESCRIPTION
The tests must consider both yes/no values, because a background job may or may not finish setting the value before we retrieve the data

Fixes: #2160