### PR TITLE
Error out on deprecated apisrv option is set

### DIFF
--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -192,6 +192,9 @@ class OscMainCommand(MainCommand):
         if conf.config["show_download_progress"]:
             self.download_progress = create_text_meter()
 
+        if conf.config["apisrv"]:
+            raise oscerr.ConfigError("apisrv in config is deprecated, use apiurl instead", "")
+
         if not args.apiurl:
             self.parser.error("Could not determine apiurl, use -A/--apiurl to specify one")
 

--- a/osc/conf.py
+++ b/osc/conf.py
@@ -511,6 +511,15 @@ class Options(OscOptions):
         ),
     )  # type: ignore[assignment]
 
+    apisrv: Optional[str] = Field(
+            default=None,
+            description=textwrap.dedent(
+                """
+                Deprecated option. Use apiurl instead.
+                """
+            ),
+        )  # type: ignore[assignment]
+
     section_auth: str = Field(
         default="Authentication options",
         exclude=True,


### PR DESCRIPTION
check if `apisrv=` is set in the config and error out with: 

`error: apisrv in config is deprecated, use apiurl instead`

This prevents unexpected behavior whan falling back to the default apiurl. 

Prevents #2137 