### PR TITLE
RFC: Add osc build --buildinfo(--debug) option

### DIFF
--- a/osc/build.py
+++ b/osc/build.py
@@ -299,6 +299,7 @@ class Buildinfo:
             if error.startswith('unresolvable: '):
                 sys.stderr.write('unresolvable: ')
                 sys.stderr.write('\n     '.join(error[14:].split(',')))
+                sys.stderr.write('\nHint: use osc build with --buildinfo-debug for more info')
             else:
                 sys.stderr.write(error)
             sys.stderr.write('\n')
@@ -1150,7 +1151,11 @@ def main(apiurl, store, opts, argv):
                                               repo,
                                               arch,
                                               specfile=build_descr_data,
-                                              addlist=extra_pkgs))
+                                              addlist=extra_pkgs,
+                                              debug=opts.buildinfo_debug))
+            if opts.buildinfo or opts.buildinfo_debug:
+                print(bi_text)
+                sys.exit(0)
             if not bi_file:
                 bi_file = open(bi_filename, 'w')
             # maybe we should check for errors before saving the file

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -7753,6 +7753,10 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                   help='Do not use preinstall images for creating the build root.')
     @cmdln.option("--just-print-buildroot", action="store_true",
                   help="Print build root path and exit.")
+    @cmdln.option("--buildinfo", action="store_true",
+                  help="Print buildinfo and exit.")
+    @cmdln.option("--buildinfo-debug", action="store_true",
+                  help="Print buildinfo in debug mode and exit.")
     @cmdln.option('--no-timestamps', '-s', '--strip-time', action='store_true',
                   help='Hide the time prefix in output.')
     @cmdln.alias('chroot')
@@ -7839,6 +7843,9 @@ Please submit there instead, or use --nodevelproject to force direct submission.
 
         if opts.debuginfo and opts.disable_debuginfo:
             raise oscerr.WrongOptions('osc: --debuginfo and --disable-debuginfo are mutual exclusive')
+
+        if (opts.buildinfo or opts.buildinfo_debug) and (opts.offline or opts.noinit):
+            raise oscerr.WrongOptions('osc: --buildinfo(-debug) is mutually exclusive with --offline and --no-init')
 
         if subcmd == 'wipe':
             opts.wipe = True


### PR DESCRIPTION
That way the debuginfo printed is really the one that is used by the build. With osc buildinfo, not everything is representable and there are subtle differences, e.g. https://github.com/openSUSE/osc/pull/2170

RFC because osc buildinfo still exists, and it can't be removed for remote buildinfo.