### PR TITLE
Fix 'osc fork --git-branch' to use the specified branch name in the checkout

### DIFF
--- a/behave/features/fork.feature
+++ b/behave/features/fork.feature
@@ -33,3 +33,12 @@ Scenario: Fork multiple git repos from different orgs
     Then the exit code is 0
      And stdout contains " scmsync URL: "
      And stdout contains "/Admin/test-GitPkgA-devel#factory"
+
+
+@destructive
+Scenario: Fork a git repo with custom branch name
+    When I execute osc with args "fork test:factory test-GitPkgA --git-branch my-branch"
+    Then the exit code is 0
+     And stdout contains " scmsync URL: "
+     And stdout contains "/Admin/test-GitPkgA#my-branch"
+     And stdout contains "Preparing branch 'my-branch' from 'parent/factory'"

--- a/osc/commands/fork.py
+++ b/osc/commands/fork.py
@@ -168,7 +168,14 @@ class ForkCommand(osc.commandline.OscCommand):
         # the branch was not specified, fetch the default branch from the repo
         if not branch:
             repo_obj = gitea_api.Repo.get(gitea_conn, owner, repo)
-            branch = repo_obj.default_branch
+            if args.git_branch:
+                try:
+                    gitea_api.Branch.get(gitea_conn, owner, repo, args.git_branch)
+                    branch = args.git_branch
+                except gitea_api.BranchDoesNotExist:
+                    branch = repo_obj.default_branch
+            else:
+                branch = repo_obj.default_branch
         fork_branch = args.git_branch or branch
 
         try:


### PR DESCRIPTION
Fixes: openSUSE/openSUSE-git#437