### PR TITLE
Fix NoWorkingCopy exception silencing in get_store()

### DIFF
--- a/osc/store.py
+++ b/osc/store.py
@@ -34,7 +34,12 @@ def get_store(path, check=True, print_warnings=False):
             store = git_scm.GitStore(path, check=check)
             if print_warnings:
                 git_scm.warn_experimental()
-        except oscerr.NoWorkingCopy:
+        except oscerr.NoWorkingCopy as e:
+            # GitStore raises "is not a Git SCM working copy" if the path is not a git repo.
+            # Any other NoWorkingCopy error indicates a valid git repo with a specific issue
+            # (e.g. detached HEAD, missing metadata), which we want to propagate to the user.
+            if "is not a Git SCM working copy" not in str(e):
+                raise
             pass
 
     if not store:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -19,10 +19,7 @@ class TestStore(unittest.TestCase):
         self.store.package = "package name"
 
     def tearDown(self):
-        try:
-            shutil.rmtree(self.tmpdir)
-        except:
-            pass
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def fileEquals(self, fn, expected_value):
         path = os.path.join(self.tmpdir, ".osc", fn)
@@ -260,10 +257,7 @@ class TestGetStore(unittest.TestCase):
 
     def tearDown(self):
         import shutil
-        try:
-            shutil.rmtree(self.tmpdir)
-        except OSError:
-            pass
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _git_init(self, path, *, branch="master"):
         import subprocess

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -250,6 +251,62 @@ class TestStore(unittest.TestCase):
 
         Store(self.tmpdir, check=True)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, ".osc", "sources", "sources")))
+
+
+class TestGetStore(unittest.TestCase):
+    def setUp(self):
+        import shutil
+        self.tmpdir = tempfile.mkdtemp(prefix='osc_test')
+
+    def tearDown(self):
+        import shutil
+        try:
+            shutil.rmtree(self.tmpdir)
+        except OSError:
+            pass
+
+    def _git_init(self, path, *, branch="master"):
+        import subprocess
+        os.makedirs(path, exist_ok=True)
+        cmd = ["git", "init"]
+        if branch:
+            cmd += ["-b", branch]
+        subprocess.check_call(cmd, cwd=path)
+        subprocess.check_call(["git", "config", "user.name", "Test User"], cwd=path)
+        subprocess.check_call(["git", "config", "user.email", "test@example.com"], cwd=path)
+
+    def test_get_store_generic_dir(self):
+        from osc.store import get_store
+        from osc import oscerr
+        with self.assertRaises(oscerr.NoWorkingCopy) as ctx:
+            get_store(self.tmpdir, check=True)
+        self.assertIn("is not a working copy", str(ctx.exception))
+
+    def test_get_store_git_branch(self):
+        from osc.store import get_store
+        from osc import oscerr
+        self._git_init(self.tmpdir, branch="master")
+        with self.assertRaises(oscerr.NoWorkingCopy) as ctx:
+            get_store(self.tmpdir, check=True)
+        # Should raise detailed metadata error because it's inside a git repo
+        self.assertIn("Git SCM package working copy doesn't have the following metadata set", str(ctx.exception))
+
+    def test_get_store_git_detached_head(self):
+        from osc.store import get_store
+        from osc import oscerr
+        import subprocess
+        self._git_init(self.tmpdir, branch="master")
+        # Create an initial commit to allow checkout
+        with open(os.path.join(self.tmpdir, "file.txt"), "w") as f:
+            f.write("test")
+        subprocess.check_call(["git", "add", "file.txt"], cwd=self.tmpdir)
+        subprocess.check_call(["git", "commit", "-m", "initial"], cwd=self.tmpdir)
+        # Detach HEAD
+        subprocess.check_call(["git", "checkout", "HEAD~0"], cwd=self.tmpdir)
+
+        with self.assertRaises(oscerr.NoWorkingCopy) as ctx:
+            get_store(self.tmpdir, check=True)
+        self.assertIn("detached HEAD state", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recent change to improve check=False behavior started silencing all NoWorkingCopy exceptions raised by GitStore. This prevented displaying highly informative errors, such as a detached HEAD state or missing metadata configuration inside a Git repository.

Refactor get_store() to propagate the exception if the path is a valid Git repository.

Fixes: bc99db823fe22fa78c11ec884f162e99e1df30d5