### PR TITLE
Add 'osc log' --limit/-l option to limit entries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+- 1.27.4
+  - Command-line:
+    - Add 'osc log' --limit/-l option to limit the number of revisions returned by the server
 - 1.27.3
   - Command-line:
     - Fix 'osc lbl' to work with git based packages

--- a/osc/commandline.py
+++ b/osc/commandline.py
@@ -8270,6 +8270,8 @@ Please submit there instead, or use --nodevelproject to force direct submission.
                         help='work on deleted package')
     @cmdln.option('-M', '--meta', action='store_true', default=None,
                         help='checkout out meta data instead of sources')
+    @cmdln.option('-l', '--limit', metavar='N', type=int, default=None,
+                        help='limit the number of revisions returned by the server')
     def do_log(self, subcmd, opts, *args):
         """
         Shows the commit log of a package
@@ -8308,7 +8310,7 @@ Please submit there instead, or use --nodevelproject to force direct submission.
         if opts.xml:
             format = 'xml'
 
-        lines = get_commitlog(apiurl, project, package, rev, format, opts.meta, opts.deleted, rev_upper, patch=opts.patch)
+        lines = get_commitlog(apiurl, project, package, rev, format, opts.meta, opts.deleted, rev_upper, patch=opts.patch, limit=opts.limit)
         pipe_to_pager(lines, add_newlines=True)
 
     @cmdln.option('-v', '--verbose', action='store_true',

--- a/osc/core.py
+++ b/osc/core.py
@@ -4941,12 +4941,13 @@ def get_commitlog(
     deleted: Optional[bool] = None,
     revision_upper: Optional[str] = None,
     patch: Optional[bool] = None,
+    limit: Optional[int] = None,
 ):
     if package is None:
         package = "_project"
 
     from . import obs_api
-    revision_list = obs_api.Package.get_revision_list(apiurl, prj, package, deleted=deleted, meta=meta)
+    revision_list = obs_api.Package.get_revision_list(apiurl, prj, package, deleted=deleted, meta=meta, limit=limit)
 
     # TODO: consider moving the following block to Package.get_revision_list()
     # keep only entries matching the specified revision

--- a/osc/obs_api/package.py
+++ b/osc/obs_api/package.py
@@ -164,13 +164,22 @@ class Package(XmlModel):
         return Status.from_file(response, apiurl=apiurl)
 
     @classmethod
-    def get_revision_list(cls, apiurl: str, project: str, package: str, deleted: Optional[bool] = None, meta: Optional[bool] = None):
+    def get_revision_list(
+        cls,
+        apiurl: str,
+        project: str,
+        package: str,
+        deleted: Optional[bool] = None,
+        meta: Optional[bool] = None,
+        limit: Optional[int] = None,
+    ):
         from ..util.xml import xml_parse
 
         url_path = ["source", project, package, "_history"]
         url_query = {
             "meta": meta,
             "deleted": deleted,
+            "limit": limit,
         }
         response = cls.xml_request("GET", apiurl, url_path, url_query)
         root = xml_parse(response).getroot()


### PR DESCRIPTION
Passes the limit through to the `/source/<project>/<package>/_history` API query, avoiding fetching the full revision history when only the most recent entries are needed.

Example:
```bash
PAGER=cat osc log -l 1 openSUSE:Factory bash
```
shows only the latest entry. Nice to use in scripts.